### PR TITLE
feat(syntonia): channel data model + frequency plan + validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntonia"
+version = "0.1.0"
+dependencies = [
+ "compact_str",
+ "koinon",
+ "proptest",
+ "serde",
+ "serde_json",
+ "snafu",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,5 +61,8 @@ blake3 = "1"
 # Binary serialization
 ciborium = "0.2"
 
+# TOML serialization
+toml = "0.8"
+
 # Testing
 tempfile = "3"

--- a/crates/syntonia/Cargo.toml
+++ b/crates/syntonia/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "syntonia"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+koinon = { path = "../koinon" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+toml = { workspace = true }
+snafu = { workspace = true }
+compact_str = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/syntonia/src/channel.rs
+++ b/crates/syntonia/src/channel.rs
@@ -1,0 +1,116 @@
+//! Radio channel data model.
+
+use koinon::Frequency;
+use serde::{Deserialize, Serialize};
+
+use crate::tone::ToneMode;
+use crate::types::{Bandwidth, FrequencyOffset, PowerLevel, ScanMode};
+
+/// A single programmable radio channel (memory slot).
+///
+/// This is a radio-agnostic representation — specific radio models enforce
+/// constraints (name length, power levels, band limits) through
+/// [`RadioConstraints`](crate::validate::RadioConstraints) validation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Channel {
+    /// Channel memory index (0-based or 1-based depending on radio).
+    pub index: u16,
+    /// Channel label. Length limits are radio-specific.
+    pub name: String,
+    /// Receive frequency.
+    pub rx_freq: Frequency,
+    /// Explicit transmit frequency. `None` means simplex (TX on RX freq).
+    pub tx_freq: Option<Frequency>,
+    /// Repeater offset configuration.
+    pub offset: FrequencyOffset,
+    /// Squelch tone configuration.
+    pub tone: ToneMode,
+    /// Transmit power level.
+    pub power: PowerLevel,
+    /// Channel bandwidth.
+    pub bandwidth: Bandwidth,
+    /// Scanner behavior.
+    pub scan: ScanMode,
+    /// Busy channel lockout — prevents transmitting when channel is busy.
+    pub busy_lock: bool,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::tone::{CtcssTone, DcsCode, DcsPolarity};
+
+    fn sample_simplex_channel() -> Channel {
+        Channel {
+            index: 0,
+            name: "CALL".to_string(),
+            rx_freq: Frequency::hz(146_520_000),
+            tx_freq: None,
+            offset: FrequencyOffset::None,
+            tone: ToneMode::None,
+            power: PowerLevel::High,
+            bandwidth: Bandwidth::Wide,
+            scan: ScanMode::Include,
+            busy_lock: false,
+        }
+    }
+
+    fn sample_repeater_channel() -> Channel {
+        Channel {
+            index: 1,
+            name: "RPT".to_string(),
+            rx_freq: Frequency::hz(146_940_000),
+            tx_freq: Some(Frequency::hz(146_340_000)),
+            offset: FrequencyOffset::Minus(Frequency::khz(600)),
+            tone: ToneMode::Ctcss(CtcssTone::new(100.0).unwrap()),
+            power: PowerLevel::High,
+            bandwidth: Bandwidth::Wide,
+            scan: ScanMode::Include,
+            busy_lock: false,
+        }
+    }
+
+    #[test]
+    fn channel_construction_simplex() {
+        let ch = sample_simplex_channel();
+        assert_eq!(ch.index, 0);
+        assert_eq!(ch.name, "CALL");
+        assert!(ch.tx_freq.is_none());
+    }
+
+    #[test]
+    fn channel_construction_repeater() {
+        let ch = sample_repeater_channel();
+        assert_eq!(ch.index, 1);
+        assert!(ch.tx_freq.is_some());
+        assert_eq!(ch.offset, FrequencyOffset::Minus(Frequency::khz(600)));
+    }
+
+    #[test]
+    fn channel_json_roundtrip() {
+        let ch = sample_repeater_channel();
+        let json = serde_json::to_string(&ch).unwrap();
+        let restored: Channel = serde_json::from_str(&json).unwrap();
+        assert_eq!(ch, restored);
+    }
+
+    #[test]
+    fn channel_with_dcs_json_roundtrip() {
+        let ch = Channel {
+            index: 2,
+            name: "DCS-CH".to_string(),
+            rx_freq: Frequency::hz(446_000_000),
+            tx_freq: None,
+            offset: FrequencyOffset::None,
+            tone: ToneMode::Dcs(DcsCode::new(23).unwrap(), DcsPolarity::Normal),
+            power: PowerLevel::Low,
+            bandwidth: Bandwidth::Narrow,
+            scan: ScanMode::Skip,
+            busy_lock: true,
+        };
+        let json = serde_json::to_string(&ch).unwrap();
+        let restored: Channel = serde_json::from_str(&json).unwrap();
+        assert_eq!(ch, restored);
+    }
+}

--- a/crates/syntonia/src/error.rs
+++ b/crates/syntonia/src/error.rs
@@ -1,0 +1,47 @@
+//! Error types for the syntonia crate.
+
+use snafu::Snafu;
+
+/// Errors that can occur in syntonia operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// An invalid CTCSS tone frequency was provided.
+    #[snafu(display("invalid CTCSS tone: {value} Hz"))]
+    InvalidCtcssTone {
+        /// The invalid tone value.
+        value: f32,
+    },
+
+    /// An invalid DCS code was provided.
+    #[snafu(display("invalid DCS code: {value}"))]
+    InvalidDcsCode {
+        /// The invalid code value.
+        value: u16,
+    },
+
+    /// JSON serialization or deserialization failed.
+    #[snafu(display("JSON error: {source}"))]
+    Json {
+        /// The underlying `serde_json` error.
+        source: serde_json::Error,
+    },
+
+    /// TOML serialization failed.
+    #[snafu(display("TOML serialization error: {source}"))]
+    TomlSerialize {
+        /// The underlying toml serialization error.
+        source: toml::ser::Error,
+    },
+
+    /// TOML deserialization failed.
+    #[snafu(display("TOML deserialization error: {source}"))]
+    TomlDeserialize {
+        /// The underlying toml deserialization error.
+        source: toml::de::Error,
+    },
+}
+
+/// A specialized `Result` type for syntonia operations.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/syntonia/src/lib.rs
+++ b/crates/syntonia/src/lib.rs
@@ -1,0 +1,30 @@
+//! Syntonia — radio-agnostic channel and frequency plan data model.
+//!
+//! This crate provides the core types for representing programmable radio
+//! channel memories, frequency plans, and radio-specific validation. It sits
+//! between raw EEPROM bytes and user-visible channel plans: every radio driver
+//! encodes/decodes channels through these types.
+//!
+//! # Key types
+//!
+//! - [`Channel`] — a single programmable memory slot
+//! - [`FrequencyPlan`] — a named collection of channels (serializable to JSON/TOML)
+//! - [`ToneMode`], [`CtcssTone`], [`DcsCode`] — squelch tone configuration
+//! - [`RadioConstraints`] — radio-specific limits for validation
+
+pub mod channel;
+pub mod error;
+pub mod plan;
+pub mod tone;
+pub mod types;
+pub mod validate;
+
+pub use channel::Channel;
+pub use error::{Error, Result};
+pub use plan::FrequencyPlan;
+pub use tone::{ALL_CTCSS_TONES, ALL_DCS_CODES, CtcssTone, DcsCode, DcsPolarity, ToneMode};
+pub use types::{Bandwidth, FrequencyOffset, PowerLevel, ScanMode};
+pub use validate::{
+    RadioConstraints, ValidationIssue, baofeng_f8hp_constraints, baofeng_uv5r_constraints,
+    validate_channel, validate_plan,
+};

--- a/crates/syntonia/src/plan.rs
+++ b/crates/syntonia/src/plan.rs
@@ -1,0 +1,149 @@
+//! Frequency plan — a named collection of channels for a radio.
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::channel::Channel;
+use crate::error::{JsonSnafu, TomlDeserializeSnafu, TomlSerializeSnafu};
+
+/// A frequency plan containing a set of programmed channels.
+///
+/// Represents a complete channel configuration that can be loaded
+/// onto a radio. Serializable to JSON and TOML for import/export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FrequencyPlan {
+    /// Human-readable name for this plan.
+    pub name: String,
+    /// Target radio model, if known (e.g. "Baofeng UV-5R").
+    pub radio_model: Option<String>,
+    /// Ordered list of channels.
+    pub channels: Vec<Channel>,
+    /// ISO 8601 creation timestamp.
+    pub created: Option<String>,
+}
+
+impl FrequencyPlan {
+    /// Returns a reference to the channel at the given index, if present.
+    #[must_use]
+    pub fn channel(&self, index: u16) -> Option<&Channel> {
+        self.channels.iter().find(|ch| ch.index == index)
+    }
+
+    /// Returns the number of channels in this plan.
+    #[must_use]
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Serializes the plan to a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails.
+    pub fn to_json(&self) -> crate::error::Result<String> {
+        serde_json::to_string_pretty(self).context(JsonSnafu)
+    }
+
+    /// Deserializes a plan from a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON is invalid or contains invalid data
+    /// (e.g. invalid CTCSS tones or DCS codes).
+    pub fn from_json(s: &str) -> crate::error::Result<Self> {
+        serde_json::from_str(s).context(JsonSnafu)
+    }
+
+    /// Serializes the plan to a TOML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails.
+    pub fn to_toml(&self) -> crate::error::Result<String> {
+        toml::to_string_pretty(self).context(TomlSerializeSnafu)
+    }
+
+    /// Deserializes a plan from a TOML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the TOML is invalid or contains invalid data
+    /// (e.g. invalid CTCSS tones or DCS codes).
+    pub fn from_toml(s: &str) -> crate::error::Result<Self> {
+        toml::from_str(s).context(TomlDeserializeSnafu)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use koinon::Frequency;
+
+    use super::*;
+    use crate::tone::ToneMode;
+    use crate::types::{Bandwidth, FrequencyOffset, PowerLevel, ScanMode};
+
+    fn sample_plan() -> FrequencyPlan {
+        FrequencyPlan {
+            name: "Test Plan".to_string(),
+            radio_model: Some("Baofeng UV-5R".to_string()),
+            channels: vec![
+                Channel {
+                    index: 0,
+                    name: "CALL".to_string(),
+                    rx_freq: Frequency::hz(146_520_000),
+                    tx_freq: None,
+                    offset: FrequencyOffset::None,
+                    tone: ToneMode::None,
+                    power: PowerLevel::High,
+                    bandwidth: Bandwidth::Wide,
+                    scan: ScanMode::Include,
+                    busy_lock: false,
+                },
+                Channel {
+                    index: 1,
+                    name: "RPT".to_string(),
+                    rx_freq: Frequency::hz(146_940_000),
+                    tx_freq: Some(Frequency::hz(146_340_000)),
+                    offset: FrequencyOffset::Minus(Frequency::khz(600)),
+                    tone: ToneMode::None,
+                    power: PowerLevel::Mid,
+                    bandwidth: Bandwidth::Wide,
+                    scan: ScanMode::Include,
+                    busy_lock: false,
+                },
+            ],
+            created: Some("2026-03-15T00:00:00Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn channel_lookup_by_index() {
+        let plan = sample_plan();
+        assert!(plan.channel(0).is_some());
+        assert!(plan.channel(1).is_some());
+        assert!(plan.channel(99).is_none());
+    }
+
+    #[test]
+    fn channel_count() {
+        let plan = sample_plan();
+        assert_eq!(plan.channel_count(), 2);
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let plan = sample_plan();
+        let json = plan.to_json().unwrap();
+        let restored = FrequencyPlan::from_json(&json).unwrap();
+        assert_eq!(plan, restored);
+    }
+
+    #[test]
+    fn toml_roundtrip() {
+        let plan = sample_plan();
+        let toml_str = plan.to_toml().unwrap();
+        let restored = FrequencyPlan::from_toml(&toml_str).unwrap();
+        assert_eq!(plan, restored);
+    }
+}

--- a/crates/syntonia/src/tone.rs
+++ b/crates/syntonia/src/tone.rs
@@ -1,0 +1,241 @@
+//! CTCSS tone and DCS code types for squelch systems.
+
+use serde::{Deserialize, Serialize};
+use snafu::ensure;
+
+use crate::error::{InvalidCtcssToneSnafu, InvalidDcsCodeSnafu};
+
+/// The 50 standard CTCSS tone frequencies in Hz.
+pub const ALL_CTCSS_TONES: [f32; 50] = [
+    67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5, 85.4, 88.5, 91.5, 94.8, 97.4, 100.0, 103.5, 107.2,
+    110.9, 114.8, 118.8, 123.0, 127.3, 131.8, 136.5, 141.3, 146.2, 151.4, 156.7, 159.8, 162.2,
+    165.5, 167.9, 171.3, 173.8, 177.3, 179.9, 183.5, 186.2, 189.9, 192.8, 196.6, 199.5, 203.5,
+    206.5, 210.7, 218.1, 225.7, 229.1, 233.6, 241.8, 250.3, 254.1,
+];
+
+/// The 104 standard DCS codes.
+pub const ALL_DCS_CODES: [u16; 104] = [
+    23, 25, 26, 31, 32, 36, 43, 47, 51, 53, 54, 65, 71, 72, 73, 74, 114, 115, 116, 122, 125, 131,
+    132, 134, 143, 145, 152, 155, 156, 162, 165, 172, 174, 205, 212, 223, 225, 226, 243, 244, 245,
+    246, 251, 252, 255, 261, 263, 265, 266, 271, 274, 306, 311, 315, 325, 331, 332, 343, 346, 351,
+    356, 364, 365, 371, 411, 412, 413, 423, 431, 432, 445, 446, 452, 454, 455, 462, 464, 465, 466,
+    503, 506, 516, 523, 526, 532, 546, 565, 606, 612, 624, 627, 631, 632, 654, 662, 664, 703, 712,
+    723, 731, 732, 734, 743, 754,
+];
+
+/// A validated CTCSS (Continuous Tone-Coded Squelch System) tone frequency.
+///
+/// Wraps one of the 50 standard sub-audible tones (67.0–254.1 Hz).
+/// Construction validates against the known tone set.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct CtcssTone(f32);
+
+impl CtcssTone {
+    /// Creates a new `CtcssTone` if the value matches a standard tone.
+    ///
+    /// Comparison uses tenths-of-Hz integer matching to avoid float precision issues.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidCtcssTone`](crate::error::Error::InvalidCtcssTone)
+    /// if the value is not one of the 50 standard CTCSS tones.
+    pub fn new(value: f32) -> crate::error::Result<Self> {
+        #[allow(clippy::cast_sign_loss)] // CTCSS tones are always positive
+        let tenths = (value * 10.0).round() as u32;
+        #[allow(clippy::cast_sign_loss)] // CTCSS tones are always positive
+        let valid = ALL_CTCSS_TONES
+            .iter()
+            .any(|&t| (t * 10.0).round() as u32 == tenths);
+        ensure!(valid, InvalidCtcssToneSnafu { value });
+        Ok(Self(value))
+    }
+
+    /// Returns the tone frequency in Hz.
+    #[must_use]
+    pub const fn as_hz(&self) -> f32 {
+        self.0
+    }
+}
+
+impl Eq for CtcssTone {}
+
+impl<'de> Deserialize<'de> for CtcssTone {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = f32::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A validated DCS (Digital-Coded Squelch) code.
+///
+/// Wraps one of the 104 standard DCS codes. Construction validates
+/// against the known code set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct DcsCode(u16);
+
+impl DcsCode {
+    /// Creates a new `DcsCode` if the value matches a standard code.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidDcsCode`](crate::error::Error::InvalidDcsCode)
+    /// if the value is not one of the 104 standard DCS codes.
+    pub fn new(value: u16) -> crate::error::Result<Self> {
+        ensure!(
+            ALL_DCS_CODES.contains(&value),
+            InvalidDcsCodeSnafu { value }
+        );
+        Ok(Self(value))
+    }
+
+    /// Returns the raw DCS code number.
+    #[must_use]
+    pub const fn code(&self) -> u16 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for DcsCode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u16::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// DCS code polarity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum DcsPolarity {
+    /// Normal polarity.
+    Normal,
+    /// Inverted polarity.
+    Inverted,
+}
+
+/// Squelch tone configuration for a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ToneMode {
+    /// No tone squelch.
+    None,
+    /// CTCSS sub-audible tone.
+    Ctcss(CtcssTone),
+    /// DCS digital code with polarity.
+    Dcs(DcsCode, DcsPolarity),
+}
+
+impl Eq for ToneMode {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_50_ctcss_tones_accepted() {
+        for &tone in &ALL_CTCSS_TONES {
+            assert!(
+                CtcssTone::new(tone).is_ok(),
+                "valid CTCSS tone {tone} was rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_ctcss_tone_rejected() {
+        assert!(CtcssTone::new(0.0).is_err());
+        assert!(CtcssTone::new(50.0).is_err());
+        assert!(CtcssTone::new(100.1).is_err());
+        assert!(CtcssTone::new(300.0).is_err());
+    }
+
+    #[test]
+    fn ctcss_tone_value_preserved() {
+        let tone = CtcssTone::new(100.0).unwrap();
+        assert!((tone.as_hz() - 100.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn all_104_dcs_codes_accepted() {
+        for &code in &ALL_DCS_CODES {
+            assert!(
+                DcsCode::new(code).is_ok(),
+                "valid DCS code {code} was rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_dcs_code_rejected() {
+        assert!(DcsCode::new(0).is_err());
+        assert!(DcsCode::new(1).is_err());
+        assert!(DcsCode::new(999).is_err());
+        assert!(DcsCode::new(100).is_err());
+    }
+
+    #[test]
+    fn dcs_code_value_preserved() {
+        let code = DcsCode::new(23).unwrap();
+        assert_eq!(code.code(), 23);
+    }
+
+    #[test]
+    fn ctcss_serde_roundtrip() {
+        let tone = CtcssTone::new(146.2).unwrap();
+        let json = serde_json::to_string(&tone).unwrap();
+        let restored: CtcssTone = serde_json::from_str(&json).unwrap();
+        assert_eq!(tone, restored);
+    }
+
+    #[test]
+    fn dcs_serde_roundtrip() {
+        let code = DcsCode::new(23).unwrap();
+        let json = serde_json::to_string(&code).unwrap();
+        let restored: DcsCode = serde_json::from_str(&json).unwrap();
+        assert_eq!(code, restored);
+    }
+
+    #[test]
+    fn invalid_ctcss_rejected_during_deserialization() {
+        let json = "50.0";
+        let result: std::result::Result<CtcssTone, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_dcs_rejected_during_deserialization() {
+        let json = "999";
+        let result: std::result::Result<DcsCode, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tone_mode_none_serde_roundtrip() {
+        let mode = ToneMode::None;
+        let json = serde_json::to_string(&mode).unwrap();
+        let restored: ToneMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, restored);
+    }
+
+    #[test]
+    fn tone_mode_ctcss_serde_roundtrip() {
+        let mode = ToneMode::Ctcss(CtcssTone::new(100.0).unwrap());
+        let json = serde_json::to_string(&mode).unwrap();
+        let restored: ToneMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, restored);
+    }
+
+    #[test]
+    fn tone_mode_dcs_serde_roundtrip() {
+        let mode = ToneMode::Dcs(DcsCode::new(23).unwrap(), DcsPolarity::Inverted);
+        let json = serde_json::to_string(&mode).unwrap();
+        let restored: ToneMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(mode, restored);
+    }
+}

--- a/crates/syntonia/src/types.rs
+++ b/crates/syntonia/src/types.rs
@@ -1,0 +1,109 @@
+//! Supporting types for channel configuration.
+
+use koinon::Frequency;
+use serde::{Deserialize, Serialize};
+
+/// Frequency offset configuration for repeater operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum FrequencyOffset {
+    /// No offset — simplex operation.
+    None,
+    /// Positive offset from RX frequency.
+    Plus(Frequency),
+    /// Negative offset from RX frequency.
+    Minus(Frequency),
+    /// Arbitrary split — TX on a specific frequency unrelated to RX by standard offset.
+    Split(Frequency),
+}
+
+/// Transmit power level.
+///
+/// Actual wattage is radio-specific and not stored here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PowerLevel {
+    /// Maximum transmit power.
+    High,
+    /// Medium transmit power.
+    Mid,
+    /// Minimum transmit power.
+    Low,
+}
+
+/// Channel bandwidth selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Bandwidth {
+    /// Wide bandwidth (25 kHz).
+    Wide,
+    /// Narrow bandwidth (12.5 kHz).
+    Narrow,
+}
+
+/// Scanner behavior for a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ScanMode {
+    /// Include this channel in scan lists.
+    Include,
+    /// Skip this channel when scanning.
+    Skip,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frequency_offset_none_serde_roundtrip() {
+        let offset = FrequencyOffset::None;
+        let json = serde_json::to_string(&offset).unwrap();
+        let restored: FrequencyOffset = serde_json::from_str(&json).unwrap();
+        assert_eq!(offset, restored);
+    }
+
+    #[test]
+    fn frequency_offset_plus_serde_roundtrip() {
+        let offset = FrequencyOffset::Plus(Frequency::khz(600));
+        let json = serde_json::to_string(&offset).unwrap();
+        let restored: FrequencyOffset = serde_json::from_str(&json).unwrap();
+        assert_eq!(offset, restored);
+    }
+
+    #[test]
+    fn frequency_offset_split_serde_roundtrip() {
+        let offset = FrequencyOffset::Split(Frequency::mhz(146));
+        let json = serde_json::to_string(&offset).unwrap();
+        let restored: FrequencyOffset = serde_json::from_str(&json).unwrap();
+        assert_eq!(offset, restored);
+    }
+
+    #[test]
+    fn power_level_serde_roundtrip() {
+        for level in [PowerLevel::High, PowerLevel::Mid, PowerLevel::Low] {
+            let json = serde_json::to_string(&level).unwrap();
+            let restored: PowerLevel = serde_json::from_str(&json).unwrap();
+            assert_eq!(level, restored);
+        }
+    }
+
+    #[test]
+    fn bandwidth_serde_roundtrip() {
+        for bw in [Bandwidth::Wide, Bandwidth::Narrow] {
+            let json = serde_json::to_string(&bw).unwrap();
+            let restored: Bandwidth = serde_json::from_str(&json).unwrap();
+            assert_eq!(bw, restored);
+        }
+    }
+
+    #[test]
+    fn scan_mode_serde_roundtrip() {
+        for mode in [ScanMode::Include, ScanMode::Skip] {
+            let json = serde_json::to_string(&mode).unwrap();
+            let restored: ScanMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(mode, restored);
+        }
+    }
+}

--- a/crates/syntonia/src/validate.rs
+++ b/crates/syntonia/src/validate.rs
@@ -1,0 +1,321 @@
+//! Channel and plan validation against radio-specific constraints.
+
+use std::collections::HashSet;
+
+use koinon::Frequency;
+
+use crate::channel::Channel;
+use crate::plan::FrequencyPlan;
+use crate::types::PowerLevel;
+
+/// A validation finding — either a hard error or a soft warning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ValidationIssue {
+    /// A hard failure that must be resolved.
+    Error(String),
+    /// A soft issue that may be acceptable.
+    Warning(String),
+}
+
+/// Radio-specific constraints used to validate channels and plans.
+#[derive(Debug, Clone)]
+pub struct RadioConstraints {
+    /// Maximum number of characters in a channel name.
+    pub max_name_length: usize,
+    /// Valid frequency bands as (low, high) inclusive pairs.
+    pub valid_bands: Vec<(Frequency, Frequency)>,
+    /// Supported power levels.
+    pub power_levels: Vec<PowerLevel>,
+    /// Maximum number of programmable channels.
+    pub max_channels: u16,
+}
+
+/// Returns constraints for the Baofeng UV-5R.
+#[must_use]
+pub fn baofeng_uv5r_constraints() -> RadioConstraints {
+    RadioConstraints {
+        max_name_length: 7,
+        valid_bands: vec![
+            (Frequency::mhz(136), Frequency::mhz(174)), // VHF
+            (Frequency::mhz(400), Frequency::mhz(520)), // UHF
+        ],
+        power_levels: vec![PowerLevel::High, PowerLevel::Low],
+        max_channels: 128,
+    }
+}
+
+/// Returns constraints for the Baofeng BF-F8HP.
+#[must_use]
+pub fn baofeng_f8hp_constraints() -> RadioConstraints {
+    RadioConstraints {
+        max_name_length: 7,
+        valid_bands: vec![
+            (Frequency::mhz(136), Frequency::mhz(174)), // VHF
+            (Frequency::mhz(400), Frequency::mhz(520)), // UHF
+        ],
+        power_levels: vec![PowerLevel::High, PowerLevel::Mid, PowerLevel::Low],
+        max_channels: 128,
+    }
+}
+
+/// Checks whether a frequency falls within any of the valid bands.
+fn freq_in_bands(freq: Frequency, bands: &[(Frequency, Frequency)]) -> bool {
+    bands.iter().any(|&(lo, hi)| freq >= lo && freq <= hi)
+}
+
+/// Validates a single channel against radio constraints.
+///
+/// Returns a list of issues found. An empty list means the channel is valid.
+#[must_use]
+pub fn validate_channel(channel: &Channel, constraints: &RadioConstraints) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    // RX frequency must be within valid bands.
+    if !freq_in_bands(channel.rx_freq, &constraints.valid_bands) {
+        issues.push(ValidationIssue::Error(format!(
+            "channel {}: RX frequency {} is outside valid bands",
+            channel.index, channel.rx_freq
+        )));
+    }
+
+    // TX frequency (if explicit) must be within valid bands.
+    if let Some(tx) = channel.tx_freq {
+        if !freq_in_bands(tx, &constraints.valid_bands) {
+            issues.push(ValidationIssue::Error(format!(
+                "channel {}: TX frequency {} is outside valid bands",
+                channel.index, tx
+            )));
+        }
+    }
+
+    // Name length check — warning, not error.
+    if channel.name.len() > constraints.max_name_length {
+        issues.push(ValidationIssue::Warning(format!(
+            "channel {}: name '{}' exceeds max length of {} characters",
+            channel.index, channel.name, constraints.max_name_length
+        )));
+    }
+
+    // Power level must be supported by the radio.
+    if !constraints.power_levels.contains(&channel.power) {
+        issues.push(ValidationIssue::Error(format!(
+            "channel {}: power level {:?} not supported by this radio",
+            channel.index, channel.power
+        )));
+    }
+
+    // Channel index must be within radio limits.
+    if channel.index >= constraints.max_channels {
+        issues.push(ValidationIssue::Error(format!(
+            "channel {}: index exceeds maximum of {}",
+            channel.index,
+            constraints.max_channels - 1
+        )));
+    }
+
+    issues
+}
+
+/// Validates an entire frequency plan against radio constraints.
+///
+/// Checks each channel individually, plus plan-level rules like
+/// channel count limits and duplicate frequency detection.
+#[must_use]
+pub fn validate_plan(plan: &FrequencyPlan, constraints: &RadioConstraints) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    // Channel count.
+    if plan.channels.len() > usize::from(constraints.max_channels) {
+        issues.push(ValidationIssue::Error(format!(
+            "plan has {} channels but radio supports at most {}",
+            plan.channels.len(),
+            constraints.max_channels
+        )));
+    }
+
+    // Per-channel validation.
+    for channel in &plan.channels {
+        issues.extend(validate_channel(channel, constraints));
+    }
+
+    // Duplicate RX frequency detection.
+    let mut seen_rx = HashSet::new();
+    for channel in &plan.channels {
+        if !seen_rx.insert(channel.rx_freq) {
+            issues.push(ValidationIssue::Warning(format!(
+                "channel {}: duplicate RX frequency {}",
+                channel.index, channel.rx_freq
+            )));
+        }
+    }
+
+    issues
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::tone::ToneMode;
+    use crate::types::{Bandwidth, FrequencyOffset, ScanMode};
+
+    fn valid_vhf_channel(index: u16) -> Channel {
+        Channel {
+            index,
+            name: "TEST".to_string(),
+            rx_freq: Frequency::hz(146_520_000),
+            tx_freq: None,
+            offset: FrequencyOffset::None,
+            tone: ToneMode::None,
+            power: PowerLevel::High,
+            bandwidth: Bandwidth::Wide,
+            scan: ScanMode::Include,
+            busy_lock: false,
+        }
+    }
+
+    #[test]
+    fn valid_channel_passes_validation() {
+        let ch = valid_vhf_channel(0);
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(issues.is_empty(), "expected no issues, got: {issues:?}");
+    }
+
+    #[test]
+    fn out_of_band_rx_frequency_rejected() {
+        let ch = Channel {
+            rx_freq: Frequency::mhz(100), // outside all bands
+            ..valid_vhf_channel(0)
+        };
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(
+            issues.iter().any(
+                |i| matches!(i, ValidationIssue::Error(s) if s.contains("outside valid bands"))
+            ),
+            "expected band error, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn out_of_band_tx_frequency_rejected() {
+        let ch = Channel {
+            tx_freq: Some(Frequency::mhz(100)),
+            ..valid_vhf_channel(0)
+        };
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(
+            issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(s) if s.contains("TX frequency"))),
+            "expected TX band error, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn name_too_long_produces_warning() {
+        let ch = Channel {
+            name: "LONGNAME".to_string(), // 8 chars, limit is 7
+            ..valid_vhf_channel(0)
+        };
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(
+            issues.iter().any(
+                |i| matches!(i, ValidationIssue::Warning(s) if s.contains("exceeds max length"))
+            ),
+            "expected name length warning, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn unsupported_power_level_rejected() {
+        let ch = Channel {
+            power: PowerLevel::Mid, // UV-5R only has High/Low
+            ..valid_vhf_channel(0)
+        };
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(
+            issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(s) if s.contains("power level"))),
+            "expected power level error, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn f8hp_supports_mid_power() {
+        let ch = Channel {
+            power: PowerLevel::Mid,
+            ..valid_vhf_channel(0)
+        };
+        let issues = validate_channel(&ch, &baofeng_f8hp_constraints());
+        assert!(
+            !issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(s) if s.contains("power level"))),
+            "F8HP should support Mid power, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn channel_index_exceeding_max_rejected() {
+        let ch = valid_vhf_channel(128); // max is 128, so valid indices are 0-127
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(
+            issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(s) if s.contains("index exceeds"))),
+            "expected index error, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn plan_too_many_channels_rejected() {
+        let channels: Vec<Channel> = (0..129).map(valid_vhf_channel).collect();
+        let plan = FrequencyPlan {
+            name: "Big Plan".to_string(),
+            radio_model: None,
+            channels,
+            created: None,
+        };
+        let issues = validate_plan(&plan, &baofeng_uv5r_constraints());
+        assert!(
+            issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(s) if s.contains("channels but radio supports"))),
+            "expected channel count error, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_rx_frequency_warned() {
+        let plan = FrequencyPlan {
+            name: "Dup Plan".to_string(),
+            radio_model: None,
+            channels: vec![valid_vhf_channel(0), valid_vhf_channel(1)], // same rx_freq
+            created: None,
+        };
+        let issues = validate_plan(&plan, &baofeng_uv5r_constraints());
+        assert!(
+            issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Warning(s) if s.contains("duplicate RX"))),
+            "expected duplicate warning, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn uhf_frequency_valid_for_uv5r() {
+        let ch = Channel {
+            rx_freq: Frequency::hz(446_000_000),
+            ..valid_vhf_channel(0)
+        };
+        let issues = validate_channel(&ch, &baofeng_uv5r_constraints());
+        assert!(
+            !issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(_))),
+            "UHF 446 MHz should be valid, got: {issues:?}"
+        );
+    }
+}

--- a/crates/syntonia/tests/family_plan.rs
+++ b/crates/syntonia/tests/family_plan.rs
@@ -1,0 +1,63 @@
+//! Integration test: load and validate the family plan TOML fixture.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use syntonia::{FrequencyPlan, ValidationIssue, baofeng_uv5r_constraints, validate_plan};
+
+#[test]
+fn load_family_plan_fixture() {
+    let toml_str = include_str!("fixtures/family-plan.toml");
+    let plan = FrequencyPlan::from_toml(toml_str).expect("fixture should parse");
+    assert_eq!(plan.name, "Family Plan");
+    assert_eq!(plan.channel_count(), 10);
+}
+
+#[test]
+fn family_plan_channels_have_expected_names() {
+    let toml_str = include_str!("fixtures/family-plan.toml");
+    let plan = FrequencyPlan::from_toml(toml_str).unwrap();
+
+    let names: Vec<&str> = plan.channels.iter().map(|ch| ch.name.as_str()).collect();
+    assert_eq!(
+        names,
+        [
+            "CALL", "RPT-1", "RPT-2", "SIMP-1", "SIMP-2", "UHF-1", "UHF-2", "WX", "RPT-3", "EMRG"
+        ]
+    );
+}
+
+#[test]
+fn family_plan_validates_with_no_errors() {
+    let toml_str = include_str!("fixtures/family-plan.toml");
+    let plan = FrequencyPlan::from_toml(toml_str).unwrap();
+    let constraints = baofeng_uv5r_constraints();
+    let issues = validate_plan(&plan, &constraints);
+
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| matches!(i, ValidationIssue::Error(_)))
+        .collect();
+
+    assert!(
+        errors.is_empty(),
+        "family plan should have no validation errors, got: {errors:?}"
+    );
+}
+
+#[test]
+fn family_plan_json_roundtrip() {
+    let toml_str = include_str!("fixtures/family-plan.toml");
+    let plan = FrequencyPlan::from_toml(toml_str).unwrap();
+    let json = plan.to_json().unwrap();
+    let restored = FrequencyPlan::from_json(&json).unwrap();
+    assert_eq!(plan, restored);
+}
+
+#[test]
+fn family_plan_toml_roundtrip() {
+    let toml_str = include_str!("fixtures/family-plan.toml");
+    let plan = FrequencyPlan::from_toml(toml_str).unwrap();
+    let re_toml = plan.to_toml().unwrap();
+    let restored = FrequencyPlan::from_toml(&re_toml).unwrap();
+    assert_eq!(plan, restored);
+}

--- a/crates/syntonia/tests/fixtures/family-plan.toml
+++ b/crates/syntonia/tests/fixtures/family-plan.toml
@@ -1,0 +1,130 @@
+name = "Family Plan"
+radio_model = "Baofeng UV-5R"
+created = "2026-03-15T00:00:00Z"
+
+[[channels]]
+index = 0
+name = "CALL"
+rx_freq = 146520000
+bandwidth = "Wide"
+power = "High"
+scan = "Include"
+busy_lock = false
+offset = "None"
+tone = "None"
+
+[[channels]]
+index = 1
+name = "RPT-1"
+rx_freq = 146940000
+tx_freq = 146340000
+bandwidth = "Wide"
+power = "High"
+scan = "Include"
+busy_lock = false
+
+[channels.offset]
+Minus = 600000
+
+[channels.tone]
+Ctcss = 100.0
+
+[[channels]]
+index = 2
+name = "RPT-2"
+rx_freq = 147120000
+tx_freq = 147720000
+bandwidth = "Wide"
+power = "High"
+scan = "Include"
+busy_lock = false
+
+[channels.offset]
+Plus = 600000
+
+[channels.tone]
+Ctcss = 131.8
+
+[[channels]]
+index = 3
+name = "SIMP-1"
+rx_freq = 146550000
+bandwidth = "Wide"
+power = "Low"
+scan = "Include"
+busy_lock = false
+offset = "None"
+tone = "None"
+
+[[channels]]
+index = 4
+name = "SIMP-2"
+rx_freq = 146580000
+bandwidth = "Wide"
+power = "Low"
+scan = "Include"
+busy_lock = false
+offset = "None"
+tone = "None"
+
+[[channels]]
+index = 5
+name = "UHF-1"
+rx_freq = 446000000
+bandwidth = "Narrow"
+power = "High"
+scan = "Include"
+busy_lock = false
+offset = "None"
+tone = "None"
+
+[[channels]]
+index = 6
+name = "UHF-2"
+rx_freq = 446500000
+bandwidth = "Narrow"
+power = "High"
+scan = "Include"
+busy_lock = true
+offset = "None"
+
+[channels.tone]
+Dcs = [23, "Normal"]
+
+[[channels]]
+index = 7
+name = "WX"
+rx_freq = 162550000
+bandwidth = "Wide"
+power = "Low"
+scan = "Skip"
+busy_lock = false
+offset = "None"
+tone = "None"
+
+[[channels]]
+index = 8
+name = "RPT-3"
+rx_freq = 443500000
+tx_freq = 448500000
+bandwidth = "Wide"
+power = "High"
+scan = "Include"
+busy_lock = false
+
+[channels.offset]
+Plus = 5000000
+
+[channels.tone]
+Ctcss = 94.8
+
+[[channels]]
+index = 9
+name = "EMRG"
+rx_freq = 146520000
+bandwidth = "Wide"
+power = "High"
+scan = "Skip"
+busy_lock = false
+offset = "None"
+tone = "None"


### PR DESCRIPTION
## Summary
- New `syntonia` crate with radio-agnostic channel/frequency plan model
- Complete CTCSS (50 tones) and DCS (104 codes) coverage with validation
- FrequencyPlan with JSON/TOML import/export
- RadioConstraints-based validation (band limits, name length, channel count)
- Family plan TOML fixture for integration testing

## Test plan
- [x] `cargo build && cargo test --workspace` — 42 syntonia tests + 138 koinon tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Serde roundtrip on Channel, FrequencyPlan (JSON + TOML)
- [x] Validation rejects invalid frequencies and tones
- [x] Family plan fixture loads and validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)