### PR TITLE
feat(kryphos): Argon2id KDF and ChaCha20-Poly1305 encryption core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +92,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +178,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -187,6 +233,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +281,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -343,6 +424,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +466,17 @@ dependencies = [
  "tempfile",
  "thiserror",
  "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -419,6 +543,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +626,15 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -560,6 +714,19 @@ dependencies = [
  "tempfile",
  "tracing",
  "ulid",
+]
+
+[[package]]
+name = "kryphos"
+version = "0.1.0"
+dependencies = [
+ "argon2",
+ "chacha20poly1305",
+ "getrandom 0.2.17",
+ "snafu",
+ "subtle",
+ "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -664,6 +831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +857,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -714,6 +898,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -808,7 +1003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -818,7 +1013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -827,7 +1031,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -836,7 +1040,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1041,6 +1245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,11 +1266,13 @@ name = "syntonia"
 version = "0.1.0"
 dependencies = [
  "compact_str",
+ "csv",
  "koinon",
  "proptest",
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "toml",
  "tracing",
 ]
@@ -1072,7 +1284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1141,6 +1353,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1238,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1499,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1534,6 +1763,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/kryphos/Cargo.toml
+++ b/crates/kryphos/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "kryphos"
+description = "κρυφός — hidden, secret. Vault cryptography: key derivation, authenticated encryption, and secret storage."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+argon2 = { version = "0.5", features = ["std"] }
+chacha20poly1305 = { version = "0.10", features = ["std"] }
+getrandom = { version = "0.2", features = ["std"] }
+snafu = { workspace = true }
+subtle = "2"
+zeroize = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kryphos/src/crypto.rs
+++ b/crates/kryphos/src/crypto.rs
@@ -1,0 +1,326 @@
+//! Argon2id key derivation and ChaCha20-Poly1305 authenticated encryption.
+
+use std::fmt;
+
+use argon2::{Algorithm, Argon2, Params, Version};
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, aead::Aead};
+use snafu::{ResultExt, Snafu};
+use subtle::ConstantTimeEq;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+const ARGON2_M_COST_KIB: u32 = 65_536;
+const ARGON2_T_COST: u32 = 3;
+const ARGON2_P_COST: u32 = 4;
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+
+/// Errors from cryptographic operations.
+#[derive(Debug, Snafu)]
+#[expect(missing_docs, reason = "snafu display messages document each variant")]
+pub enum CryptoError {
+    #[snafu(display("key derivation failed"))]
+    KeyDerivation {
+        source: argon2::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("random number generation failed"))]
+    RandomGeneration {
+        source: getrandom::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("encryption failed"))]
+    Encryption {
+        source: chacha20poly1305::aead::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("ciphertext too short: expected at least {expected} bytes, got {actual}"))]
+    CiphertextTooShort {
+        expected: usize,
+        actual: usize,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("decryption failed"))]
+    Decryption {
+        source: chacha20poly1305::aead::Error,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+/// 256-bit symmetric key derived from a passphrase.
+///
+/// Zeroed on drop. Constant-time equality comparison.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct VaultKey {
+    bytes: [u8; KEY_LEN],
+}
+
+impl VaultKey {
+    /// Returns the raw key bytes.
+    pub const fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.bytes
+    }
+}
+
+impl PartialEq for VaultKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes.ct_eq(&other.bytes).into()
+    }
+}
+
+impl Eq for VaultKey {}
+
+impl fmt::Debug for VaultKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VaultKey").finish_non_exhaustive()
+    }
+}
+
+/// Generates a 32-byte cryptographic salt from OS randomness.
+///
+/// # Errors
+///
+/// Returns [`CryptoError::RandomGeneration`] if the OS RNG is unavailable.
+pub fn generate_salt() -> Result<[u8; KEY_LEN], CryptoError> {
+    let mut salt = [0u8; KEY_LEN];
+    getrandom::getrandom(&mut salt).context(RandomGenerationSnafu)?;
+    Ok(salt)
+}
+
+/// Derives a 256-bit key from a passphrase and salt using Argon2id.
+///
+/// Parameters: m=64 MiB, t=3, p=4.
+///
+/// # Errors
+///
+/// Returns [`CryptoError::KeyDerivation`] if the salt is too short (minimum 8 bytes)
+/// or if the Argon2id computation fails.
+pub fn derive_key(passphrase: &[u8], salt: &[u8]) -> Result<VaultKey, CryptoError> {
+    let params = Params::new(
+        ARGON2_M_COST_KIB,
+        ARGON2_T_COST,
+        ARGON2_P_COST,
+        Some(KEY_LEN),
+    )
+    .context(KeyDerivationSnafu)?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let mut key_bytes = [0u8; KEY_LEN];
+    argon2
+        .hash_password_into(passphrase, salt, &mut key_bytes)
+        .context(KeyDerivationSnafu)?;
+    Ok(VaultKey { bytes: key_bytes })
+}
+
+/// Encrypts plaintext using ChaCha20-Poly1305 with a random nonce.
+///
+/// Returns `nonce (12 bytes) || ciphertext || tag (16 bytes)`.
+///
+/// # Errors
+///
+/// Returns [`CryptoError::RandomGeneration`] if nonce generation fails, or
+/// [`CryptoError::Encryption`] if the AEAD operation fails.
+pub fn encrypt(key: &VaultKey, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let cipher = ChaCha20Poly1305::new(key.bytes.as_ref().into());
+
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    getrandom::getrandom(&mut nonce_bytes).context(RandomGenerationSnafu)?;
+    let nonce = chacha20poly1305::Nonce::from(nonce_bytes);
+
+    let ciphertext = cipher.encrypt(&nonce, plaintext).context(EncryptionSnafu)?;
+
+    let mut output = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    output.extend_from_slice(&nonce_bytes);
+    output.extend_from_slice(&ciphertext);
+    Ok(output)
+}
+
+/// Decrypts ciphertext produced by [`encrypt`].
+///
+/// Expects `nonce (12 bytes) || ciphertext || tag (16 bytes)`.
+///
+/// # Errors
+///
+/// Returns [`CryptoError::CiphertextTooShort`] if the input is shorter than the nonce,
+/// or [`CryptoError::Decryption`] if authentication fails (wrong key or tampered data).
+pub fn decrypt(key: &VaultKey, ciphertext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    snafu::ensure!(
+        ciphertext.len() > NONCE_LEN,
+        CiphertextTooShortSnafu {
+            expected: NONCE_LEN + 1,
+            actual: ciphertext.len(),
+        }
+    );
+
+    let (nonce_bytes, encrypted) = ciphertext.split_at(NONCE_LEN);
+    let nonce = chacha20poly1305::Nonce::from_slice(nonce_bytes);
+    let cipher = ChaCha20Poly1305::new(key.bytes.as_ref().into());
+
+    cipher.decrypt(nonce, encrypted).context(DecryptionSnafu)
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "tests use expect/unwrap for clarity and indexing for nonce extraction"
+)]
+mod tests {
+    use super::*;
+
+    fn test_salt() -> [u8; KEY_LEN] {
+        let mut salt = [0u8; KEY_LEN];
+        for (i, byte) in salt.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        salt
+    }
+
+    #[test]
+    fn derive_key_deterministic_for_same_inputs() {
+        let salt = test_salt();
+        let key_a = derive_key(b"correct horse battery staple", &salt)
+            .expect("key derivation should succeed");
+        let key_b = derive_key(b"correct horse battery staple", &salt)
+            .expect("key derivation should succeed");
+        assert_eq!(key_a, key_b);
+    }
+
+    #[test]
+    fn derive_key_differs_for_different_passphrases() {
+        let salt = test_salt();
+        let key_a = derive_key(b"passphrase-one", &salt).expect("key derivation should succeed");
+        let key_b = derive_key(b"passphrase-two", &salt).expect("key derivation should succeed");
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn derive_key_differs_for_different_salts() {
+        let salt_a = test_salt();
+        let mut salt_b = test_salt();
+        salt_b[0] = 0xFF;
+        let key_a = derive_key(b"same-passphrase", &salt_a).expect("key derivation should succeed");
+        let key_b = derive_key(b"same-passphrase", &salt_b).expect("key derivation should succeed");
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn encrypt_decrypt_round_trip() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+        let plaintext = b"secret vault entry";
+
+        let ciphertext = encrypt(&key, plaintext).expect("encryption should succeed");
+        let decrypted = decrypt(&key, &ciphertext).expect("decryption should succeed");
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn encrypt_decrypt_empty_plaintext() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+
+        let ciphertext = encrypt(&key, b"").expect("encryption should succeed");
+        let decrypted = decrypt(&key, &ciphertext).expect("decryption should succeed");
+
+        assert!(decrypted.is_empty());
+    }
+
+    #[test]
+    fn encrypt_decrypt_large_payload() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+        let plaintext = vec![0xAB_u8; 1_000_000];
+
+        let ciphertext = encrypt(&key, &plaintext).expect("encryption should succeed");
+        let decrypted = decrypt(&key, &ciphertext).expect("decryption should succeed");
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_with_wrong_key_fails() {
+        let salt = test_salt();
+        let key = derive_key(b"correct-key", &salt).expect("key derivation should succeed");
+        let wrong_key = derive_key(b"wrong-key", &salt).expect("key derivation should succeed");
+
+        let ciphertext = encrypt(&key, b"secret").expect("encryption should succeed");
+        let result = decrypt(&wrong_key, &ciphertext);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            CryptoError::Decryption { .. }
+        ));
+    }
+
+    #[test]
+    fn decrypt_tampered_ciphertext_fails() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+
+        let mut ciphertext = encrypt(&key, b"secret").expect("encryption should succeed");
+        let last = ciphertext.len() - 1;
+        ciphertext[last] ^= 0xFF;
+
+        let result = decrypt(&key, &ciphertext);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            CryptoError::Decryption { .. }
+        ));
+    }
+
+    #[test]
+    fn decrypt_too_short_ciphertext_fails() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+
+        let result = decrypt(&key, &[0u8; NONCE_LEN]);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            CryptoError::CiphertextTooShort { .. }
+        ));
+    }
+
+    #[test]
+    fn nonce_is_random_per_encryption() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+        let plaintext = b"same plaintext";
+
+        let ct_a = encrypt(&key, plaintext).expect("encryption should succeed");
+        let ct_b = encrypt(&key, plaintext).expect("encryption should succeed");
+
+        assert_ne!(
+            ct_a, ct_b,
+            "two encryptions of the same plaintext must differ"
+        );
+
+        let nonce_a = &ct_a[..NONCE_LEN];
+        let nonce_b = &ct_b[..NONCE_LEN];
+        assert_ne!(nonce_a, nonce_b, "nonces must differ between encryptions");
+    }
+
+    #[test]
+    fn generate_salt_returns_random_bytes() {
+        let salt_a = generate_salt().expect("salt generation should succeed");
+        let salt_b = generate_salt().expect("salt generation should succeed");
+        assert_ne!(salt_a, salt_b);
+    }
+
+    #[test]
+    fn vault_key_debug_does_not_leak_bytes() {
+        let salt = test_salt();
+        let key = derive_key(b"test-passphrase", &salt).expect("key derivation should succeed");
+        let debug = format!("{key:?}");
+        assert!(!debug.contains('['));
+        assert!(debug.contains("VaultKey"));
+    }
+}

--- a/crates/kryphos/src/lib.rs
+++ b/crates/kryphos/src/lib.rs
@@ -1,0 +1,5 @@
+//! Vault cryptography: key derivation, authenticated encryption, and secret storage.
+
+mod crypto;
+
+pub use crypto::{CryptoError, VaultKey, decrypt, derive_key, encrypt, generate_salt};


### PR DESCRIPTION
## Summary

- Add `kryphos` crate with Argon2id key derivation (m=64MiB, t=3, p=4) and ChaCha20-Poly1305 authenticated encryption
- `VaultKey` type with zeroize-on-drop and constant-time equality via `subtle::ConstantTimeEq`
- Encrypt prepends random 12-byte nonce; decrypt extracts it — two encryptions of the same plaintext always differ
- 12 tests covering: deterministic derivation, round-trip, empty plaintext, 1MB payload, wrong key rejection, tampered ciphertext rejection, nonce uniqueness, salt randomness, debug non-leakage

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p kryphos --all-targets -- -D warnings`
- [x] `cargo test -p kryphos` — 12/12 pass

## Observations

- **Bug** `crates/akroasis/src/radio/export.rs:171,188` and `crates/akroasis/src/radio/read.rs:77`: calls to `.code()` should be `.as_code()` — workspace-wide clippy fails on `akroasis` crate (pre-existing, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)