### PR TITLE
feat(kryphos): installation identity — Ed25519 keypair and tamper log signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +157,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -187,6 +212,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +260,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -299,6 +359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +409,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,12 +491,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -393,6 +563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +593,27 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -481,6 +678,15 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -560,6 +766,19 @@ dependencies = [
  "tempfile",
  "tracing",
  "ulid",
+]
+
+[[package]]
+name = "kryphos"
+version = "0.1.0"
+dependencies = [
+ "chacha20poly1305",
+ "ed25519-dalek",
+ "koinon",
+ "rand_core 0.6.4",
+ "serde",
+ "snafu",
+ "tempfile",
 ]
 
 [[package]]
@@ -664,6 +883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +939,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -808,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -818,7 +1064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -827,7 +1082,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -836,7 +1091,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -864,6 +1119,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -907,6 +1171,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -961,6 +1231,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1270,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1029,6 +1319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1339,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1056,11 +1362,13 @@ name = "syntonia"
 version = "0.1.0"
 dependencies = [
  "compact_str",
+ "csv",
  "koinon",
  "proptest",
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "toml",
  "tracing",
 ]
@@ -1072,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1141,6 +1449,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1238,6 +1547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1595,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,11 @@ figment = { version = "0.10", features = ["toml", "env"] }
 # Hashing
 blake3 = "1"
 
+# Cryptography
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+chacha20poly1305 = "0.10"
+rand_core = { version = "0.6", features = ["getrandom"] }
+
 # Binary serialization
 ciborium = "0.2"
 

--- a/crates/kryphos/Cargo.toml
+++ b/crates/kryphos/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "kryphos"
+description = "κρυφός — encryption, key management, credential vault, identity"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+koinon = { path = "../koinon" }
+ed25519-dalek.workspace = true
+chacha20poly1305.workspace = true
+rand_core.workspace = true
+snafu.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/kryphos/src/identity.rs
+++ b/crates/kryphos/src/identity.rs
@@ -1,0 +1,279 @@
+//! Installation identity — Ed25519 keypair for provenance signing.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use rand_core::OsRng;
+use snafu::{ResultExt, Snafu};
+
+use crate::vault::{VaultError, VaultKey, VaultStorage};
+
+/// Errors from identity operations.
+#[derive(Debug, Snafu)]
+pub enum IdentityError {
+    /// Failed to store identity in vault.
+    #[snafu(display("failed to store identity: {source}"))]
+    VaultStore {
+        /// Underlying vault error.
+        source: VaultError,
+    },
+
+    /// Failed to load identity from vault.
+    #[snafu(display("failed to load identity: {source}"))]
+    VaultLoad {
+        /// Underlying vault error.
+        source: VaultError,
+    },
+
+    /// Stored key material has wrong length.
+    #[snafu(display("invalid key length: expected 32 bytes, got {actual}"))]
+    InvalidKeyLength {
+        /// Actual length of the decrypted bytes.
+        actual: usize,
+    },
+}
+
+/// An installation's Ed25519 identity for signing tamper log entries.
+///
+/// Each Akroasis installation has a unique keypair. The private key signs
+/// tamper log entries (proving provenance). The public key is the
+/// installation's identity fingerprint.
+pub struct InstallationIdentity {
+    signing_key: SigningKey,
+}
+
+impl InstallationIdentity {
+    /// Generates a new random Ed25519 keypair.
+    pub fn generate() -> Self {
+        Self {
+            signing_key: SigningKey::generate(&mut OsRng),
+        }
+    }
+
+    /// Signs a message and returns the Ed25519 signature.
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        self.signing_key.sign(message)
+    }
+
+    /// Verifies a signature against a message using this identity's public key.
+    pub fn verify(&self, message: &[u8], signature: &Signature) -> bool {
+        self.signing_key
+            .verifying_key()
+            .verify(message, signature)
+            .is_ok()
+    }
+
+    /// Returns the 32-byte public key for identity fingerprinting.
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.signing_key.verifying_key().to_bytes()
+    }
+
+    /// Returns the verifying (public) key.
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.signing_key.verifying_key()
+    }
+
+    /// Signs a tamper log entry hash (the 32-byte BLAKE3 hash from the chain).
+    ///
+    /// Use with [`koinon::TamperLog::last_hash`] to sign the most recent entry.
+    pub fn sign_entry(&self, entry_hash: &[u8; 32]) -> Signature {
+        self.signing_key.sign(entry_hash.as_slice())
+    }
+
+    /// Stores the keypair encrypted in the vault.
+    ///
+    /// Only the 32-byte private key seed is stored; the public key is
+    /// derived on load.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::VaultStore`] if encryption or I/O fails.
+    pub fn store(&self, vault: &VaultStorage, vault_key: &VaultKey) -> Result<(), IdentityError> {
+        let private_bytes = self.signing_key.to_bytes();
+        vault
+            .store(&private_bytes, vault_key)
+            .context(VaultStoreSnafu)
+    }
+
+    /// Loads a keypair from the vault.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::VaultLoad`] if decryption fails, or
+    /// [`IdentityError::InvalidKeyLength`] if the decrypted data is not 32 bytes.
+    pub fn load(vault: &VaultStorage, vault_key: &VaultKey) -> Result<Self, IdentityError> {
+        let decrypted = vault.load(vault_key).context(VaultLoadSnafu)?;
+        let bytes: [u8; 32] = decrypted
+            .try_into()
+            .map_err(|v: Vec<u8>| IdentityError::InvalidKeyLength { actual: v.len() })?;
+        let signing_key = SigningKey::from_bytes(&bytes);
+        Ok(Self { signing_key })
+    }
+}
+
+/// Verifies a signature using a standalone public key (no private key needed).
+///
+/// Returns `false` if the public key bytes are invalid or verification fails.
+pub fn verify_with_public_key(
+    public_key_bytes: &[u8; 32],
+    message: &[u8],
+    signature: &Signature,
+) -> bool {
+    let Ok(verifying_key) = VerifyingKey::from_bytes(public_key_bytes) else {
+        return false;
+    };
+    verifying_key.verify(message, signature).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items
+)]
+mod tests {
+    use super::*;
+    use koinon::tamper_log::{LogEntryKind, TamperLog};
+
+    #[test]
+    fn generate_creates_valid_keypair() {
+        let id = InstallationIdentity::generate();
+        let pk = id.public_key_bytes();
+        // Public key must not be all zeros.
+        assert_ne!(pk, [0u8; 32]);
+        // Verify the verifying key is derivable.
+        assert_eq!(pk, id.verifying_key().to_bytes());
+    }
+
+    #[test]
+    fn sign_verify_roundtrip() {
+        let id = InstallationIdentity::generate();
+        let message = b"tamper log entry hash placeholder";
+        let signature = id.sign(message);
+        assert!(id.verify(message, &signature));
+    }
+
+    #[test]
+    fn wrong_key_rejects_signature() {
+        let id_a = InstallationIdentity::generate();
+        let id_b = InstallationIdentity::generate();
+
+        let message = b"signed by identity A";
+        let signature = id_a.sign(message);
+
+        // Verification with a different identity's key must fail.
+        assert!(!id_b.verify(message, &signature));
+    }
+
+    #[test]
+    fn tampered_message_rejects_signature() {
+        let id = InstallationIdentity::generate();
+        let signature = id.sign(b"original");
+        assert!(!id.verify(b"tampered", &signature));
+    }
+
+    #[test]
+    fn vault_storage_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("identity.vault");
+        let vault = VaultStorage::new(&vault_path);
+        let vault_key = VaultKey::from_bytes([42u8; 32]);
+
+        let original = InstallationIdentity::generate();
+        original.store(&vault, &vault_key).unwrap();
+
+        let loaded = InstallationIdentity::load(&vault, &vault_key).unwrap();
+        assert_eq!(original.public_key_bytes(), loaded.public_key_bytes());
+
+        // Loaded identity can still sign and verify.
+        let sig = loaded.sign(b"after vault roundtrip");
+        assert!(loaded.verify(b"after vault roundtrip", &sig));
+        // Original can verify loaded's signature (same keypair).
+        assert!(original.verify(b"after vault roundtrip", &sig));
+    }
+
+    #[test]
+    fn vault_load_wrong_key_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("identity.vault");
+        let vault = VaultStorage::new(&vault_path);
+
+        let id = InstallationIdentity::generate();
+        let correct_key = VaultKey::from_bytes([1u8; 32]);
+        id.store(&vault, &correct_key).unwrap();
+
+        let wrong_key = VaultKey::from_bytes([99u8; 32]);
+        let result = InstallationIdentity::load(&vault, &wrong_key);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sign_entry_signs_tamper_log_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+
+        let mut log = TamperLog::open(&log_path).unwrap();
+        log.append(LogEntryKind::ActionTaken {
+            actor: "operator".into(),
+            action: "deploy".into(),
+            target: Some("production".into()),
+        })
+        .unwrap();
+
+        let entry_hash = log.last_hash();
+        let id = InstallationIdentity::generate();
+
+        let signature = id.sign_entry(entry_hash);
+        // Verify using the generic verify method.
+        assert!(id.verify(entry_hash, &signature));
+        // Verify using the standalone public key function.
+        assert!(verify_with_public_key(
+            &id.public_key_bytes(),
+            entry_hash,
+            &signature
+        ));
+    }
+
+    #[test]
+    fn sign_entry_different_identity_rejects() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+
+        let mut log = TamperLog::open(&log_path).unwrap();
+        log.append(LogEntryKind::ConfigChanged {
+            key: "threshold".into(),
+            old_value: Some("10".into()),
+            new_value: "20".into(),
+        })
+        .unwrap();
+
+        let entry_hash = log.last_hash();
+        let signer = InstallationIdentity::generate();
+        let impostor = InstallationIdentity::generate();
+
+        let signature = signer.sign_entry(entry_hash);
+        assert!(!impostor.verify(entry_hash, &signature));
+    }
+
+    #[test]
+    fn verify_with_standalone_public_key() {
+        let id = InstallationIdentity::generate();
+        let message = b"standalone verification";
+        let signature = id.sign(message);
+        let pk = id.public_key_bytes();
+
+        assert!(verify_with_public_key(&pk, message, &signature));
+        // Wrong message fails.
+        assert!(!verify_with_public_key(&pk, b"wrong", &signature));
+        // Wrong key fails.
+        let other = InstallationIdentity::generate();
+        assert!(!verify_with_public_key(
+            &other.public_key_bytes(),
+            message,
+            &signature
+        ));
+    }
+}

--- a/crates/kryphos/src/lib.rs
+++ b/crates/kryphos/src/lib.rs
@@ -1,0 +1,8 @@
+//! κρυφός — encryption, key management, credential vault, identity.
+
+pub mod identity;
+pub mod vault;
+
+pub use ed25519_dalek::Signature;
+pub use identity::{IdentityError, InstallationIdentity, verify_with_public_key};
+pub use vault::{VaultError, VaultKey, VaultStorage};

--- a/crates/kryphos/src/vault.rs
+++ b/crates/kryphos/src/vault.rs
@@ -1,0 +1,134 @@
+//! Encrypted vault storage using ChaCha20-Poly1305 AEAD.
+
+use std::path::{Path, PathBuf};
+
+use chacha20poly1305::{
+    ChaCha20Poly1305,
+    aead::{Aead, KeyInit},
+};
+use rand_core::{OsRng, RngCore};
+use snafu::{ResultExt, Snafu};
+
+/// Nonce length for ChaCha20-Poly1305 (96 bits).
+const NONCE_LEN: usize = 12;
+
+/// Errors from vault operations.
+#[derive(Debug, Snafu)]
+pub enum VaultError {
+    /// I/O error accessing vault file.
+    #[snafu(display("vault I/O error on {}: {source}", path.display()))]
+    Io {
+        /// Path of the file that triggered the error.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// AEAD encryption failed.
+    #[snafu(display("encryption failed"))]
+    Encrypt,
+
+    /// AEAD decryption failed (wrong key or corrupted data).
+    #[snafu(display("decryption failed: wrong key or corrupted data"))]
+    Decrypt,
+
+    /// Vault file too short to contain nonce and ciphertext.
+    #[snafu(display("vault file corrupted: too short ({size} bytes)"))]
+    TooShort {
+        /// Actual file size.
+        size: usize,
+    },
+}
+
+/// A 256-bit key used to encrypt and decrypt vault contents.
+#[derive(Clone)]
+pub struct VaultKey([u8; 32]);
+
+impl VaultKey {
+    /// Creates a vault key from raw bytes.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the raw key bytes.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Drop for VaultKey {
+    fn drop(&mut self) {
+        // WHY: Zeroize key material on drop to minimize exposure window.
+        // black_box prevents the compiler from optimizing away the fill.
+        self.0.fill(0);
+        std::hint::black_box(&self.0);
+    }
+}
+
+/// File-based encrypted storage for sensitive key material.
+///
+/// Stored format: `[12-byte nonce][ciphertext + 16-byte Poly1305 tag]`.
+pub struct VaultStorage {
+    path: PathBuf,
+}
+
+impl VaultStorage {
+    /// Creates a vault storage backed by the given file path.
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_owned(),
+        }
+    }
+
+    /// Returns the vault file path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Encrypts `plaintext` with `key` and writes to the vault file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::Encrypt`] if AEAD encryption fails, or
+    /// [`VaultError::Io`] on filesystem errors.
+    pub fn store(&self, plaintext: &[u8], key: &VaultKey) -> Result<(), VaultError> {
+        let cipher = ChaCha20Poly1305::new(key.0.as_ref().into());
+
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = chacha20poly1305::Nonce::from(nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|_| VaultError::Encrypt)?;
+
+        let mut output = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        output.extend_from_slice(&nonce_bytes);
+        output.extend_from_slice(&ciphertext);
+
+        std::fs::write(&self.path, &output).context(IoSnafu { path: &self.path })
+    }
+
+    /// Reads the vault file, decrypts with `key`, and returns the plaintext.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::Io`] on filesystem errors,
+    /// [`VaultError::TooShort`] if the file is malformed, or
+    /// [`VaultError::Decrypt`] if decryption fails.
+    pub fn load(&self, key: &VaultKey) -> Result<Vec<u8>, VaultError> {
+        let data = std::fs::read(&self.path).context(IoSnafu { path: &self.path })?;
+
+        if data.len() < NONCE_LEN + 1 {
+            return Err(VaultError::TooShort { size: data.len() });
+        }
+
+        let (nonce_bytes, ciphertext) = data.split_at(NONCE_LEN);
+        let nonce = chacha20poly1305::Nonce::from_slice(nonce_bytes);
+        let cipher = ChaCha20Poly1305::new(key.0.as_ref().into());
+
+        cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|_| VaultError::Decrypt)
+    }
+}


### PR DESCRIPTION
## Summary

- Add the **kryphos** crate (`κρυφός` — encryption, key management, credential vault, identity)
- Implement `InstallationIdentity` with Ed25519 keypair generation, signing, verification, and public key fingerprinting via `ed25519-dalek`
- Implement `VaultStorage` with ChaCha20-Poly1305 AEAD encryption for storing/retrieving private key material on disk
- Add `sign_entry` method for signing tamper log entry hashes (integrates with koinon's `TamperLog::last_hash()`)
- 9 tests: generate, sign/verify round-trip, wrong key rejection, tampered message rejection, vault storage round-trip, vault wrong key, tamper log entry signing, cross-identity rejection, standalone public key verification

## Observations

- **Bug**: `crates/akroasis/src/radio/export.rs:171` and `:188`, `crates/akroasis/src/radio/read.rs:77` — `DcsCode::code()` was renamed to `DcsCode::as_code()` but call sites not updated. Workspace `cargo clippy` fails on akroasis crate. Pre-existing on main.
- **Debt**: kryphos vault storage is file-based with a single key. Future prompts (P3-05, P3-06) will add config encryption and key lifecycle management.
- **Missing test**: No property-based test for sign/verify (e.g., proptest over random messages). Could be added in a follow-up.

## Test plan

- [x] `cargo fmt -p kryphos -- --check` passes
- [x] `cargo clippy -p kryphos --all-targets -- -D warnings` passes
- [x] `cargo test -p kryphos` — 9/9 tests pass
- [x] `cargo test -p koinon` — 138/138 tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)