### PR TITLE
feat(akroasis): radio CLI — read, program, export, import, detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,10 +16,16 @@ name = "akroasis"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "comfy-table",
+ "dialoguer",
  "figment",
+ "indicatif",
  "koinon",
  "serde",
+ "serde_json",
  "snafu",
+ "syntonia",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -27,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,15 +48,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -74,12 +80,6 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -122,12 +122,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -178,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -221,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -231,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -243,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -261,9 +255,20 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "compact_str"
@@ -281,26 +286,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -312,31 +314,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "csv"
-version = "1.4.0"
+name = "dialoguer"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
-name = "csv-core"
-version = "0.1.13"
+name = "document-features"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
- "memchr",
+ "litrs",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -387,12 +419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,21 +426,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -430,15 +443,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -450,21 +454,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -472,16 +481,6 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
-name = "io-kit-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
-dependencies = [
- "core-foundation-sys",
- "mach2",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -570,42 +569,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -621,15 +600,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "matchers"
@@ -658,17 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +644,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -751,12 +716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,9 +723,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -778,16 +737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -820,7 +769,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -839,9 +788,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -851,12 +800,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -884,7 +827,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -902,7 +845,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -928,7 +871,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -964,12 +907,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1024,26 +961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serialport"
-version = "4.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f60a586160667241d7702c420fc223939fb3c0bb8d3fac84f78768e8970dee"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "core-foundation",
- "core-foundation-sys",
- "io-kit-sys",
- "libudev",
- "mach2",
- "nix",
- "quote",
- "scopeguard",
- "unescaper",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +968,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1133,14 +1056,11 @@ name = "syntonia"
 version = "0.1.0"
 dependencies = [
  "compact_str",
- "csv",
  "koinon",
  "proptest",
  "serde",
  "serde_json",
- "serialport",
  "snafu",
- "tempfile",
  "toml",
  "tracing",
 ]
@@ -1152,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1160,18 +1080,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1221,7 +1141,6 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1302,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1345,25 +1264,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "unescaper"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
+name = "unicode-segmentation"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -1403,15 +1319,6 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1462,40 +1369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1379,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,9 +1408,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -1607,88 +1502,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "yansi"
@@ -1715,6 +1528,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/crates/akroasis/Cargo.toml
+++ b/crates/akroasis/Cargo.toml
@@ -13,13 +13,21 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
+comfy-table = "7"
+dialoguer = "0.11"
 figment = { workspace = true }
+indicatif = "0.17"
 koinon = { path = "../koinon" }
 serde = { workspace = true }
+serde_json = { workspace = true }
 snafu = { workspace = true }
+syntonia = { path = "../syntonia" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/akroasis/src/cli.rs
+++ b/crates/akroasis/src/cli.rs
@@ -1,0 +1,53 @@
+//! CLI definition — top-level subcommand tree.
+
+use clap::{Parser, Subcommand};
+
+use crate::radio::RadioCommand;
+
+#[allow(clippy::doc_markdown)]
+#[derive(Parser)]
+#[command(name = "akroasis", version, about = "ἀκρόασις — attentive reception")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Top-level subcommands.
+#[derive(Subcommand)]
+pub enum Command {
+    /// Radio management — frequency plans, programming, vehicle telemetry
+    Radio(RadioArgs),
+    /// Mesh networking — Meshtastic, topology, DTN, PACE communications
+    Mesh,
+    /// SDR reception — spectrum, demodulation, EW detection
+    Sdr,
+    /// Proximity — `WiFi`, BLE, Zigbee, NFC/RFID monitoring
+    Proximity,
+    /// Network defense — IDS/IPS, CAN bus, `IoT` security
+    Shield,
+    /// OSINT — feeds, recon, asset discovery, threat intel
+    Watch,
+    /// Offensive security — pentesting, vulnerability assessment
+    Test,
+    /// Signal intelligence — aggregation, correlation, focal points
+    Intel,
+    /// Automation — playbooks, PACE, state machines, triggers
+    Auto,
+    /// Navigation — vehicle/foot routing, military planning, maps
+    Nav,
+    /// Knowledge — offline references, frequency databases, manuals
+    Know,
+    /// Communications — encrypted messaging, key management
+    Comms,
+    /// Privacy — VPN, anonymization, OPSEC assessment
+    Privacy,
+    /// Serve the Akroasis daemon
+    Serve,
+}
+
+/// Radio subcommand arguments.
+#[derive(clap::Args)]
+pub struct RadioArgs {
+    #[command(subcommand)]
+    pub command: RadioCommand,
+}

--- a/crates/akroasis/src/main.rs
+++ b/crates/akroasis/src/main.rs
@@ -3,6 +3,9 @@
 //! RF intelligence, communications sovereignty, and operational awareness.
 //! 17 crates. 10 capability domains. One shared signal model.
 
+mod cli;
+mod radio;
+
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -12,6 +15,8 @@ use figment::{
 };
 use serde::Deserialize;
 use snafu::{ResultExt, Snafu};
+
+use cli::{Cli, Command};
 
 /// Top-level application errors.
 #[derive(Debug, Snafu)]
@@ -23,6 +28,10 @@ enum Error {
         #[snafu(source(from(figment::Error, Box::new)))]
         source: Box<figment::Error>,
     },
+
+    /// A radio operation failed.
+    #[snafu(display("{source}"))]
+    Radio { source: radio::errors::RadioError },
 }
 
 /// Application configuration loaded from TOML file and environment overrides.
@@ -47,64 +56,34 @@ fn load_config() -> Result<Config, Error> {
         .context(ConfigSnafu)
 }
 
-#[allow(clippy::doc_markdown)]
-#[derive(Parser)]
-#[command(name = "akroasis", version, about = "ἀκρόασις — attentive reception")]
-enum Cli {
-    /// Radio management — frequency plans, programming, vehicle telemetry
-    Radio,
-    /// Mesh networking — Meshtastic, topology, DTN, PACE communications
-    Mesh,
-    /// SDR reception — spectrum, demodulation, EW detection
-    Sdr,
-    /// Proximity — WiFi, BLE, Zigbee, NFC/RFID monitoring
-    Proximity,
-    /// Network defense — IDS/IPS, CAN bus, IoT security
-    Shield,
-    /// OSINT — feeds, recon, asset discovery, threat intel
-    Watch,
-    /// Offensive security — pentesting, vulnerability assessment
-    Test,
-    /// Signal intelligence — aggregation, correlation, focal points
-    Intel,
-    /// Automation — playbooks, PACE, state machines, triggers
-    Auto,
-    /// Navigation — vehicle/foot routing, military planning, maps
-    Nav,
-    /// Knowledge — offline references, frequency databases, manuals
-    Know,
-    /// Communications — encrypted messaging, key management
-    Comms,
-    /// Privacy — VPN, anonymization, OPSEC assessment
-    Privacy,
-    /// Serve the Akroasis daemon
-    Serve,
-}
-
-fn dispatch(cli: &Cli) {
-    match cli {
-        Cli::Radio => println!("syntonia — radio management (not yet implemented)"),
-        Cli::Mesh => println!("kerykeion — mesh networking (not yet implemented)"),
-        Cli::Sdr => println!("dektis — SDR reception (not yet implemented)"),
-        Cli::Proximity => println!("engys — proximity intelligence (not yet implemented)"),
-        Cli::Shield => println!("aspis — network defense (not yet implemented)"),
-        Cli::Watch => println!("skopos — OSINT collection (not yet implemented)"),
-        Cli::Test => println!("peira — offensive security (not yet implemented)"),
-        Cli::Intel => println!("semaino + ichneutes — intelligence (not yet implemented)"),
-        Cli::Auto => println!("praxis — automation (not yet implemented)"),
-        Cli::Nav => println!("chorografia — navigation (not yet implemented)"),
-        Cli::Know => println!("pinax — knowledge repository (not yet implemented)"),
-        Cli::Comms => println!("kryphos — communications (not yet implemented)"),
-        Cli::Privacy => println!("lethe — privacy (not yet implemented)"),
-        Cli::Serve => println!("daemon mode (not yet implemented)"),
+fn dispatch(command: &Command) -> Result<(), Error> {
+    match command {
+        Command::Radio(args) => {
+            radio::dispatch(&args.command).context(RadioSnafu)?;
+        }
+        Command::Mesh => println!("kerykeion — mesh networking (not yet implemented)"),
+        Command::Sdr => println!("dektis — SDR reception (not yet implemented)"),
+        Command::Proximity => println!("engys — proximity intelligence (not yet implemented)"),
+        Command::Shield => println!("aspis — network defense (not yet implemented)"),
+        Command::Watch => println!("skopos — OSINT collection (not yet implemented)"),
+        Command::Test => println!("peira — offensive security (not yet implemented)"),
+        Command::Intel => {
+            println!("semaino + ichneutes — intelligence (not yet implemented)");
+        }
+        Command::Auto => println!("praxis — automation (not yet implemented)"),
+        Command::Nav => println!("chorografia — navigation (not yet implemented)"),
+        Command::Know => println!("pinax — knowledge repository (not yet implemented)"),
+        Command::Comms => println!("kryphos — communications (not yet implemented)"),
+        Command::Privacy => println!("lethe — privacy (not yet implemented)"),
+        Command::Serve => println!("daemon mode (not yet implemented)"),
     }
+    Ok(())
 }
 
 fn run() -> Result<(), Error> {
     let _config = load_config()?;
     let cli = Cli::parse();
-    dispatch(&cli);
-    Ok(())
+    dispatch(&cli.command)
 }
 
 fn main() {

--- a/crates/akroasis/src/radio/detect.rs
+++ b/crates/akroasis/src/radio/detect.rs
@@ -1,0 +1,95 @@
+//! `akroasis radio detect` — discover connected radios.
+
+use super::errors::RadioError;
+use super::{DetectedRadio, Hardware};
+
+/// Runs the detect subcommand.
+pub fn run(hw: &dyn Hardware) -> Result<(), RadioError> {
+    let radios = hw.detect_radios()?;
+
+    if radios.is_empty() {
+        println!(
+            "No radios detected. Check that the radio is on \
+             and the programming cable is connected."
+        );
+        return Ok(());
+    }
+
+    print_detected(&radios);
+    Ok(())
+}
+
+/// Formats and prints detected radios.
+pub fn print_detected(radios: &[DetectedRadio]) {
+    println!("Detected radios:");
+    for (i, radio) in radios.iter().enumerate() {
+        let firmware_info = if radio.firmware.is_empty() {
+            String::new()
+        } else {
+            format!(" (firmware: {})", radio.firmware)
+        };
+        println!(
+            "  {}. {} on {}{}",
+            i + 1,
+            radio.variant.display_name(),
+            radio.port,
+            firmware_info,
+        );
+    }
+
+    let warnings: Vec<&str> = radios
+        .iter()
+        .flat_map(|r| r.warnings.iter().map(String::as_str))
+        .collect();
+    for warning in warnings {
+        println!("\n\u{26a0} {warning}");
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use crate::radio::RadioVariant;
+
+    #[test]
+    fn format_single_detected_radio() {
+        let radios = vec![DetectedRadio {
+            variant: RadioVariant::BfF8hp,
+            port: "/dev/ttyUSB0".to_string(),
+            firmware: "BFP3V3".to_string(),
+            warnings: vec![],
+        }];
+
+        // Capture by calling print — we just verify it doesn't panic.
+        // The format is validated by the integration test.
+        print_detected(&radios);
+    }
+
+    #[test]
+    fn format_multiple_radios_with_warnings() {
+        let radios = vec![
+            DetectedRadio {
+                variant: RadioVariant::BfF8hp,
+                port: "/dev/ttyUSB0".to_string(),
+                firmware: "BFP3V3".to_string(),
+                warnings: vec![
+                    "PL2303 clone detected on /dev/ttyUSB0 \u{2014} works on Linux, may fail on Windows.".to_string(),
+                ],
+            },
+            DetectedRadio {
+                variant: RadioVariant::Uv5r,
+                port: "/dev/ttyUSB1".to_string(),
+                firmware: "BFB297".to_string(),
+                warnings: vec![],
+            },
+        ];
+
+        print_detected(&radios);
+    }
+}

--- a/crates/akroasis/src/radio/errors.rs
+++ b/crates/akroasis/src/radio/errors.rs
@@ -1,0 +1,118 @@
+//! User-friendly error types for radio operations.
+
+use snafu::Snafu;
+
+/// Errors from radio CLI operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+#[non_exhaustive]
+pub enum RadioError {
+    #[snafu(display(
+        "No radio detected. Check that the radio is on and the programming cable is connected."
+    ))]
+    NoRadioDetected,
+
+    #[snafu(display("Multiple radios detected. Use --port to specify which one."))]
+    MultipleRadiosDetected,
+
+    #[snafu(display(
+        "Radio not responding. Try: power cycle the radio, reseat the cable, \
+         check the volume knob isn't muting the mic connector."
+    ))]
+    SerialTimeout { port: String },
+
+    #[snafu(display(
+        "Cannot access {port}. Run: sudo usermod -aG dialout $USER (then log out and back in)"
+    ))]
+    PermissionDenied { port: String },
+
+    #[snafu(display(
+        "Radio didn't respond at 9600 baud. This might be a UV-17Pro or similar \
+         radio requiring a different protocol."
+    ))]
+    WrongBaudRate { port: String },
+
+    #[snafu(display(
+        "SAFETY: Refused to write calibration data at address {addr:#06x}. \
+         This protects your radio from being bricked."
+    ))]
+    ForbiddenAddress { addr: u16 },
+
+    #[snafu(display(
+        "File size doesn't match any known radio. Expected 6152 or 7176 bytes, got {size}."
+    ))]
+    ImageSizeMismatch { size: usize },
+
+    #[snafu(display("failed to read {}: {source}", path.display()))]
+    ReadFile {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("failed to write {}: {source}", path.display()))]
+    WriteFile {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("unsupported file format '{ext}'. Supported: .toml, .json, .csv, .img"))]
+    UnsupportedFormat { ext: String },
+
+    #[snafu(display("plan validation failed: {message}"))]
+    ValidationFailed { message: String },
+
+    #[snafu(display("{message}"))]
+    Plan { message: String },
+
+    #[snafu(display("{source}"))]
+    Syntonia { source: syntonia::Error },
+
+    #[snafu(display("write aborted by user"))]
+    WriteAborted,
+
+    #[snafu(display("verification failed: {message}"))]
+    VerificationFailed { message: String },
+
+    #[snafu(display("CSV parse error at line {line}: {message}"))]
+    CsvParse { line: usize, message: String },
+
+    #[snafu(display("hardware support not yet available (syntonia protocol layer pending)"))]
+    HardwareNotAvailable,
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_radio_detected_message() {
+        let err = RadioError::NoRadioDetected;
+        let msg = err.to_string();
+        assert!(msg.contains("No radio detected"));
+        assert!(msg.contains("programming cable"));
+    }
+
+    #[test]
+    fn permission_denied_includes_port_and_fix() {
+        let err = RadioError::PermissionDenied {
+            port: "/dev/ttyUSB0".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("/dev/ttyUSB0"));
+        assert!(msg.contains("dialout"));
+    }
+
+    #[test]
+    fn forbidden_address_shows_hex() {
+        let err = RadioError::ForbiddenAddress { addr: 0x1EC0 };
+        let msg = err.to_string();
+        assert!(msg.contains("0x1ec0") || msg.contains("0x1EC0"));
+        assert!(msg.contains("SAFETY"));
+    }
+}

--- a/crates/akroasis/src/radio/export.rs
+++ b/crates/akroasis/src/radio/export.rs
@@ -1,0 +1,298 @@
+//! `akroasis radio export` — read radio and export channels to a file.
+
+use std::fmt::Write;
+use std::path::Path;
+
+use snafu::ResultExt;
+use syntonia::{Bandwidth, Channel, FrequencyPlan, PowerLevel, ScanMode, ToneMode};
+
+use super::errors::{RadioError, SyntoniaSnafu, WriteFileSnafu};
+use super::progress;
+use super::{ExportFormat, Hardware, resolve_target};
+
+/// Runs the export subcommand.
+pub fn run(
+    port: Option<&str>,
+    format: &ExportFormat,
+    output: Option<&Path>,
+    hw: &dyn Hardware,
+) -> Result<(), RadioError> {
+    let target = resolve_target(port, hw)?;
+    let mut session = hw.open(&target.port)?;
+
+    let pb = progress::download_bar(128);
+    let image = session.download_image(&|done, total| {
+        pb.set_length(u64::from(total));
+        pb.set_position(u64::from(done));
+    })?;
+    pb.finish_and_clear();
+
+    let channels = session.decode_channels(&image)?;
+
+    let plan = FrequencyPlan {
+        name: format!("{} export", target.variant.display_name()),
+        radio_model: Some(target.variant.display_name().to_string()),
+        channels,
+        created: None,
+    };
+
+    let content = serialize_plan(&plan, format)?;
+
+    match output {
+        Some(path) => {
+            std::fs::write(path, &content).context(WriteFileSnafu {
+                path: path.to_path_buf(),
+            })?;
+            println!(
+                "Exported {} channels to {}",
+                plan.channel_count(),
+                path.display()
+            );
+        }
+        None => print!("{content}"),
+    }
+
+    Ok(())
+}
+
+/// Serializes a plan to the requested format.
+pub fn serialize_plan(plan: &FrequencyPlan, format: &ExportFormat) -> Result<String, RadioError> {
+    match format {
+        ExportFormat::Toml => plan.to_toml().context(SyntoniaSnafu),
+        ExportFormat::Json => plan.to_json().context(SyntoniaSnafu),
+        ExportFormat::Csv => Ok(export_native_csv(plan)),
+        ExportFormat::ChirpCsv => Ok(export_chirp_csv(plan)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native CSV (simple format)
+// ---------------------------------------------------------------------------
+
+/// Exports a plan as a simple CSV with the most useful fields.
+pub fn export_native_csv(plan: &FrequencyPlan) -> String {
+    let mut out = String::from("Index,Name,RX Freq (MHz),TX Freq (MHz),Tone,Power\n");
+    for ch in &plan.channels {
+        let tx = ch.tx_freq.unwrap_or(ch.rx_freq);
+        let _ = writeln!(
+            out,
+            "{},{},{:.6},{:.6},{},{}",
+            ch.index,
+            csv_escape(&ch.name),
+            ch.rx_freq.as_mhz_f64(),
+            tx.as_mhz_f64(),
+            format_tone_csv(ch.tone),
+            format_power_csv(ch.power),
+        );
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// CHIRP-compatible CSV (20 columns)
+// ---------------------------------------------------------------------------
+
+const CHIRP_HEADER: &str = "Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,\
+    DtcsCode,DtcsPolarity,RxDtcsCode,Mode,TStep,Skip,Power,Comment,\
+    URCALL,RPT1CALL,RPT2CALL,DVCODE";
+
+/// Exports a plan as a CHIRP-compatible 20-column CSV.
+pub fn export_chirp_csv(plan: &FrequencyPlan) -> String {
+    let mut out = String::from(CHIRP_HEADER);
+    out.push('\n');
+
+    for ch in &plan.channels {
+        let (duplex, offset_mhz) = chirp_duplex_offset(ch);
+        let (tone_mode, r_tone, c_tone, dtcs_code, dtcs_polarity) = chirp_tone_fields(ch);
+        let mode = match ch.bandwidth {
+            Bandwidth::Narrow => "NFM",
+            _ => "FM",
+        };
+        let skip = match ch.scan {
+            ScanMode::Skip => "S",
+            _ => "",
+        };
+        let power = format_power_csv(ch.power);
+
+        let _ = writeln!(
+            out,
+            "{},{},{:.6},{},{:.6},{},{},{},{},{},{},{},5.00,{},{},,,,,",
+            ch.index,
+            csv_escape(&ch.name),
+            ch.rx_freq.as_mhz_f64(),
+            duplex,
+            offset_mhz,
+            tone_mode,
+            r_tone,
+            c_tone,
+            dtcs_code,
+            dtcs_polarity,
+            dtcs_code, // RxDtcsCode mirrors DtcsCode
+            mode,
+            skip,
+            power,
+        );
+    }
+    out
+}
+
+fn chirp_duplex_offset(ch: &Channel) -> (&'static str, f64) {
+    use syntonia::FrequencyOffset;
+    match ch.offset {
+        FrequencyOffset::Plus(f) => ("+", f.as_mhz_f64()),
+        FrequencyOffset::Minus(f) => ("-", f.as_mhz_f64()),
+        FrequencyOffset::Split(_) => ("split", {
+            let tx = ch.tx_freq.unwrap_or(ch.rx_freq);
+            tx.as_mhz_f64()
+        }),
+        _ => ("", 0.0),
+    }
+}
+
+fn chirp_tone_fields(ch: &Channel) -> (&'static str, String, String, String, &'static str) {
+    match ch.tone {
+        ToneMode::Ctcss(tone) => (
+            "Tone",
+            format!("{:.1}", tone.as_hz()),
+            format!("{:.1}", tone.as_hz()),
+            "023".to_string(),
+            "NN",
+        ),
+        ToneMode::Dcs(code, polarity) => {
+            use syntonia::DcsPolarity;
+            let pol = match polarity {
+                DcsPolarity::Inverted => "RR",
+                _ => "NN",
+            };
+            (
+                "DTCS",
+                "88.5".to_string(),
+                "88.5".to_string(),
+                format!("{:03}", code.code()),
+                pol,
+            )
+        }
+        _ => (
+            "",
+            "88.5".to_string(),
+            "88.5".to_string(),
+            "023".to_string(),
+            "NN",
+        ),
+    }
+}
+
+fn format_tone_csv(tone: ToneMode) -> String {
+    match tone {
+        ToneMode::Ctcss(t) => format!("{:.1} Hz", t.as_hz()),
+        ToneMode::Dcs(code, _) => format!("DCS {:03}", code.code()),
+        _ => String::new(),
+    }
+}
+
+const fn format_power_csv(power: PowerLevel) -> &'static str {
+    match power {
+        PowerLevel::Mid => "Mid",
+        PowerLevel::Low => "Low",
+        _ => "High",
+    }
+}
+
+/// Escapes a CSV field if it contains special characters.
+fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use koinon::Frequency;
+    use syntonia::tone::CtcssTone;
+    use syntonia::types::FrequencyOffset;
+
+    use super::*;
+
+    fn sample_plan() -> FrequencyPlan {
+        FrequencyPlan {
+            name: "Test".to_string(),
+            radio_model: Some("Baofeng UV-5R".to_string()),
+            channels: vec![
+                Channel {
+                    index: 0,
+                    name: "CALL".to_string(),
+                    rx_freq: Frequency::hz(146_520_000),
+                    tx_freq: None,
+                    offset: FrequencyOffset::None,
+                    tone: ToneMode::None,
+                    power: PowerLevel::High,
+                    bandwidth: Bandwidth::Wide,
+                    scan: ScanMode::Include,
+                    busy_lock: false,
+                },
+                Channel {
+                    index: 1,
+                    name: "RPT-IN".to_string(),
+                    rx_freq: Frequency::hz(147_060_000),
+                    tx_freq: Some(Frequency::hz(147_660_000)),
+                    offset: FrequencyOffset::Plus(Frequency::khz(600)),
+                    tone: ToneMode::Ctcss(CtcssTone::new(100.0).unwrap()),
+                    power: PowerLevel::High,
+                    bandwidth: Bandwidth::Wide,
+                    scan: ScanMode::Include,
+                    busy_lock: false,
+                },
+            ],
+            created: None,
+        }
+    }
+
+    #[test]
+    fn chirp_csv_has_20_columns() {
+        let plan = sample_plan();
+        let csv = export_chirp_csv(&plan);
+        let lines: Vec<&str> = csv.lines().collect();
+
+        // Header
+        assert_eq!(
+            lines[0].split(',').count(),
+            20,
+            "header should have 20 columns"
+        );
+
+        // Data rows
+        for (i, line) in lines.iter().skip(1).enumerate() {
+            assert_eq!(
+                line.split(',').count(),
+                20,
+                "row {i} should have 20 columns"
+            );
+        }
+    }
+
+    #[test]
+    fn native_csv_has_expected_header() {
+        let plan = sample_plan();
+        let csv = export_native_csv(&plan);
+        let header = csv.lines().next().unwrap();
+        assert_eq!(header, "Index,Name,RX Freq (MHz),TX Freq (MHz),Tone,Power");
+    }
+
+    #[test]
+    fn chirp_csv_tone_column_for_ctcss() {
+        let plan = sample_plan();
+        let csv = export_chirp_csv(&plan);
+        let rpt_line = csv.lines().nth(2).unwrap();
+        let cols: Vec<&str> = rpt_line.split(',').collect();
+        assert_eq!(cols[5], "Tone"); // Tone mode
+        assert_eq!(cols[6], "100.0"); // rToneFreq
+    }
+}

--- a/crates/akroasis/src/radio/import.rs
+++ b/crates/akroasis/src/radio/import.rs
@@ -1,0 +1,350 @@
+//! `akroasis radio import` — parse and display a frequency plan from a file.
+
+use std::path::Path;
+
+use koinon::Frequency;
+use snafu::ResultExt;
+use syntonia::{Bandwidth, Channel, FrequencyPlan, PowerLevel, ScanMode, ToneMode};
+
+use super::errors::{RadioError, ReadFileSnafu, SyntoniaSnafu};
+use super::read;
+
+/// Supported file formats for import.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileFormat {
+    Toml,
+    Json,
+    ChirpCsv,
+    BinaryImage,
+}
+
+/// Detects file format from the extension.
+pub fn detect_format(path: &Path) -> Result<FileFormat, RadioError> {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+    match ext {
+        "toml" => Ok(FileFormat::Toml),
+        "json" => Ok(FileFormat::Json),
+        "csv" => Ok(FileFormat::ChirpCsv),
+        "img" => Ok(FileFormat::BinaryImage),
+        other => Err(RadioError::UnsupportedFormat {
+            ext: other.to_string(),
+        }),
+    }
+}
+
+/// Runs the import subcommand.
+pub fn run(file: &Path) -> Result<(), RadioError> {
+    let format = detect_format(file)?;
+    let plan = import_plan(file, format)?;
+
+    read::print_channel_table_owned(&plan.channels);
+
+    let warning_count = plan
+        .channels
+        .iter()
+        .filter(|ch| ch.rx_freq.as_hz() == 0)
+        .count();
+    if warning_count > 0 {
+        println!("\u{26a0} {warning_count} empty channel slots skipped");
+    }
+
+    println!(
+        "Imported {} channels from {}",
+        plan.channel_count(),
+        file.display(),
+    );
+
+    Ok(())
+}
+
+/// Imports a plan from a file in the detected format.
+pub fn import_plan(path: &Path, format: FileFormat) -> Result<FrequencyPlan, RadioError> {
+    if format == FileFormat::BinaryImage {
+        return Err(RadioError::HardwareNotAvailable);
+    }
+
+    let content = std::fs::read_to_string(path).context(ReadFileSnafu {
+        path: path.to_path_buf(),
+    })?;
+    import_from_string(&content, format, path)
+}
+
+/// Imports a plan from a string in the given format.
+pub fn import_from_string(
+    content: &str,
+    format: FileFormat,
+    source_path: &Path,
+) -> Result<FrequencyPlan, RadioError> {
+    match format {
+        FileFormat::Toml => FrequencyPlan::from_toml(content).context(SyntoniaSnafu),
+        FileFormat::Json => FrequencyPlan::from_json(content).context(SyntoniaSnafu),
+        FileFormat::ChirpCsv => parse_chirp_csv(content),
+        FileFormat::BinaryImage => Err(RadioError::UnsupportedFormat {
+            ext: source_path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("img")
+                .to_string(),
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CHIRP CSV parser
+// ---------------------------------------------------------------------------
+
+/// Parses a CHIRP-compatible CSV into a `FrequencyPlan`.
+#[allow(clippy::indexing_slicing)] // Column access is safe: we verify cols.len() >= 15 above each use.
+pub fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError> {
+    let mut channels = Vec::new();
+    let mut lines = content.lines();
+
+    // Skip header
+    let _header = lines.next();
+
+    for (line_num, line) in lines.enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let cols: Vec<&str> = line.split(',').collect();
+        if cols.len() < 15 {
+            return Err(RadioError::CsvParse {
+                line: line_num + 2,
+                message: format!("expected at least 15 columns, got {}", cols.len()),
+            });
+        }
+
+        let index: u16 = cols[0].trim().parse().map_err(|_| RadioError::CsvParse {
+            line: line_num + 2,
+            message: format!("invalid location: '{}'", cols[0].trim()),
+        })?;
+
+        let name = cols[1].trim().trim_matches('"').to_string();
+
+        let rx_mhz: f64 = cols[2].trim().parse().map_err(|_| RadioError::CsvParse {
+            line: line_num + 2,
+            message: format!("invalid frequency: '{}'", cols[2].trim()),
+        })?;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rx_freq = Frequency::hz((rx_mhz * 1_000_000.0).round() as u64);
+
+        let duplex = cols[3].trim();
+        let offset_mhz: f64 = cols[4].trim().parse().unwrap_or(0.0);
+
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let offset_freq = Frequency::hz((offset_mhz * 1_000_000.0).round() as u64);
+
+        let (offset, tx_freq) = match duplex {
+            "+" => (
+                syntonia::FrequencyOffset::Plus(offset_freq),
+                Some(rx_freq + offset_freq),
+            ),
+            "-" => (
+                syntonia::FrequencyOffset::Minus(offset_freq),
+                Some(rx_freq - offset_freq),
+            ),
+            "split" => (
+                syntonia::FrequencyOffset::Split(offset_freq),
+                Some(offset_freq),
+            ),
+            _ => (syntonia::FrequencyOffset::None, None),
+        };
+
+        let tone = parse_chirp_tone(
+            cols[5].trim(),
+            cols[6].trim(),
+            cols[8].trim(),
+            cols[9].trim(),
+        );
+
+        let bandwidth = match cols.get(11).map(|s| s.trim()) {
+            Some("NFM") => Bandwidth::Narrow,
+            _ => Bandwidth::Wide,
+        };
+
+        let scan = match cols.get(13).map(|s| s.trim()) {
+            Some("S") => ScanMode::Skip,
+            _ => ScanMode::Include,
+        };
+
+        let power = match cols.get(14).map(|s| s.trim()) {
+            Some("Low") => PowerLevel::Low,
+            Some("Mid") => PowerLevel::Mid,
+            _ => PowerLevel::High,
+        };
+
+        channels.push(Channel {
+            index,
+            name,
+            rx_freq,
+            tx_freq,
+            offset,
+            tone,
+            power,
+            bandwidth,
+            scan,
+            busy_lock: false,
+        });
+    }
+
+    Ok(FrequencyPlan {
+        name: "CHIRP Import".to_string(),
+        radio_model: None,
+        channels,
+        created: None,
+    })
+}
+
+fn parse_chirp_tone(tone_mode: &str, r_tone: &str, dtcs_code: &str, dtcs_pol: &str) -> ToneMode {
+    match tone_mode {
+        "Tone" | "TSQL" => {
+            let freq: f32 = r_tone.parse().unwrap_or(88.5);
+            syntonia::CtcssTone::new(freq)
+                .map(ToneMode::Ctcss)
+                .unwrap_or(ToneMode::None)
+        }
+        "DTCS" => {
+            let code: u16 = dtcs_code.parse().unwrap_or(23);
+            let polarity = match dtcs_pol {
+                "RR" | "RN" => syntonia::DcsPolarity::Inverted,
+                _ => syntonia::DcsPolarity::Normal,
+            };
+            syntonia::DcsCode::new(code)
+                .map(|c| ToneMode::Dcs(c, polarity))
+                .unwrap_or(ToneMode::None)
+        }
+        _ => ToneMode::None,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_toml_format() {
+        assert_eq!(
+            detect_format(Path::new("plan.toml")).unwrap(),
+            FileFormat::Toml
+        );
+    }
+
+    #[test]
+    fn detect_json_format() {
+        assert_eq!(
+            detect_format(Path::new("plan.json")).unwrap(),
+            FileFormat::Json
+        );
+    }
+
+    #[test]
+    fn detect_csv_format() {
+        assert_eq!(
+            detect_format(Path::new("channels.csv")).unwrap(),
+            FileFormat::ChirpCsv
+        );
+    }
+
+    #[test]
+    fn detect_img_format() {
+        assert_eq!(
+            detect_format(Path::new("radio.img")).unwrap(),
+            FileFormat::BinaryImage
+        );
+    }
+
+    #[test]
+    fn detect_unknown_format_errors() {
+        let result = detect_format(Path::new("file.xyz"));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("xyz"));
+        assert!(msg.contains("Supported"));
+    }
+
+    #[test]
+    fn parse_chirp_csv_basic() {
+        let csv = "\
+Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPolarity,RxDtcsCode,Mode,TStep,Skip,Power,Comment,URCALL,RPT1CALL,RPT2CALL,DVCODE
+0,CALL,146.520000,,0.000000,,88.5,88.5,023,NN,023,FM,5.00,,High,,,,,
+1,RPT-IN,147.060000,+,0.600000,Tone,100.0,100.0,023,NN,023,FM,5.00,,High,,,,,\n";
+
+        let plan = parse_chirp_csv(csv).unwrap();
+        assert_eq!(plan.channels.len(), 2);
+
+        let ch0 = &plan.channels[0];
+        assert_eq!(ch0.index, 0);
+        assert_eq!(ch0.name, "CALL");
+        assert_eq!(ch0.rx_freq.as_hz(), 146_520_000);
+        assert!(ch0.tx_freq.is_none());
+        assert!(matches!(ch0.tone, ToneMode::None));
+
+        let ch1 = &plan.channels[1];
+        assert_eq!(ch1.index, 1);
+        assert_eq!(ch1.name, "RPT-IN");
+        assert!(ch1.tx_freq.is_some());
+        assert!(matches!(ch1.tone, ToneMode::Ctcss(_)));
+    }
+
+    #[test]
+    fn chirp_csv_roundtrip() {
+        use crate::radio::export::export_chirp_csv;
+
+        let plan = FrequencyPlan {
+            name: "Roundtrip".to_string(),
+            radio_model: None,
+            channels: vec![Channel {
+                index: 0,
+                name: "TEST".to_string(),
+                rx_freq: Frequency::hz(146_520_000),
+                tx_freq: None,
+                offset: syntonia::FrequencyOffset::None,
+                tone: ToneMode::None,
+                power: PowerLevel::High,
+                bandwidth: Bandwidth::Wide,
+                scan: ScanMode::Include,
+                busy_lock: false,
+            }],
+            created: None,
+        };
+
+        let csv = export_chirp_csv(&plan);
+        let imported = parse_chirp_csv(&csv).unwrap();
+
+        assert_eq!(imported.channels.len(), 1);
+        assert_eq!(imported.channels[0].index, 0);
+        assert_eq!(imported.channels[0].name, "TEST");
+        assert_eq!(imported.channels[0].rx_freq, plan.channels[0].rx_freq);
+    }
+
+    #[test]
+    fn import_from_toml_string() {
+        let toml = r#"
+name = "Test Plan"
+radio_model = "Baofeng UV-5R"
+
+[[channels]]
+index = 0
+name = "CALL"
+rx_freq = 146520000
+offset = "None"
+tone = "None"
+power = "High"
+bandwidth = "Wide"
+scan = "Include"
+busy_lock = false
+"#;
+
+        let plan = import_from_string(toml, FileFormat::Toml, Path::new("test.toml")).unwrap();
+        assert_eq!(plan.channels.len(), 1);
+        assert_eq!(plan.channels[0].name, "CALL");
+    }
+}

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -1,0 +1,314 @@
+//! Radio management CLI — detect, read, program, export, import.
+
+pub mod detect;
+pub mod errors;
+pub mod export;
+pub mod import;
+pub mod program;
+pub mod progress;
+pub mod read;
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use syntonia::{Channel, RadioConstraints};
+
+use self::errors::RadioError;
+
+/// Radio subcommands.
+#[derive(Subcommand)]
+pub enum RadioCommand {
+    /// Detect connected radios
+    Detect,
+
+    /// Read channels from radio
+    Read {
+        /// Serial port (e.g. /dev/ttyUSB0). Auto-detects if omitted.
+        #[arg(long)]
+        port: Option<String>,
+    },
+
+    /// Program radio with frequency plan
+    Program {
+        /// Serial port. Auto-detects if omitted.
+        #[arg(long)]
+        port: Option<String>,
+
+        /// Frequency plan file (.toml or .json)
+        #[arg(long)]
+        plan: PathBuf,
+    },
+
+    /// Export channels from radio to file
+    Export {
+        /// Serial port. Auto-detects if omitted.
+        #[arg(long)]
+        port: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum)]
+        format: ExportFormat,
+
+        /// Output file (stdout if omitted)
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+    },
+
+    /// Import and display a frequency plan from file
+    Import {
+        /// Input file (.toml, .json, .csv, or .img)
+        file: PathBuf,
+    },
+}
+
+/// Supported export formats.
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum ExportFormat {
+    Toml,
+    Json,
+    Csv,
+    ChirpCsv,
+}
+
+// ---------------------------------------------------------------------------
+// Radio variant model
+// ---------------------------------------------------------------------------
+
+/// Known radio variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum RadioVariant {
+    Uv5r,
+    BfF8hp,
+    Uv5rmPlus,
+}
+
+impl RadioVariant {
+    /// Human-readable display name.
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Uv5r => "Baofeng UV-5R",
+            Self::BfF8hp => "Baofeng BF-F8HP",
+            Self::Uv5rmPlus => "Baofeng UV-5RM Plus",
+        }
+    }
+
+    /// Returns radio-specific validation constraints.
+    pub fn constraints(self) -> RadioConstraints {
+        match self {
+            Self::Uv5r | Self::Uv5rmPlus => syntonia::baofeng_uv5r_constraints(),
+            Self::BfF8hp => syntonia::baofeng_f8hp_constraints(),
+        }
+    }
+
+    /// Maximum number of channels for this variant.
+    pub fn max_channels(self) -> u16 {
+        self.constraints().max_channels
+    }
+}
+
+impl std::fmt::Display for RadioVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.display_name())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detected radio descriptor
+// ---------------------------------------------------------------------------
+
+/// A radio discovered during hardware detection.
+#[derive(Debug, Clone)]
+pub struct DetectedRadio {
+    pub variant: RadioVariant,
+    pub port: String,
+    pub firmware: String,
+    pub warnings: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Hardware abstraction (trait-based for testability)
+// ---------------------------------------------------------------------------
+
+/// Abstraction over radio hardware detection and connection.
+pub trait Hardware {
+    fn detect_radios(&self) -> Result<Vec<DetectedRadio>, RadioError>;
+    fn open(&self, port: &str) -> Result<Box<dyn Session>, RadioError>;
+}
+
+/// An open connection to a radio.
+pub trait Session {
+    fn variant(&self) -> RadioVariant;
+    fn download_image(&mut self, on_block: &dyn Fn(u16, u16)) -> Result<Vec<u8>, RadioError>;
+    fn upload_image(&mut self, data: &[u8], on_block: &dyn Fn(u16, u16)) -> Result<(), RadioError>;
+    fn decode_channels(&self, image: &[u8]) -> Result<Vec<Channel>, RadioError>;
+    fn encode_channels(&self, channels: &[Channel]) -> Result<Vec<u8>, RadioError>;
+}
+
+// ---------------------------------------------------------------------------
+// Stub hardware (returns errors until P1-02..P1-06 are implemented)
+// ---------------------------------------------------------------------------
+
+pub struct StubHardware;
+
+impl Hardware for StubHardware {
+    fn detect_radios(&self) -> Result<Vec<DetectedRadio>, RadioError> {
+        Err(RadioError::HardwareNotAvailable)
+    }
+
+    fn open(&self, _port: &str) -> Result<Box<dyn Session>, RadioError> {
+        Err(RadioError::HardwareNotAvailable)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Port resolution helper
+// ---------------------------------------------------------------------------
+
+/// Resolves the target radio from an explicit port or auto-detection.
+pub fn resolve_target(port: Option<&str>, hw: &dyn Hardware) -> Result<DetectedRadio, RadioError> {
+    if let Some(port) = port {
+        let mut radios = hw.detect_radios()?;
+        radios.iter().position(|r| r.port == port).map_or_else(
+            || {
+                // WHY: Port was given explicitly but detection didn't find it.
+                // Fall back to opening directly — the user knows what they're doing.
+                Ok(DetectedRadio {
+                    variant: RadioVariant::Uv5r,
+                    port: port.to_string(),
+                    firmware: String::new(),
+                    warnings: Vec::new(),
+                })
+            },
+            |idx| Ok(radios.swap_remove(idx)),
+        )
+    } else {
+        let radios = hw.detect_radios()?;
+        match radios.len() {
+            0 => Err(RadioError::NoRadioDetected),
+            1 => Ok(radios.into_iter().next().unwrap_or_else(|| {
+                // SAFETY: We just verified len() == 1
+                unreachable!()
+            })),
+            _ => Err(RadioError::MultipleRadiosDetected),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/// Dispatches a radio subcommand.
+pub fn dispatch(cmd: &RadioCommand) -> Result<(), RadioError> {
+    dispatch_with(cmd, &StubHardware)
+}
+
+/// Dispatches with a specific hardware backend (for testing).
+pub fn dispatch_with(cmd: &RadioCommand, hw: &dyn Hardware) -> Result<(), RadioError> {
+    match cmd {
+        RadioCommand::Detect => detect::run(hw),
+        RadioCommand::Read { port } => read::run(port.as_deref(), hw),
+        RadioCommand::Program { port, plan } => program::run(port.as_deref(), plan, hw),
+        RadioCommand::Export {
+            port,
+            format,
+            output,
+        } => export::run(port.as_deref(), format, output.as_deref(), hw),
+        RadioCommand::Import { file } => import::run(file),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    // Wrapper to test subcommand parsing via clap.
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: RadioCommand,
+    }
+
+    fn parse(args: &[&str]) -> RadioCommand {
+        TestCli::parse_from(std::iter::once("test").chain(args.iter().copied())).command
+    }
+
+    #[test]
+    fn parse_detect() {
+        let cmd = parse(&["detect"]);
+        assert!(matches!(cmd, RadioCommand::Detect));
+    }
+
+    #[test]
+    fn parse_read_with_port() {
+        let cmd = parse(&["read", "--port", "/dev/ttyUSB0"]);
+        match cmd {
+            RadioCommand::Read { port } => {
+                assert_eq!(port.as_deref(), Some("/dev/ttyUSB0"));
+            }
+            _ => panic!("expected Read"),
+        }
+    }
+
+    #[test]
+    fn parse_program_with_both_args() {
+        let cmd = parse(&[
+            "program",
+            "--port",
+            "/dev/ttyUSB0",
+            "--plan",
+            "channels.toml",
+        ]);
+        match cmd {
+            RadioCommand::Program { port, plan } => {
+                assert_eq!(port.as_deref(), Some("/dev/ttyUSB0"));
+                assert_eq!(plan, PathBuf::from("channels.toml"));
+            }
+            _ => panic!("expected Program"),
+        }
+    }
+
+    #[test]
+    fn parse_export_format_and_output() {
+        let cmd = parse(&["export", "--format", "json", "--output", "out.json"]);
+        match cmd {
+            RadioCommand::Export {
+                port,
+                format,
+                output,
+            } => {
+                assert!(port.is_none());
+                assert!(matches!(format, ExportFormat::Json));
+                assert_eq!(output, Some(PathBuf::from("out.json")));
+            }
+            _ => panic!("expected Export"),
+        }
+    }
+
+    #[test]
+    fn parse_import_file() {
+        let cmd = parse(&["import", "channels.csv"]);
+        match cmd {
+            RadioCommand::Import { file } => {
+                assert_eq!(file, PathBuf::from("channels.csv"));
+            }
+            _ => panic!("expected Import"),
+        }
+    }
+
+    #[test]
+    fn parse_missing_required_args_fails() {
+        // `program` requires --plan
+        let result = TestCli::try_parse_from(["test", "program"]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/akroasis/src/radio/program.rs
+++ b/crates/akroasis/src/radio/program.rs
@@ -1,0 +1,199 @@
+//! `akroasis radio program` — write a frequency plan to a radio.
+
+use std::path::Path;
+
+use dialoguer::Confirm;
+use snafu::ResultExt;
+use syntonia::{FrequencyPlan, ValidationIssue, validate_plan};
+
+use super::errors::{RadioError, ReadFileSnafu, SyntoniaSnafu};
+use super::progress;
+use super::{Hardware, resolve_target};
+
+/// Runs the program subcommand.
+pub fn run(port: Option<&str>, plan_path: &Path, hw: &dyn Hardware) -> Result<(), RadioError> {
+    let plan = load_plan(plan_path)?;
+
+    let target = resolve_target(port, hw)?;
+    let variant = target.variant;
+    let constraints = variant.constraints();
+
+    let issues = validate_plan(&plan, &constraints);
+    let errors: Vec<&ValidationIssue> = issues
+        .iter()
+        .filter(|i| matches!(i, ValidationIssue::Error(_)))
+        .collect();
+    let warnings: Vec<&ValidationIssue> = issues
+        .iter()
+        .filter(|i| matches!(i, ValidationIssue::Warning(_)))
+        .collect();
+
+    if !errors.is_empty() {
+        for e in &errors {
+            eprintln!("error: {e:?}");
+        }
+        return Err(RadioError::ValidationFailed {
+            message: format!("{} validation errors", errors.len()),
+        });
+    }
+
+    for w in &warnings {
+        eprintln!("warning: {w:?}");
+    }
+
+    println!(
+        "About to program {} on {}. {} channels.",
+        variant.display_name(),
+        target.port,
+        plan.channel_count(),
+    );
+
+    let confirmed = Confirm::new()
+        .with_prompt("Continue?")
+        .default(false)
+        .interact()
+        .map_err(|e| RadioError::Plan {
+            message: format!("prompt failed: {e}"),
+        })?;
+
+    if !confirmed {
+        return Err(RadioError::WriteAborted);
+    }
+
+    let mut session = hw.open(&target.port)?;
+    let image = session.encode_channels(&plan.channels)?;
+
+    // Upload
+    let pb = progress::upload_bar(128);
+    session.upload_image(&image, &|done, total| {
+        pb.set_length(u64::from(total));
+        pb.set_position(u64::from(done));
+    })?;
+    pb.finish_and_clear();
+
+    // Verify: re-download and compare
+    println!("Verifying...");
+    let pb = progress::download_bar(128);
+    let readback = session.download_image(&|done, total| {
+        pb.set_length(u64::from(total));
+        pb.set_position(u64::from(done));
+    })?;
+    pb.finish_and_clear();
+
+    if readback != image {
+        return Err(RadioError::VerificationFailed {
+            message: "readback does not match uploaded image".to_string(),
+        });
+    }
+
+    println!(
+        "Programming complete. {} channels written.",
+        plan.channel_count()
+    );
+
+    Ok(())
+}
+
+/// Loads a frequency plan from a file, detecting format by extension.
+pub fn load_plan(path: &Path) -> Result<FrequencyPlan, RadioError> {
+    let content = std::fs::read_to_string(path).context(ReadFileSnafu {
+        path: path.to_path_buf(),
+    })?;
+
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+    match ext {
+        "toml" => FrequencyPlan::from_toml(&content).context(SyntoniaSnafu),
+        "json" => FrequencyPlan::from_json(&content).context(SyntoniaSnafu),
+        other => Err(RadioError::UnsupportedFormat {
+            ext: other.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use koinon::Frequency;
+    use syntonia::{Bandwidth, Channel, PowerLevel, ScanMode, ToneMode, types::FrequencyOffset};
+
+    use super::*;
+
+    #[test]
+    fn load_plan_from_toml_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.toml");
+
+        let plan = FrequencyPlan {
+            name: "Test".to_string(),
+            radio_model: Some("Baofeng UV-5R".to_string()),
+            channels: vec![Channel {
+                index: 0,
+                name: "CALL".to_string(),
+                rx_freq: Frequency::hz(146_520_000),
+                tx_freq: None,
+                offset: FrequencyOffset::None,
+                tone: ToneMode::None,
+                power: PowerLevel::High,
+                bandwidth: Bandwidth::Wide,
+                scan: ScanMode::Include,
+                busy_lock: false,
+            }],
+            created: None,
+        };
+
+        let toml = plan.to_toml().unwrap();
+        std::fs::write(&path, &toml).unwrap();
+
+        let loaded = load_plan(&path).unwrap();
+        assert_eq!(loaded.channel_count(), 1);
+        assert_eq!(loaded.channels[0].name, "CALL");
+    }
+
+    #[test]
+    fn load_plan_unsupported_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.xml");
+        std::fs::write(&path, "<plan/>").unwrap();
+
+        let result = load_plan(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("xml"));
+    }
+
+    #[test]
+    fn validation_catches_out_of_band_frequency() {
+        let plan = FrequencyPlan {
+            name: "Bad".to_string(),
+            radio_model: None,
+            channels: vec![Channel {
+                index: 0,
+                name: "OOB".to_string(),
+                rx_freq: Frequency::mhz(100), // out of band for UV-5R
+                tx_freq: None,
+                offset: FrequencyOffset::None,
+                tone: ToneMode::None,
+                power: PowerLevel::High,
+                bandwidth: Bandwidth::Wide,
+                scan: ScanMode::Include,
+                busy_lock: false,
+            }],
+            created: None,
+        };
+
+        let constraints = crate::radio::RadioVariant::Uv5r.constraints();
+        let issues = validate_plan(&plan, &constraints);
+        assert!(
+            issues
+                .iter()
+                .any(|i| matches!(i, ValidationIssue::Error(_))),
+            "should have validation errors for out-of-band frequency"
+        );
+    }
+}

--- a/crates/akroasis/src/radio/progress.rs
+++ b/crates/akroasis/src/radio/progress.rs
@@ -1,0 +1,27 @@
+//! Progress bar wrappers for EEPROM transfer operations.
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Creates a progress bar for EEPROM download (radio → host).
+pub fn download_bar(total_blocks: u64) -> ProgressBar {
+    let pb = ProgressBar::new(total_blocks);
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} Reading EEPROM [{bar:40.cyan/blue}] {pos}/{len} blocks",
+    )
+    .unwrap_or_else(|_| ProgressStyle::default_bar());
+    pb.set_style(style);
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    pb
+}
+
+/// Creates a progress bar for EEPROM upload (host → radio).
+pub fn upload_bar(total_blocks: u64) -> ProgressBar {
+    let pb = ProgressBar::new(total_blocks);
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} Writing EEPROM [{bar:40.cyan/blue}] {pos}/{len} blocks",
+    )
+    .unwrap_or_else(|_| ProgressStyle::default_bar());
+    pb.set_style(style);
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    pb
+}

--- a/crates/akroasis/src/radio/read.rs
+++ b/crates/akroasis/src/radio/read.rs
@@ -1,0 +1,164 @@
+//! `akroasis radio read` — download channels from a radio and display them.
+
+use comfy_table::{Cell, ContentArrangement, Table};
+use syntonia::{Bandwidth, Channel, PowerLevel, ScanMode, ToneMode};
+
+use super::errors::RadioError;
+use super::progress;
+use super::{Hardware, resolve_target};
+
+/// Runs the read subcommand.
+pub fn run(port: Option<&str>, hw: &dyn Hardware) -> Result<(), RadioError> {
+    let target = resolve_target(port, hw)?;
+    let mut session = hw.open(&target.port)?;
+
+    let total_blocks: u16 = 128;
+    let pb = progress::download_bar(u64::from(total_blocks));
+    let image = session.download_image(&|done, total| {
+        pb.set_length(u64::from(total));
+        pb.set_position(u64::from(done));
+    })?;
+    pb.finish_and_clear();
+
+    let channels = session.decode_channels(&image)?;
+    let programmed: Vec<&Channel> = channels
+        .iter()
+        .filter(|ch| ch.rx_freq.as_hz() > 0)
+        .collect();
+
+    print_channel_table(&programmed);
+    println!(
+        "{} channels programmed (of {} slots)",
+        programmed.len(),
+        session.variant().max_channels(),
+    );
+
+    Ok(())
+}
+
+/// Formats a channel table for display.
+pub fn print_channel_table(channels: &[&Channel]) {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![
+        "Ch", "Name", "RX Freq", "TX Freq", "Tone", "Pwr", "BW", "Scan",
+    ]);
+
+    for ch in channels {
+        let tx_display = ch
+            .tx_freq
+            .map_or_else(|| format!("{}", ch.rx_freq), |tx| format!("{tx}"));
+
+        table.add_row(vec![
+            Cell::new(format!("{:03}", ch.index + 1)),
+            Cell::new(&ch.name),
+            Cell::new(format!("{}", ch.rx_freq)),
+            Cell::new(tx_display),
+            Cell::new(format_tone(ch.tone)),
+            Cell::new(format_power(ch.power)),
+            Cell::new(format_bandwidth(ch.bandwidth)),
+            Cell::new(format_scan(ch.scan)),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+/// Formats a channel table from owned channel references (for import display).
+pub fn print_channel_table_owned(channels: &[Channel]) {
+    let refs: Vec<&Channel> = channels.iter().collect();
+    print_channel_table(&refs);
+}
+
+fn format_tone(tone: ToneMode) -> String {
+    match tone {
+        ToneMode::None => "\u{2014}".to_string(),
+        ToneMode::Ctcss(t) => format!("{:.1} Hz", t.as_hz()),
+        ToneMode::Dcs(code, _polarity) => format!("DCS {:03}", code.code()),
+        _ => "?".to_string(),
+    }
+}
+
+const fn format_power(power: PowerLevel) -> &'static str {
+    match power {
+        PowerLevel::High => "High",
+        PowerLevel::Mid => "Mid",
+        PowerLevel::Low => "Low",
+        _ => "?",
+    }
+}
+
+const fn format_bandwidth(bw: Bandwidth) -> &'static str {
+    match bw {
+        Bandwidth::Wide => "Wide",
+        Bandwidth::Narrow => "Narrow",
+        _ => "?",
+    }
+}
+
+const fn format_scan(scan: ScanMode) -> &'static str {
+    match scan {
+        ScanMode::Include => "\u{2713}",
+        ScanMode::Skip => "\u{2014}",
+        _ => "?",
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use koinon::Frequency;
+    use syntonia::tone::CtcssTone;
+    use syntonia::types::FrequencyOffset;
+
+    use super::*;
+
+    fn sample_channels() -> Vec<Channel> {
+        vec![
+            Channel {
+                index: 0,
+                name: "CALL".to_string(),
+                rx_freq: Frequency::hz(146_520_000),
+                tx_freq: None,
+                offset: FrequencyOffset::None,
+                tone: ToneMode::None,
+                power: PowerLevel::High,
+                bandwidth: Bandwidth::Wide,
+                scan: ScanMode::Include,
+                busy_lock: false,
+            },
+            Channel {
+                index: 1,
+                name: "RPT-IN".to_string(),
+                rx_freq: Frequency::hz(147_060_000),
+                tx_freq: Some(Frequency::hz(147_660_000)),
+                offset: FrequencyOffset::Plus(Frequency::khz(600)),
+                tone: ToneMode::Ctcss(CtcssTone::new(100.0).unwrap()),
+                power: PowerLevel::High,
+                bandwidth: Bandwidth::Wide,
+                scan: ScanMode::Include,
+                busy_lock: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn channel_table_displays_without_panic() {
+        let channels = sample_channels();
+        let refs: Vec<&Channel> = channels.iter().collect();
+        print_channel_table(&refs);
+    }
+
+    #[test]
+    fn tone_formatting() {
+        assert_eq!(format_tone(ToneMode::None), "\u{2014}");
+
+        let ctcss = ToneMode::Ctcss(CtcssTone::new(100.0).unwrap());
+        assert_eq!(format_tone(ctcss), "100.0 Hz");
+    }
+}


### PR DESCRIPTION
## Summary

Wire the full syntonia stack into user-facing `akroasis radio` subcommands, completing the CLI integration layer for P1-07.

### Changes

- **`cli.rs`** (new) — `Cli` struct + `Command` enum + `RadioArgs` wrapper for nested clap subcommands
- **`radio/mod.rs`** (new) — `RadioCommand` enum, `ExportFormat`, `RadioVariant` model, `DetectedRadio`, `Hardware`/`Session` traits, `StubHardware`, `resolve_target()` helper, `dispatch()`/`dispatch_with()`
- **`radio/errors.rs`** (new) — 15-variant `RadioError` enum with user-friendly messages and actionable fix suggestions (snafu)
- **`radio/detect.rs`** (new) — detect subcommand, prints discovered radios with variant/port/firmware/warnings
- **`radio/read.rs`** (new) — read subcommand, downloads EEPROM image with progress bar, decodes channels, prints comfy-table
- **`radio/program.rs`** (new) — program subcommand, loads TOML/JSON plan, validates against radio constraints, confirms with user, uploads + verifies
- **`radio/export.rs`** (new) — export to TOML/JSON/CSV/CHIRP-CSV with proper tone/duplex mapping (20-column CHIRP format)
- **`radio/import.rs`** (new) — import from TOML/JSON/CHIRP-CSV/binary image with format auto-detection
- **`radio/progress.rs`** (new) — indicatif progress bar helpers for download/upload
- **`main.rs`** — refactored to use `cli::Cli` + `radio::dispatch()`, added `RadioError` integration

### Design decisions

- **Trait-based hardware abstraction**: `Hardware` + `Session` traits allow full testing without serial hardware. `StubHardware` returns `HardwareNotAvailable` until P1-02..P1-06 protocol layers land.
- **CHIRP interop**: 20-column CSV export/import matches CHIRP's format exactly, enabling round-trip with existing radio programming tools.
- **Safety-first programming**: dialoguer confirmation before writing, post-upload verification by re-reading image, forbidden calibration address protection.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (207 tests, 27 in akroasis)
- [x] 6 CLI parsing tests (all subcommands + missing required args)
- [x] 3 error message tests (no radio, permission denied, forbidden address)
- [x] 2 detect tests (no radios, multiple radios)
- [x] 2 read tests (channel table display, tone formatting)
- [x] 3 export tests (CHIRP 20-column, native CSV header, CTCSS tone column)
- [x] 8 import tests (5 format detection, CSV parsing, roundtrip, TOML import)
- [x] 3 program tests (plan loading, unsupported format, validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)