### PR TITLE
feat(syntonia): USB hardware detection + radio auto-detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,15 +42,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -61,7 +61,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -72,8 +72,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -97,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +128,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -166,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -209,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -219,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -231,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -249,9 +267,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -273,6 +291,32 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -302,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -338,6 +382,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,8 +401,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -362,6 +431,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -373,13 +451,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -387,6 +473,16 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -412,7 +508,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -475,10 +571,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -500,6 +628,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -524,7 +661,18 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -533,7 +681,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -543,6 +691,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "nusb"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f861541f15de120eae5982923d073bfc0c1a65466561988c82d6e197734c19e"
+dependencies = [
+ "atomic-waker",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys",
+ "libc",
+ "log",
+ "once_cell",
+ "rustix 0.38.44",
+ "slab",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -610,6 +777,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,9 +790,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -631,6 +804,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -663,7 +846,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -682,9 +865,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -694,6 +877,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -721,7 +910,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -739,7 +928,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -761,15 +950,28 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -801,6 +1003,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -855,6 +1063,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serialport"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f60a586160667241d7702c420fc223939fb3c0bb8d3fac84f78768e8970dee"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "libudev",
+ "mach2",
+ "nix",
+ "quote",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +1106,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -913,7 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -945,10 +1179,13 @@ version = "0.1.0"
 dependencies = [
  "compact_str",
  "koinon",
+ "nusb",
  "proptest",
  "serde",
  "serde_json",
+ "serialport",
  "snafu",
+ "tempfile",
  "toml",
  "tracing",
 ]
@@ -960,10 +1197,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -989,7 +1246,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1089,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1132,10 +1389,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unescaper"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1175,6 +1447,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1225,6 +1506,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,12 +1557,160 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1263,6 +1726,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "yansi"

--- a/crates/syntonia/Cargo.toml
+++ b/crates/syntonia/Cargo.toml
@@ -1,22 +1,26 @@
 [package]
 name = "syntonia"
-description = "Radio-agnostic channel and frequency plan data model"
+description = "Radio-agnostic channel and frequency plan data model with hardware detection"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 koinon = { path = "../koinon" }
+compact_str = { workspace = true }
+nusb = "0.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-toml = { workspace = true }
+serialport = "4"
 snafu = { workspace = true }
-compact_str = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 proptest = "1"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/syntonia/src/hardware/cables.rs
+++ b/crates/syntonia/src/hardware/cables.rs
@@ -1,0 +1,172 @@
+//! Programming cable chip identification.
+
+use std::fmt;
+
+/// USB-to-serial chipset found in radio programming cables.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CableChip {
+    /// Prolific PL2303 — most common Baofeng cable. Clones are rampant.
+    Pl2303,
+    /// `WinChipHead` CH340 — second most common. Generally reliable.
+    Ch340,
+    /// Silicon Labs CP2102 — higher-end cables.
+    Cp2102,
+    /// FTDI FT232R — rare for Baofeng, common for other radios.
+    Ftdi,
+    /// Unrecognized USB-to-serial adapter.
+    Unknown {
+        /// USB vendor ID.
+        vid: u16,
+        /// USB product ID.
+        pid: u16,
+    },
+}
+
+impl fmt::Display for CableChip {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pl2303 => f.write_str("PL2303"),
+            Self::Ch340 => f.write_str("CH340"),
+            Self::Cp2102 => f.write_str("CP2102"),
+            Self::Ftdi => f.write_str("FT232R"),
+            Self::Unknown { vid, pid } => write!(f, "Unknown ({vid:04X}:{pid:04X})"),
+        }
+    }
+}
+
+/// A known programming cable entry.
+#[derive(Debug, Clone, Copy)]
+pub struct KnownCable {
+    /// USB vendor ID.
+    pub vid: u16,
+    /// USB product ID.
+    pub pid: u16,
+    /// Chipset type.
+    pub chip: CableChip,
+    /// Human-readable name.
+    pub name: &'static str,
+}
+
+/// Known USB-to-serial chips used in radio programming cables.
+pub const KNOWN_CABLES: &[KnownCable] = &[
+    KnownCable {
+        vid: 0x067B,
+        pid: 0x2303,
+        chip: CableChip::Pl2303,
+        name: "Prolific PL2303",
+    },
+    KnownCable {
+        vid: 0x1A86,
+        pid: 0x7523,
+        chip: CableChip::Ch340,
+        name: "WinChipHead CH340",
+    },
+    KnownCable {
+        vid: 0x10C4,
+        pid: 0xEA60,
+        chip: CableChip::Cp2102,
+        name: "Silicon Labs CP2102",
+    },
+    KnownCable {
+        vid: 0x0403,
+        pid: 0x6001,
+        chip: CableChip::Ftdi,
+        name: "FTDI FT232R",
+    },
+];
+
+/// Classify a USB device by VID:PID into a cable chip type.
+#[must_use]
+pub fn classify_cable(vid: u16, pid: u16) -> CableChip {
+    KNOWN_CABLES
+        .iter()
+        .find(|c| c.vid == vid && c.pid == pid)
+        .map_or(CableChip::Unknown { vid, pid }, |c| c.chip)
+}
+
+/// Look up a known cable entry by VID:PID.
+#[must_use]
+pub fn lookup_cable(vid: u16, pid: u16) -> Option<&'static KnownCable> {
+    KNOWN_CABLES.iter().find(|c| c.vid == vid && c.pid == pid)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pl2303_vid_pid_classifies_correctly() {
+        assert_eq!(classify_cable(0x067B, 0x2303), CableChip::Pl2303);
+    }
+
+    #[test]
+    fn ch340_vid_pid_classifies_correctly() {
+        assert_eq!(classify_cable(0x1A86, 0x7523), CableChip::Ch340);
+    }
+
+    #[test]
+    fn cp2102_vid_pid_classifies_correctly() {
+        assert_eq!(classify_cable(0x10C4, 0xEA60), CableChip::Cp2102);
+    }
+
+    #[test]
+    fn ftdi_vid_pid_classifies_correctly() {
+        assert_eq!(classify_cable(0x0403, 0x6001), CableChip::Ftdi);
+    }
+
+    #[test]
+    fn unknown_vid_pid_classifies_as_unknown() {
+        assert_eq!(
+            classify_cable(0xDEAD, 0xBEEF),
+            CableChip::Unknown {
+                vid: 0xDEAD,
+                pid: 0xBEEF,
+            }
+        );
+    }
+
+    #[test]
+    fn all_known_cables_resolve_via_lookup() {
+        let entries = [
+            (0x067B_u16, 0x2303_u16, CableChip::Pl2303),
+            (0x1A86, 0x7523, CableChip::Ch340),
+            (0x10C4, 0xEA60, CableChip::Cp2102),
+            (0x0403, 0x6001, CableChip::Ftdi),
+        ];
+        for (vid, pid, expected_chip) in &entries {
+            let cable = lookup_cable(*vid, *pid).expect("cable must be in table");
+            assert_eq!(cable.chip, *expected_chip);
+        }
+    }
+
+    #[test]
+    fn vid_pid_match_is_exact_no_false_positives() {
+        assert!(lookup_cable(0x067B, 0x2304).is_none());
+        assert!(lookup_cable(0x067C, 0x2303).is_none());
+        assert!(lookup_cable(0x1A86, 0x7524).is_none());
+        assert!(lookup_cable(0x0000, 0x0000).is_none());
+    }
+
+    #[test]
+    fn display_shows_chip_names() {
+        assert_eq!(CableChip::Pl2303.to_string(), "PL2303");
+        assert_eq!(CableChip::Ch340.to_string(), "CH340");
+        assert_eq!(CableChip::Cp2102.to_string(), "CP2102");
+        assert_eq!(CableChip::Ftdi.to_string(), "FT232R");
+        assert_eq!(
+            CableChip::Unknown {
+                vid: 0xABCD,
+                pid: 0x1234
+            }
+            .to_string(),
+            "Unknown (ABCD:1234)"
+        );
+    }
+}

--- a/crates/syntonia/src/hardware/detect.rs
+++ b/crates/syntonia/src/hardware/detect.rs
@@ -1,0 +1,506 @@
+//! Radio detection via serial port probing.
+
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use koinon::RadioKind;
+use snafu::{ResultExt, Snafu};
+
+use crate::hardware::cables::{CableChip, classify_cable};
+use crate::hardware::usb::{ScanError, UsbCable, scan_usb_cables};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Detected radio variant configuration.
+#[derive(Debug, Clone)]
+pub struct VariantConfig {
+    /// Radio model.
+    pub kind: RadioKind,
+    /// Baud rate for programming communication.
+    pub baud_rate: u32,
+    /// Memory size in bytes.
+    pub memory_size: u32,
+}
+
+/// Radio identification response from the auto-detect probe.
+#[derive(Debug, Clone)]
+pub struct RadioIdent {
+    /// Firmware version string.
+    pub firmware: String,
+    /// Raw identification bytes from the radio.
+    pub raw_response: Vec<u8>,
+}
+
+/// A detected radio with its cable and identification info.
+#[derive(Debug, Clone)]
+pub struct DetectedRadio {
+    /// USB cable connecting the radio.
+    pub cable: UsbCable,
+    /// Detected radio variant configuration.
+    pub variant: VariantConfig,
+    /// Radio identification response.
+    pub ident: RadioIdent,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+/// Errors from radio detection.
+#[derive(Debug, Snafu)]
+pub enum DetectError {
+    /// Failed to scan USB ports.
+    #[snafu(display("failed to scan USB ports"))]
+    ScanPorts {
+        /// Source scan error.
+        source: ScanError,
+        /// Source location.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Failed to open a serial port.
+    #[snafu(display("failed to open serial port {port}"))]
+    OpenPort {
+        /// Port path that could not be opened.
+        port: String,
+        /// The underlying serialport error.
+        source: serialport::Error,
+        /// Source location.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Serial I/O error during probing.
+    #[snafu(display("serial I/O failed on {port}"))]
+    SerialIo {
+        /// Port path where I/O failed.
+        port: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+        /// Source location.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Failed to enumerate serial ports for cable lookup.
+    #[snafu(display("failed to enumerate ports for cable lookup"))]
+    EnumerateForLookup {
+        /// The underlying serialport error.
+        source: serialport::Error,
+        /// Source location.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+// ── Magic sequences ──────────────────────────────────────────────────────────
+
+const ACK: u8 = 0x06;
+const IDENT_REQUEST: u8 = 0x02;
+const IDENT_LENGTH: usize = 8;
+const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+const BAUD_RATE: u32 = 9600;
+
+struct MagicSequence {
+    magic: &'static [u8],
+    parse: fn(&[u8]) -> Option<VariantConfig>,
+}
+
+// WHY: Baofeng radios enter programming mode via a specific magic byte handshake.
+// Different radio families use different magic sequences.
+const MAGIC_SEQUENCES: &[MagicSequence] = &[MagicSequence {
+    magic: &[0x50, 0xBB, 0xFF, 0x20, 0x12, 0x07, 0x25],
+    parse: parse_uv5r_ident,
+}];
+
+fn parse_uv5r_ident(ident: &[u8]) -> Option<VariantConfig> {
+    let prefix = ident.get(..3)?;
+    match prefix {
+        b"BFB" => Some(VariantConfig {
+            kind: RadioKind::BaofengUv5r,
+            baud_rate: BAUD_RATE,
+            memory_size: 0x1808,
+        }),
+        b"BFF" => Some(VariantConfig {
+            kind: RadioKind::BaofengBfF8hp,
+            baud_rate: BAUD_RATE,
+            memory_size: 0x1808,
+        }),
+        b"BFU" => Some(VariantConfig {
+            kind: RadioKind::BaofengUv5rmPlus,
+            baud_rate: BAUD_RATE,
+            memory_size: 0x1808,
+        }),
+        _ => None,
+    }
+}
+
+// ── Prober trait ─────────────────────────────────────────────────────────────
+
+/// Abstraction over serial port probing for testability.
+pub trait RadioProber {
+    /// Probe a serial port for a connected radio.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DetectError`] if the port cannot be opened or communication fails.
+    fn probe(&self, port_path: &str) -> Result<Option<(VariantConfig, RadioIdent)>, DetectError>;
+}
+
+/// Default prober that opens real serial ports.
+struct DefaultProber;
+
+impl RadioProber for DefaultProber {
+    fn probe(&self, port_path: &str) -> Result<Option<(VariantConfig, RadioIdent)>, DetectError> {
+        let mut port = serialport::new(port_path, BAUD_RATE)
+            .timeout(PROBE_TIMEOUT)
+            .open()
+            .context(OpenPortSnafu {
+                port: port_path.to_string(),
+            })?;
+
+        for seq in MAGIC_SEQUENCES {
+            if let Some(result) = try_magic_sequence(&mut *port, seq) {
+                return Ok(Some(result));
+            }
+        }
+        Ok(None)
+    }
+}
+
+fn try_magic_sequence(
+    port: &mut (impl Read + Write + ?Sized),
+    seq: &MagicSequence,
+) -> Option<(VariantConfig, RadioIdent)> {
+    port.write_all(seq.magic).ok()?;
+
+    let mut ack = [0u8; 1];
+    port.read_exact(&mut ack).ok()?;
+    if ack[0] != ACK {
+        return None;
+    }
+
+    port.write_all(&[IDENT_REQUEST]).ok()?;
+
+    let mut ident_buf = [0u8; IDENT_LENGTH];
+    port.read_exact(&mut ident_buf).ok()?;
+
+    let _ = port.write_all(&[ACK]);
+
+    let variant = (seq.parse)(&ident_buf)?;
+    let firmware = String::from_utf8_lossy(&ident_buf)
+        .trim_end_matches('\0')
+        .to_string();
+    let ident = RadioIdent {
+        firmware,
+        raw_response: ident_buf.to_vec(),
+    };
+    Some((variant, ident))
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Scan for USB cables and probe each for a connected radio.
+///
+/// Skips ports that fail to open or don't respond to any magic sequence.
+/// Returns an empty list (not an error) if no radios are found.
+///
+/// # Errors
+///
+/// Returns [`DetectError::ScanPorts`] if USB port enumeration fails.
+pub fn detect_radios() -> Result<Vec<DetectedRadio>, DetectError> {
+    let cables = scan_usb_cables().context(ScanPortsSnafu)?;
+    Ok(detect_radios_impl(cables, &DefaultProber))
+}
+
+/// Probe a specific serial port for a connected radio.
+///
+/// # Errors
+///
+/// Returns errors if port enumeration or serial communication fails.
+pub fn detect_radio_on_port(port_path: &str) -> Result<Option<DetectedRadio>, DetectError> {
+    detect_radio_on_port_impl(port_path, &DefaultProber)
+}
+
+pub(crate) fn detect_radios_impl(
+    cables: Vec<UsbCable>,
+    prober: &dyn RadioProber,
+) -> Vec<DetectedRadio> {
+    let mut detected = Vec::new();
+
+    for cable in cables {
+        match prober.probe(&cable.serial_port) {
+            Ok(Some((variant, ident))) => {
+                detected.push(DetectedRadio {
+                    cable,
+                    variant,
+                    ident,
+                });
+            }
+            Ok(None) => {
+                tracing::debug!(port = %cable.serial_port, "no radio detected");
+            }
+            Err(e) => {
+                tracing::warn!(port = %cable.serial_port, error = %e, "failed to probe port");
+            }
+        }
+    }
+
+    detected
+}
+
+fn detect_radio_on_port_impl(
+    port_path: &str,
+    prober: &dyn RadioProber,
+) -> Result<Option<DetectedRadio>, DetectError> {
+    let cable = find_cable_for_port(port_path)?;
+    match prober.probe(port_path)? {
+        Some((variant, ident)) => Ok(Some(DetectedRadio {
+            cable,
+            variant,
+            ident,
+        })),
+        None => Ok(None),
+    }
+}
+
+fn find_cable_for_port(port_path: &str) -> Result<UsbCable, DetectError> {
+    let ports = serialport::available_ports().context(EnumerateForLookupSnafu)?;
+    for port in &ports {
+        if port.port_name == port_path {
+            if let serialport::SerialPortType::UsbPort(info) = &port.port_type {
+                return Ok(UsbCable {
+                    vid: info.vid,
+                    pid: info.pid,
+                    chip: classify_cable(info.vid, info.pid),
+                    serial_port: port_path.to_string(),
+                    manufacturer: info.manufacturer.clone(),
+                    product: info.product.clone(),
+                    serial_number: info.serial_number.clone(),
+                    is_clone: None,
+                });
+            }
+        }
+    }
+
+    Ok(UsbCable {
+        vid: 0,
+        pid: 0,
+        chip: CableChip::Unknown { vid: 0, pid: 0 },
+        serial_port: port_path.to_string(),
+        manufacturer: None,
+        product: None,
+        serial_number: None,
+        is_clone: None,
+    })
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items
+)]
+mod tests {
+    use super::*;
+
+    // ── Mock serial port ─────────────────────────────────────────────────
+
+    struct MockSerial {
+        read_data: std::io::Cursor<Vec<u8>>,
+        written: Vec<u8>,
+    }
+
+    impl MockSerial {
+        fn new(read_data: Vec<u8>) -> Self {
+            Self {
+                read_data: std::io::Cursor::new(read_data),
+                written: Vec::new(),
+            }
+        }
+    }
+
+    impl Read for MockSerial {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.read_data.read(buf)
+        }
+    }
+
+    impl Write for MockSerial {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // ── Mock prober ──────────────────────────────────────────────────────
+
+    struct MockProber {
+        responses: Vec<(String, Option<(VariantConfig, RadioIdent)>)>,
+    }
+
+    impl RadioProber for MockProber {
+        fn probe(
+            &self,
+            port_path: &str,
+        ) -> Result<Option<(VariantConfig, RadioIdent)>, DetectError> {
+            Ok(self
+                .responses
+                .iter()
+                .find(|(p, _)| p == port_path)
+                .and_then(|(_, r)| r.clone()))
+        }
+    }
+
+    fn test_variant(kind: RadioKind) -> VariantConfig {
+        VariantConfig {
+            kind,
+            baud_rate: 9600,
+            memory_size: 0x1808,
+        }
+    }
+
+    fn test_ident(firmware: &str) -> RadioIdent {
+        RadioIdent {
+            firmware: firmware.to_string(),
+            raw_response: firmware.as_bytes().to_vec(),
+        }
+    }
+
+    fn test_cable(port: &str) -> UsbCable {
+        UsbCable {
+            vid: 0x067B,
+            pid: 0x2303,
+            chip: CableChip::Pl2303,
+            serial_port: port.to_string(),
+            manufacturer: None,
+            product: None,
+            serial_number: None,
+            is_clone: None,
+        }
+    }
+
+    // ── Magic sequence tests ─────────────────────────────────────────────
+
+    #[test]
+    fn try_magic_returns_variant_on_valid_uv5r_response() {
+        let response = [&[ACK][..], b"BFB297\x00\x00"].concat();
+        let mut port = MockSerial::new(response);
+
+        let result = try_magic_sequence(&mut port, &MAGIC_SEQUENCES[0]);
+        assert!(result.is_some());
+
+        let (variant, ident) = result.unwrap();
+        assert_eq!(variant.kind, RadioKind::BaofengUv5r);
+        assert_eq!(ident.firmware, "BFB297");
+    }
+
+    #[test]
+    fn try_magic_returns_variant_for_f8hp() {
+        let response = [&[ACK][..], b"BFF800\x00\x00"].concat();
+        let mut port = MockSerial::new(response);
+
+        let result = try_magic_sequence(&mut port, &MAGIC_SEQUENCES[0]);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0.kind, RadioKind::BaofengBfF8hp);
+    }
+
+    #[test]
+    fn try_magic_returns_none_on_no_ack() {
+        let response = vec![0xFF]; // Not an ACK
+        let mut port = MockSerial::new(response);
+        assert!(try_magic_sequence(&mut port, &MAGIC_SEQUENCES[0]).is_none());
+    }
+
+    #[test]
+    fn try_magic_returns_none_on_empty_response() {
+        let mut port = MockSerial::new(vec![]);
+        assert!(try_magic_sequence(&mut port, &MAGIC_SEQUENCES[0]).is_none());
+    }
+
+    #[test]
+    fn try_magic_returns_none_for_unrecognized_ident() {
+        let response = [&[ACK][..], b"ZZZ999\x00\x00"].concat();
+        let mut port = MockSerial::new(response);
+        assert!(try_magic_sequence(&mut port, &MAGIC_SEQUENCES[0]).is_none());
+    }
+
+    #[test]
+    fn parse_uv5r_ident_recognizes_known_prefixes() {
+        assert!(parse_uv5r_ident(b"BFB297\x00\x00").is_some());
+        assert!(parse_uv5r_ident(b"BFF800\x00\x00").is_some());
+        assert!(parse_uv5r_ident(b"BFU100\x00\x00").is_some());
+        assert!(parse_uv5r_ident(b"ZZZ000\x00\x00").is_none());
+        assert!(parse_uv5r_ident(b"BF").is_none());
+        assert!(parse_uv5r_ident(b"").is_none());
+    }
+
+    // ── Detection integration tests (mocked) ────────────────────────────
+
+    #[test]
+    fn detect_with_mock_returns_responding_radio() {
+        let cables = vec![test_cable("/dev/ttyUSB0")];
+        let prober = MockProber {
+            responses: vec![(
+                "/dev/ttyUSB0".to_string(),
+                Some((test_variant(RadioKind::BaofengUv5r), test_ident("BFB297"))),
+            )],
+        };
+
+        let results = detect_radios_impl(cables, &prober);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].variant.kind, RadioKind::BaofengUv5r);
+        assert_eq!(results[0].cable.serial_port, "/dev/ttyUSB0");
+    }
+
+    #[test]
+    fn detect_skips_unresponsive_ports() {
+        let cables = vec![test_cable("/dev/ttyUSB0")];
+        let prober = MockProber {
+            responses: vec![("/dev/ttyUSB0".to_string(), None)],
+        };
+
+        let results = detect_radios_impl(cables, &prober);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn detect_multiple_ports_returns_only_responding() {
+        let cables = vec![
+            test_cable("/dev/ttyUSB0"),
+            UsbCable {
+                vid: 0x1A86,
+                pid: 0x7523,
+                chip: CableChip::Ch340,
+                serial_port: "/dev/ttyUSB1".to_string(),
+                manufacturer: None,
+                product: None,
+                serial_number: None,
+                is_clone: None,
+            },
+        ];
+        let prober = MockProber {
+            responses: vec![
+                ("/dev/ttyUSB0".to_string(), None),
+                (
+                    "/dev/ttyUSB1".to_string(),
+                    Some((test_variant(RadioKind::BaofengBfF8hp), test_ident("BFF800"))),
+                ),
+            ],
+        };
+
+        let results = detect_radios_impl(cables, &prober);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].cable.serial_port, "/dev/ttyUSB1");
+        assert_eq!(results[0].variant.kind, RadioKind::BaofengBfF8hp);
+    }
+
+    #[test]
+    fn no_cables_returns_empty_detection() {
+        let prober = MockProber { responses: vec![] };
+        let results = detect_radios_impl(vec![], &prober);
+        assert!(results.is_empty());
+    }
+}

--- a/crates/syntonia/src/hardware/mod.rs
+++ b/crates/syntonia/src/hardware/mod.rs
@@ -1,0 +1,14 @@
+//! Hardware detection, cable identification, and radio probing.
+
+pub mod cables;
+pub mod detect;
+pub mod usb;
+pub mod warnings;
+
+pub use cables::{CableChip, KNOWN_CABLES, KnownCable, classify_cable, lookup_cable};
+pub use detect::{
+    DetectError, DetectedRadio, RadioIdent, RadioProber, VariantConfig, detect_radio_on_port,
+    detect_radios,
+};
+pub use usb::{ScanError, UsbCable, scan_usb_cables};
+pub use warnings::HardwareWarning;

--- a/crates/syntonia/src/hardware/usb.rs
+++ b/crates/syntonia/src/hardware/usb.rs
@@ -1,0 +1,182 @@
+//! USB cable scanning and enumeration.
+
+use snafu::{ResultExt, Snafu};
+
+use crate::hardware::cables::{CableChip, classify_cable};
+
+/// A detected USB programming cable.
+#[derive(Debug, Clone)]
+pub struct UsbCable {
+    /// USB vendor ID.
+    pub vid: u16,
+    /// USB product ID.
+    pub pid: u16,
+    /// Identified chipset.
+    pub chip: CableChip,
+    /// Serial port path (e.g., "/dev/ttyUSB0").
+    pub serial_port: String,
+    /// USB manufacturer string, if available.
+    pub manufacturer: Option<String>,
+    /// USB product string, if available.
+    pub product: Option<String>,
+    /// USB serial number, if available.
+    pub serial_number: Option<String>,
+    /// Whether this is a PL2303 clone (`None` if not checked or not PL2303).
+    pub is_clone: Option<bool>,
+}
+
+/// Errors from USB cable scanning.
+#[derive(Debug, Snafu)]
+pub enum ScanError {
+    /// Failed to enumerate available serial ports.
+    #[snafu(display("failed to enumerate serial ports"))]
+    EnumeratePorts {
+        /// The underlying serialport error.
+        source: serialport::Error,
+        /// Source location.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// Scan for USB programming cables connected to the system.
+///
+/// Returns a list of detected cables with their VID:PID, chipset, and serial port path.
+/// PL2303 cables are checked for clone indicators via USB descriptors.
+///
+/// # Errors
+///
+/// Returns [`ScanError::EnumeratePorts`] if serial port enumeration fails.
+pub fn scan_usb_cables() -> Result<Vec<UsbCable>, ScanError> {
+    let ports = serialport::available_ports().context(EnumeratePortsSnafu)?;
+    let mut cables = cables_from_ports(&ports);
+    check_pl2303_clones(&mut cables);
+    Ok(cables)
+}
+
+/// Build cable list from serialport info (testable without hardware).
+pub(crate) fn cables_from_ports(ports: &[serialport::SerialPortInfo]) -> Vec<UsbCable> {
+    ports
+        .iter()
+        .filter_map(|port| {
+            if let serialport::SerialPortType::UsbPort(info) = &port.port_type {
+                Some(UsbCable {
+                    vid: info.vid,
+                    pid: info.pid,
+                    chip: classify_cable(info.vid, info.pid),
+                    serial_port: port.port_name.clone(),
+                    manufacturer: info.manufacturer.clone(),
+                    product: info.product.clone(),
+                    serial_number: info.serial_number.clone(),
+                    is_clone: None,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Check PL2303 cables for clone indicators via USB descriptors.
+fn check_pl2303_clones(cables: &mut [UsbCable]) {
+    let Ok(devices) = nusb::list_devices() else {
+        return;
+    };
+    let usb_devices: Vec<_> = devices.collect();
+
+    for cable in cables.iter_mut() {
+        if cable.chip == CableChip::Pl2303 {
+            cable.is_clone = Some(is_pl2303_clone(&usb_devices, cable.vid, cable.pid));
+        }
+    }
+}
+
+/// Detect PL2303 clones via `bcdDevice` version in USB descriptors.
+///
+/// Genuine PL2303 chips (TA, TB, RA series) report `bcdDevice` >= 0x0400.
+/// Clones (HX, HXA) typically report `bcdDevice` 0x0300.
+fn is_pl2303_clone(devices: &[nusb::DeviceInfo], vid: u16, pid: u16) -> bool {
+    // WHY: PL2303 clones work on Linux but fail on modern Windows drivers.
+    // Checking bcdDevice distinguishes genuine chips from counterfeits.
+    for dev in devices {
+        if dev.vendor_id() == vid && dev.product_id() == pid {
+            return dev.device_version() < 0x0400;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items
+)]
+mod tests {
+    use super::*;
+
+    fn make_usb_port(name: &str, vid: u16, pid: u16) -> serialport::SerialPortInfo {
+        serialport::SerialPortInfo {
+            port_name: name.to_string(),
+            port_type: serialport::SerialPortType::UsbPort(serialport::UsbPortInfo {
+                vid,
+                pid,
+                serial_number: None,
+                manufacturer: None,
+                product: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn cables_from_empty_port_list_returns_empty() {
+        assert!(cables_from_ports(&[]).is_empty());
+    }
+
+    #[test]
+    fn cables_from_usb_ports_identifies_chips() {
+        let ports = vec![
+            make_usb_port("/dev/ttyUSB0", 0x067B, 0x2303),
+            make_usb_port("/dev/ttyUSB1", 0x1A86, 0x7523),
+        ];
+        let cables = cables_from_ports(&ports);
+        assert_eq!(cables.len(), 2);
+        assert_eq!(cables[0].chip, CableChip::Pl2303);
+        assert_eq!(cables[0].serial_port, "/dev/ttyUSB0");
+        assert_eq!(cables[1].chip, CableChip::Ch340);
+        assert_eq!(cables[1].serial_port, "/dev/ttyUSB1");
+    }
+
+    #[test]
+    fn non_usb_ports_are_filtered_out() {
+        let ports = vec![
+            make_usb_port("/dev/ttyUSB0", 0x067B, 0x2303),
+            serialport::SerialPortInfo {
+                port_name: "/dev/ttyS0".to_string(),
+                port_type: serialport::SerialPortType::PciPort,
+            },
+            serialport::SerialPortInfo {
+                port_name: "/dev/rfcomm0".to_string(),
+                port_type: serialport::SerialPortType::BluetoothPort,
+            },
+        ];
+        let cables = cables_from_ports(&ports);
+        assert_eq!(cables.len(), 1);
+        assert_eq!(cables[0].serial_port, "/dev/ttyUSB0");
+    }
+
+    #[test]
+    fn unknown_usb_device_classified_as_unknown() {
+        let ports = vec![make_usb_port("/dev/ttyUSB0", 0xDEAD, 0xBEEF)];
+        let cables = cables_from_ports(&ports);
+        assert_eq!(cables.len(), 1);
+        assert_eq!(
+            cables[0].chip,
+            CableChip::Unknown {
+                vid: 0xDEAD,
+                pid: 0xBEEF
+            }
+        );
+    }
+}

--- a/crates/syntonia/src/hardware/warnings.rs
+++ b/crates/syntonia/src/hardware/warnings.rs
@@ -1,0 +1,242 @@
+//! Hardware warnings generated during cable scanning and radio detection.
+
+use std::fmt;
+
+use crate::hardware::cables::CableChip;
+use crate::hardware::detect::DetectedRadio;
+use crate::hardware::usb::UsbCable;
+
+/// Warnings produced during hardware detection.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HardwareWarning {
+    /// PL2303 clone detected — works on Linux but may fail on Windows.
+    Pl2303Clone {
+        /// Serial port path.
+        port: String,
+    },
+    /// Multiple radios detected — user should specify which one.
+    MultipleRadiosDetected {
+        /// Number of radios found.
+        count: usize,
+    },
+    /// Serial port access denied — likely a permissions issue.
+    PortAccessDenied {
+        /// Serial port path.
+        port: String,
+    },
+    /// Unknown USB serial device — might still work.
+    UnknownCable {
+        /// USB vendor ID.
+        vid: u16,
+        /// USB product ID.
+        pid: u16,
+        /// Serial port path.
+        port: String,
+    },
+}
+
+impl fmt::Display for HardwareWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pl2303Clone { port } => write!(
+                f,
+                "PL2303 clone detected on {port}. Works on Linux but may fail on Windows."
+            ),
+            Self::MultipleRadiosDetected { count } => write!(
+                f,
+                "Multiple radios detected ({count}). Use --port to specify which one."
+            ),
+            Self::PortAccessDenied { port } => write!(
+                f,
+                "Cannot access {port}. Add your user to the 'dialout' group: \
+                 `sudo usermod -aG dialout $USER`"
+            ),
+            Self::UnknownCable { vid, pid, port } => write!(
+                f,
+                "Unknown USB serial device {vid:04X}:{pid:04X} on {port}. \
+                 It might work \u{2014} try --port {port} to use it directly."
+            ),
+        }
+    }
+}
+
+/// Collect warnings from a cable scan result.
+#[must_use]
+pub fn collect_scan_warnings(cables: &[UsbCable]) -> Vec<HardwareWarning> {
+    let mut warnings = Vec::new();
+    for cable in cables {
+        if cable.is_clone == Some(true) {
+            warnings.push(HardwareWarning::Pl2303Clone {
+                port: cable.serial_port.clone(),
+            });
+        }
+        if let CableChip::Unknown { vid, pid } = cable.chip {
+            warnings.push(HardwareWarning::UnknownCable {
+                vid,
+                pid,
+                port: cable.serial_port.clone(),
+            });
+        }
+    }
+    warnings
+}
+
+/// Collect warnings from radio detection results.
+#[must_use]
+pub fn collect_detection_warnings(detected: &[DetectedRadio]) -> Vec<HardwareWarning> {
+    let mut warnings = Vec::new();
+    if detected.len() > 1 {
+        warnings.push(HardwareWarning::MultipleRadiosDetected {
+            count: detected.len(),
+        });
+    }
+    warnings
+}
+
+/// Create a port-access-denied warning.
+#[must_use]
+pub fn port_access_denied(port: &str) -> HardwareWarning {
+    HardwareWarning::PortAccessDenied {
+        port: port.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items
+)]
+mod tests {
+    use super::*;
+
+    fn make_cable(port: &str, chip: CableChip, is_clone: Option<bool>) -> UsbCable {
+        let (vid, pid) = match chip {
+            CableChip::Pl2303 => (0x067B, 0x2303),
+            CableChip::Ch340 => (0x1A86, 0x7523),
+            CableChip::Unknown { vid, pid } => (vid, pid),
+            CableChip::Cp2102 => (0x10C4, 0xEA60),
+            CableChip::Ftdi => (0x0403, 0x6001),
+        };
+        UsbCable {
+            vid,
+            pid,
+            chip,
+            serial_port: port.to_string(),
+            manufacturer: None,
+            product: None,
+            serial_number: None,
+            is_clone,
+        }
+    }
+
+    #[test]
+    fn pl2303_clone_generates_warning() {
+        let cables = vec![make_cable("/dev/ttyUSB0", CableChip::Pl2303, Some(true))];
+        let warnings = collect_scan_warnings(&cables);
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            &warnings[0],
+            HardwareWarning::Pl2303Clone { port } if port == "/dev/ttyUSB0"
+        ));
+    }
+
+    #[test]
+    fn genuine_pl2303_generates_no_warning() {
+        let cables = vec![make_cable("/dev/ttyUSB0", CableChip::Pl2303, Some(false))];
+        let warnings = collect_scan_warnings(&cables);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn unknown_cable_generates_warning() {
+        let cables = vec![make_cable(
+            "/dev/ttyUSB0",
+            CableChip::Unknown {
+                vid: 0xDEAD,
+                pid: 0xBEEF,
+            },
+            None,
+        )];
+        let warnings = collect_scan_warnings(&cables);
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            &warnings[0],
+            HardwareWarning::UnknownCable {
+                vid: 0xDEAD,
+                pid: 0xBEEF,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn port_access_denied_generates_actionable_message() {
+        let warning = port_access_denied("/dev/ttyUSB0");
+        let msg = warning.to_string();
+        assert!(msg.contains("/dev/ttyUSB0"));
+        assert!(msg.contains("dialout"));
+    }
+
+    #[test]
+    fn multiple_radios_generates_warning() {
+        use crate::hardware::detect::{RadioIdent, VariantConfig};
+        use koinon::RadioKind;
+
+        let detected = vec![
+            DetectedRadio {
+                cable: make_cable("/dev/ttyUSB0", CableChip::Pl2303, None),
+                variant: VariantConfig {
+                    kind: RadioKind::BaofengUv5r,
+                    baud_rate: 9600,
+                    memory_size: 0x1808,
+                },
+                ident: RadioIdent {
+                    firmware: "BFB297".to_string(),
+                    raw_response: vec![],
+                },
+            },
+            DetectedRadio {
+                cable: make_cable("/dev/ttyUSB1", CableChip::Ch340, None),
+                variant: VariantConfig {
+                    kind: RadioKind::BaofengBfF8hp,
+                    baud_rate: 9600,
+                    memory_size: 0x1808,
+                },
+                ident: RadioIdent {
+                    firmware: "BFF800".to_string(),
+                    raw_response: vec![],
+                },
+            },
+        ];
+        let warnings = collect_detection_warnings(&detected);
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            &warnings[0],
+            HardwareWarning::MultipleRadiosDetected { count: 2 }
+        ));
+    }
+
+    #[test]
+    fn single_radio_generates_no_detection_warning() {
+        use crate::hardware::detect::{RadioIdent, VariantConfig};
+        use koinon::RadioKind;
+
+        let detected = vec![DetectedRadio {
+            cable: make_cable("/dev/ttyUSB0", CableChip::Ch340, None),
+            variant: VariantConfig {
+                kind: RadioKind::BaofengUv5r,
+                baud_rate: 9600,
+                memory_size: 0x1808,
+            },
+            ident: RadioIdent {
+                firmware: "BFB297".to_string(),
+                raw_response: vec![],
+            },
+        }];
+        let warnings = collect_detection_warnings(&detected);
+        assert!(warnings.is_empty());
+    }
+}

--- a/crates/syntonia/src/lib.rs
+++ b/crates/syntonia/src/lib.rs
@@ -1,9 +1,12 @@
-//! Syntonia — radio-agnostic channel and frequency plan data model.
+//! Syntonia — radio-agnostic channel and frequency plan data model with hardware detection.
 //!
 //! This crate provides the core types for representing programmable radio
 //! channel memories, frequency plans, and radio-specific validation. It sits
 //! between raw EEPROM bytes and user-visible channel plans: every radio driver
 //! encodes/decodes channels through these types.
+//!
+//! The [`hardware`] module provides USB cable detection, radio auto-discovery,
+//! and actionable diagnostics for connection issues.
 //!
 //! # Key types
 //!
@@ -15,6 +18,7 @@
 pub mod baofeng;
 pub mod channel;
 pub mod error;
+pub mod hardware;
 pub mod plan;
 pub mod tone;
 pub mod types;


### PR DESCRIPTION
## Summary
- USB cable scanning with VID:PID matching (PL2303, CH340, CP2102, FTDI)
- PL2303 clone detection via nusb bcdDevice version check with user warning
- Serial port radio probing via magic byte auto-detect sequence (Baofeng UV-5R family)
- Actionable error messages (dialout group hint, cable troubleshooting)
- `detect_radios()` for automatic discovery, `detect_radio_on_port()` for explicit

## Test plan
- [x] `cargo build && cargo test --workspace` — 28 syntonia tests + 138 koinon tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] Known cable VID:PIDs identified correctly (8 cable tests)
- [x] Radio detection via mock serial port (10 detect tests)
- [x] Warning generation for clones, permissions, unknown cables (6 warning tests)
- [x] No `.unwrap()` or `.expect()` outside `#[cfg(test)]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)