### PR TITLE
chore(deny): standardize deny.toml with reasons and stricter policy

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,28 +2,26 @@
 # https://embarkstudios.github.io/cargo-deny/
 
 [advisories]
-ignore = []
+ignore = [
+    # No unfixable advisories at this time.
+]
 
 [licenses]
 allow = [
     "MIT",
     "Apache-2.0",
-    "AGPL-3.0-or-later",
-    "AGPL-3.0-only",
+    "AGPL-3.0-only",    # Akroasis's own license
     "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
     "Zlib",
     "Unicode-3.0",
     "BSL-1.0",
     "CC0-1.0",
-    "0BSD",
-    "MPL-2.0",
-    "CDLA-Permissive-2.0",
-    "OpenSSL",
 ]
 confidence-threshold = 0.8
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "deny"
 wildcards = "allow"
+skip = [
+    # No unavoidable duplicate versions at this time.
+]


### PR DESCRIPTION
## Summary
- Remove 7 stale license entries not encountered by any transitive dep (`AGPL-3.0-or-later`, `BSD-3-Clause`, `ISC`, `0BSD`, `MPL-2.0`, `CDLA-Permissive-2.0`, `OpenSSL`)
- Add comment to `AGPL-3.0-only` clarifying it is Akroasis's own license
- Tighten `multiple-versions` from `"warn"` to `"deny"` — no duplicates exist at this time
- Convert `advisories.ignore` and `bans.skip` to table format with comment placeholders for future entries

## Test plan
- [x] `cargo deny check` passes cleanly with no warnings

## Observations
- Akroasis currently has a very small dep graph with no duplicate crate versions and no unfixable advisories — the table-format placeholders leave clear landmarks for future entries.
- The prior allow list contained `AGPL-3.0-or-later` (incorrect — the license is `AGPL-3.0-only`) and several licenses for deps that do not exist in this workspace yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)