### PR TITLE
feat(kryphos): vault storage backend with fjall, Argon2id KDF, ChaCha20-Poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +92,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +178,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -156,10 +202,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "byteview"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "castaway"
@@ -187,6 +245,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +293,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -286,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "compare"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +411,31 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -343,6 +467,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +523,17 @@ dependencies = [
  "tempfile",
  "thiserror",
  "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -369,6 +550,18 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -413,10 +606,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fjall"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cf071a6f6090e99f3e095aaca9d38f78ad6fcf40bca736dc4cf7cbe15e4438"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "dashmap",
+ "flume",
+ "log",
+ "lsm-tree",
+ "lz4_flex",
+ "tempfile",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -443,6 +693,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -460,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -481,6 +737,24 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "interval-heap"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6"
+dependencies = [
+ "compare",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -563,6 +837,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "kryphos"
+version = "0.1.0"
+dependencies = [
+ "argon2",
+ "chacha20poly1305",
+ "ciborium",
+ "compact_str",
+ "fjall",
+ "fs2",
+ "jiff",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +893,37 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsm-tree"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97484b43ad0b232eaaeb83ee6edbf5d2e3602a389eee4205997b4ad3f6d3ace"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "crossbeam-skiplist",
+ "enum_dispatch",
+ "interval-heap",
+ "log",
+ "lz4_flex",
+ "quick_cache",
+ "rustc-hash",
+ "self_cell",
+ "sfa",
+ "tempfile",
+ "varint-rs",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "matchers"
@@ -664,6 +988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +1014,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -714,6 +1055,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -771,8 +1123,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -785,6 +1137,16 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick_cache"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "quote"
@@ -803,12 +1165,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -818,7 +1201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -827,7 +1219,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -836,7 +1228,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -864,6 +1256,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -907,6 +1305,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "serde"
@@ -958,6 +1362,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sfa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175"
+dependencies = [
+ "byteorder-lite",
+ "log",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1029,6 +1444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1463,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1056,11 +1486,13 @@ name = "syntonia"
 version = "0.1.0"
 dependencies = [
  "compact_str",
+ "csv",
  "koinon",
  "proptest",
  "serde",
  "serde_json",
  "snafu",
+ "tempfile",
  "toml",
  "tracing",
 ]
@@ -1072,7 +1504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1141,6 +1573,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1238,12 +1671,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "serde",
  "web-time",
 ]
@@ -1282,6 +1727,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1747,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "varint-rs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
 
 [[package]]
 name = "version_check"
@@ -1502,6 +1963,12 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/crates/kryphos/Cargo.toml
+++ b/crates/kryphos/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "kryphos"
+description = "κρυφός — credential vault and installation identity"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+snafu.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+jiff.workspace = true
+tracing.workspace = true
+compact_str.workspace = true
+ciborium.workspace = true
+
+# Crypto
+chacha20poly1305 = "0.10"
+argon2 = "0.5"
+
+# Storage
+fjall = "3"
+
+# File locking
+fs2 = "0.4"
+
+# Random bytes
+rand = "0.8"
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/kryphos/src/crypto.rs
+++ b/crates/kryphos/src/crypto.rs
@@ -1,0 +1,214 @@
+//! Cryptographic primitives: Argon2id KDF and ChaCha20-Poly1305 AEAD.
+
+use rand::RngCore;
+
+use chacha20poly1305::aead::{Aead, KeyInit, OsRng};
+use chacha20poly1305::{AeadCore, ChaCha20Poly1305, Nonce};
+
+use crate::error::CryptoError;
+use crate::model::KdfParams;
+
+/// Nonce size for ChaCha20-Poly1305 (12 bytes).
+const NONCE_LEN: usize = 12;
+
+/// Derived symmetric key for vault encryption.
+#[derive(Clone)]
+pub struct VaultKey {
+    bytes: [u8; 32],
+}
+
+impl VaultKey {
+    pub(crate) const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self { bytes }
+    }
+
+    pub(crate) const fn as_bytes(&self) -> &[u8; 32] {
+        &self.bytes
+    }
+}
+
+impl Drop for VaultKey {
+    fn drop(&mut self) {
+        // WHY: Zero key material on drop to reduce exposure window.
+        self.bytes.fill(0);
+    }
+}
+
+impl std::fmt::Debug for VaultKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VaultKey").finish_non_exhaustive()
+    }
+}
+
+/// Derive a 256-bit key from a passphrase and salt using Argon2id.
+pub fn derive_key(passphrase: &[u8], salt: &[u8], params: &KdfParams) -> VaultKey {
+    let argon_params = argon2::Params::new(params.m_cost, params.t_cost, params.p_cost, Some(32))
+        .unwrap_or_else(|_| {
+            // WHY: Fallback to defaults if caller provides invalid params.
+            let d = KdfParams::default();
+            argon2::Params::new(d.m_cost, d.t_cost, d.p_cost, Some(32))
+                .unwrap_or_else(|_| argon2::Params::default())
+        });
+
+    let argon2 = argon2::Argon2::new(
+        argon2::Algorithm::Argon2id,
+        argon2::Version::V0x13,
+        argon_params,
+    );
+
+    let mut key_bytes = [0u8; 32];
+    // WHY: hash_password_into only fails if output length is wrong (32 is valid).
+    let _ = argon2.hash_password_into(passphrase, salt, &mut key_bytes);
+
+    VaultKey::from_bytes(key_bytes)
+}
+
+/// Generate a cryptographically random 32-byte salt.
+pub fn generate_salt() -> [u8; 32] {
+    let mut salt = [0u8; 32];
+    OsRng.fill_bytes(&mut salt);
+    salt
+}
+
+/// Encrypt plaintext with ChaCha20-Poly1305. Returns nonce || ciphertext.
+///
+/// # Errors
+///
+/// Returns `CryptoError::Encrypt` if encryption fails.
+pub fn encrypt(key: &VaultKey, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let cipher = ChaCha20Poly1305::new(key.as_bytes().into());
+    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|_| CryptoError::Encrypt)?;
+
+    let mut output = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    output.extend_from_slice(&nonce);
+    output.extend_from_slice(&ciphertext);
+    Ok(output)
+}
+
+/// Decrypt nonce || ciphertext with ChaCha20-Poly1305.
+///
+/// # Errors
+///
+/// Returns `CryptoError::Decrypt` if decryption fails (wrong key or tampered data).
+pub fn decrypt(key: &VaultKey, data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    if data.len() < NONCE_LEN {
+        return Err(CryptoError::Decrypt);
+    }
+
+    let (nonce_bytes, ciphertext) = data.split_at(NONCE_LEN);
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let cipher = ChaCha20Poly1305::new(key.as_bytes().into());
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| CryptoError::Decrypt)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::model::KdfParams;
+
+    fn test_params() -> KdfParams {
+        // WHY: Reduced params for fast tests.
+        KdfParams {
+            m_cost: 256,
+            t_cost: 1,
+            p_cost: 1,
+        }
+    }
+
+    #[test]
+    fn derive_key_deterministic_for_same_inputs() {
+        let salt = [42u8; 32];
+        let params = test_params();
+        let k1 = derive_key(b"passphrase", &salt, &params);
+        let k2 = derive_key(b"passphrase", &salt, &params);
+        assert_eq!(k1.as_bytes(), k2.as_bytes());
+    }
+
+    #[test]
+    fn derive_key_differs_for_different_passphrase() {
+        let salt = [42u8; 32];
+        let params = test_params();
+        let k1 = derive_key(b"alpha", &salt, &params);
+        let k2 = derive_key(b"beta", &salt, &params);
+        assert_ne!(k1.as_bytes(), k2.as_bytes());
+    }
+
+    #[test]
+    fn derive_key_differs_for_different_salt() {
+        let params = test_params();
+        let k1 = derive_key(b"passphrase", &[1u8; 32], &params);
+        let k2 = derive_key(b"passphrase", &[2u8; 32], &params);
+        assert_ne!(k1.as_bytes(), k2.as_bytes());
+    }
+
+    #[test]
+    fn encrypt_decrypt_round_trip() {
+        let key = derive_key(b"test", &[0u8; 32], &test_params());
+        let plaintext = b"hello vault";
+        let encrypted = encrypt(&key, plaintext).unwrap();
+        let decrypted = decrypt(&key, &encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_with_wrong_key_fails() {
+        let k1 = derive_key(b"correct", &[0u8; 32], &test_params());
+        let k2 = derive_key(b"wrong", &[0u8; 32], &test_params());
+        let encrypted = encrypt(&k1, b"secret").unwrap();
+        assert!(decrypt(&k2, &encrypted).is_err());
+    }
+
+    #[test]
+    fn tampered_ciphertext_rejected() {
+        let key = derive_key(b"test", &[0u8; 32], &test_params());
+        let mut encrypted = encrypt(&key, b"data").unwrap();
+        if let Some(last) = encrypted.last_mut() {
+            *last ^= 0xFF;
+        }
+        assert!(decrypt(&key, &encrypted).is_err());
+    }
+
+    #[test]
+    fn two_encryptions_of_same_plaintext_differ() {
+        let key = derive_key(b"test", &[0u8; 32], &test_params());
+        let e1 = encrypt(&key, b"same").unwrap();
+        let e2 = encrypt(&key, b"same").unwrap();
+        assert_ne!(e1, e2);
+    }
+
+    #[test]
+    fn encrypt_decrypt_empty_plaintext() {
+        let key = derive_key(b"test", &[0u8; 32], &test_params());
+        let encrypted = encrypt(&key, b"").unwrap();
+        let decrypted = decrypt(&key, &encrypted).unwrap();
+        assert!(decrypted.is_empty());
+    }
+
+    #[test]
+    fn encrypt_decrypt_large_payload() {
+        let key = derive_key(b"test", &[0u8; 32], &test_params());
+        let big = vec![0xABu8; 1024 * 1024];
+        let encrypted = encrypt(&key, &big).unwrap();
+        let decrypted = decrypt(&key, &encrypted).unwrap();
+        assert_eq!(decrypted, big);
+    }
+
+    #[test]
+    fn decrypt_too_short_data_fails() {
+        let key = derive_key(b"test", &[0u8; 32], &test_params());
+        assert!(decrypt(&key, &[0u8; 5]).is_err());
+    }
+
+    #[test]
+    fn generate_salt_produces_unique_values() {
+        let s1 = generate_salt();
+        let s2 = generate_salt();
+        assert_ne!(s1, s2);
+    }
+}

--- a/crates/kryphos/src/error.rs
+++ b/crates/kryphos/src/error.rs
@@ -1,0 +1,149 @@
+//! Error types for the kryphos crate.
+
+use snafu::Snafu;
+use std::path::PathBuf;
+
+/// Crypto operation error.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum CryptoError {
+    /// Encryption failed.
+    #[snafu(display("encryption failed"))]
+    Encrypt,
+
+    /// Decryption failed (wrong key or tampered ciphertext).
+    #[snafu(display("decryption failed — wrong key or tampered ciphertext"))]
+    Decrypt,
+}
+
+/// Vault operation error.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum VaultError {
+    /// Failed to create the vault directory.
+    #[snafu(display("failed to create vault directory at {path}", path = path.display()))]
+    CreateDir {
+        /// Directory path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// Vault already exists at the given path.
+    #[snafu(display("vault already exists at {path}", path = path.display()))]
+    AlreadyExists {
+        /// Vault path.
+        path: PathBuf,
+    },
+
+    /// No vault found at the given path.
+    #[snafu(display("vault not found at {path}", path = path.display()))]
+    NotFound {
+        /// Vault path.
+        path: PathBuf,
+    },
+
+    /// Failed to write the vault header.
+    #[snafu(display("failed to write vault header at {path}", path = path.display()))]
+    WriteHeader {
+        /// Header file path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// Failed to read the vault header.
+    #[snafu(display("failed to read vault header at {path}", path = path.display()))]
+    ReadHeader {
+        /// Header file path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+
+    /// Vault header is corrupted or incompatible.
+    #[snafu(display("invalid vault header — corrupted or incompatible version"))]
+    InvalidHeader,
+
+    /// Passphrase does not match the vault.
+    #[snafu(display("wrong passphrase"))]
+    WrongPassphrase,
+
+    /// Failed to open the fjall database.
+    #[snafu(display("failed to open fjall database at {path}", path = path.display()))]
+    OpenDatabase {
+        /// Database path.
+        path: PathBuf,
+        /// Underlying fjall error.
+        source: fjall::Error,
+    },
+
+    /// Failed to open a fjall keyspace.
+    #[snafu(display("failed to open fjall keyspace"))]
+    OpenKeyspace {
+        /// Underlying fjall error.
+        source: fjall::Error,
+    },
+
+    /// Fjall storage operation failed.
+    #[snafu(display("fjall storage operation failed"))]
+    Storage {
+        /// Underlying fjall error.
+        source: fjall::Error,
+    },
+
+    /// Encryption failed for a specific entry.
+    #[snafu(display("encryption failed for entry '{name}'"))]
+    EntryEncrypt {
+        /// Entry name.
+        name: String,
+        /// Underlying crypto error.
+        source: CryptoError,
+    },
+
+    /// Decryption failed for a specific entry.
+    #[snafu(display("decryption failed for entry '{name}'"))]
+    EntryDecrypt {
+        /// Entry name.
+        name: String,
+        /// Underlying crypto error.
+        source: CryptoError,
+    },
+
+    /// CBOR serialization failed.
+    #[snafu(display("serialization failed"))]
+    Serialize {
+        /// Underlying ciborium error.
+        source: ciborium::ser::Error<std::io::Error>,
+    },
+
+    /// CBOR deserialization failed.
+    #[snafu(display("deserialization failed"))]
+    Deserialize {
+        /// Underlying ciborium error.
+        source: ciborium::de::Error<std::io::Error>,
+    },
+
+    /// Entry not found in the vault.
+    #[snafu(display("entry '{name}' not found in vault"))]
+    EntryNotFound {
+        /// Entry name.
+        name: String,
+    },
+
+    /// Vault is locked by another process.
+    #[snafu(display("vault is locked by another process at {path}", path = path.display()))]
+    Locked {
+        /// Vault path.
+        path: PathBuf,
+    },
+
+    /// Failed to acquire the vault lock.
+    #[snafu(display("failed to acquire vault lock at {path}", path = path.display()))]
+    LockAcquire {
+        /// Lock file path.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+}

--- a/crates/kryphos/src/lib.rs
+++ b/crates/kryphos/src/lib.rs
@@ -1,0 +1,11 @@
+//! κρυφός — credential vault and installation identity.
+
+pub mod crypto;
+pub mod error;
+pub mod model;
+pub mod vault;
+
+pub use crypto::VaultKey;
+pub use error::{CryptoError, VaultError};
+pub use model::{CredentialType, EntryMetadata, KdfParams, VaultEntry, VaultHeader};
+pub use vault::Vault;

--- a/crates/kryphos/src/model.rs
+++ b/crates/kryphos/src/model.rs
@@ -1,0 +1,96 @@
+//! Vault data model types.
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+/// Type of credential stored in the vault.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum CredentialType {
+    /// API key for external services.
+    ApiKey,
+    /// Pre-shared key for mesh networks.
+    Psk,
+    /// Certificate (PEM or DER).
+    Certificate,
+    /// Radio programming key.
+    RadioKey,
+    /// Arbitrary secret blob.
+    Custom(CompactString),
+}
+
+/// Metadata for a vault entry (never contains decrypted secrets).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryMetadata {
+    /// Human-readable name.
+    pub name: CompactString,
+    /// What kind of credential this is.
+    pub credential_type: CredentialType,
+    /// Unix milliseconds when the entry was created.
+    pub created_at_ms: i64,
+    /// Unix milliseconds when the entry was last rotated.
+    pub rotated_at_ms: Option<i64>,
+    /// User-defined tags.
+    pub tags: Vec<CompactString>,
+}
+
+/// Internal representation stored encrypted in fjall.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct VaultEntryInner {
+    /// Entry metadata.
+    pub metadata: EntryMetadata,
+    /// Secret bytes.
+    pub secret: Vec<u8>,
+}
+
+/// A decrypted vault entry returned to callers.
+#[derive(Debug, Clone)]
+pub struct VaultEntry {
+    /// Entry metadata.
+    pub metadata: EntryMetadata,
+    /// The decrypted secret bytes.
+    pub secret: Vec<u8>,
+}
+
+/// KDF parameters stored in the vault header.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KdfParams {
+    /// Memory cost in KiB.
+    pub m_cost: u32,
+    /// Time cost (iterations).
+    pub t_cost: u32,
+    /// Parallelism.
+    pub p_cost: u32,
+}
+
+impl Default for KdfParams {
+    fn default() -> Self {
+        Self {
+            m_cost: 65536,
+            t_cost: 3,
+            p_cost: 4,
+        }
+    }
+}
+
+/// Vault header stored on disk alongside the fjall data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultHeader {
+    /// Header format version.
+    pub version: u8,
+    /// Random salt for KDF.
+    pub salt: Vec<u8>,
+    /// KDF parameters.
+    pub kdf_params: KdfParams,
+    /// Verification tag: encrypt a known plaintext to detect wrong passphrase.
+    pub verify_tag: Vec<u8>,
+}
+
+/// Magic bytes at the start of the header file.
+pub(crate) const HEADER_MAGIC: &[u8; 8] = b"KRYPHOS\0";
+
+/// Current header version.
+pub(crate) const HEADER_VERSION: u8 = 1;
+
+/// Known plaintext used to verify the passphrase on open.
+pub(crate) const VERIFY_PLAINTEXT: &[u8] = b"kryphos-vault-verify";

--- a/crates/kryphos/src/vault.rs
+++ b/crates/kryphos/src/vault.rs
@@ -1,0 +1,533 @@
+//! Vault storage backend using fjall.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+use compact_str::CompactString;
+use fs2::FileExt;
+use snafu::ResultExt;
+
+use crate::crypto::{self, VaultKey};
+use crate::error::{self, VaultError};
+use crate::model::{
+    CredentialType, EntryMetadata, HEADER_MAGIC, HEADER_VERSION, KdfParams, VERIFY_PLAINTEXT,
+    VaultEntry, VaultEntryInner, VaultHeader,
+};
+
+/// File name for the vault header within the vault directory.
+const HEADER_FILE: &str = "vault.header";
+
+/// File name for the advisory lock.
+const LOCK_FILE: &str = "vault.lock";
+
+/// Fjall subdirectory within the vault directory.
+const FJALL_DIR: &str = "data";
+
+/// Fjall partition name for vault entries.
+const ENTRIES_PARTITION: &str = "entries";
+
+/// An opened credential vault backed by fjall.
+pub struct Vault {
+    _lock_file: File,
+    key: VaultKey,
+    db: fjall::Database,
+    entries: fjall::Keyspace,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for Vault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Vault")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Vault {
+    /// Create a new vault at `path` with the given passphrase.
+    ///
+    /// The directory must not already exist as a vault (contain a header file).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vault already exists, the directory cannot be created,
+    /// or the storage backend fails to initialize.
+    pub fn create(path: impl AsRef<Path>, passphrase: &[u8]) -> Result<Self, VaultError> {
+        Self::create_with_params(path, passphrase, &KdfParams::default())
+    }
+
+    /// Create with explicit KDF parameters (useful for testing with fast params).
+    pub(crate) fn create_with_params(
+        path: impl AsRef<Path>,
+        passphrase: &[u8],
+        kdf_params: &KdfParams,
+    ) -> Result<Self, VaultError> {
+        let path = path.as_ref();
+
+        let header_path = path.join(HEADER_FILE);
+        if header_path.exists() {
+            return Err(VaultError::AlreadyExists {
+                path: path.to_path_buf(),
+            });
+        }
+
+        fs::create_dir_all(path).context(error::CreateDirSnafu {
+            path: path.to_path_buf(),
+        })?;
+
+        let lock = acquire_lock(path)?;
+        let salt = crypto::generate_salt();
+        let key = crypto::derive_key(passphrase, &salt, kdf_params);
+
+        let verify_tag =
+            crypto::encrypt(&key, VERIFY_PLAINTEXT).map_err(|source| VaultError::EntryEncrypt {
+                name: "<verify>".to_string(),
+                source,
+            })?;
+
+        let header = VaultHeader {
+            version: HEADER_VERSION,
+            salt: salt.to_vec(),
+            kdf_params: kdf_params.clone(),
+            verify_tag,
+        };
+
+        write_header(&header_path, &header)?;
+
+        let fjall_path = path.join(FJALL_DIR);
+        let db = fjall::Database::builder(&fjall_path)
+            .open()
+            .context(error::OpenDatabaseSnafu { path: fjall_path })?;
+        let entries = db
+            .keyspace(ENTRIES_PARTITION, fjall::KeyspaceCreateOptions::default)
+            .context(error::OpenKeyspaceSnafu)?;
+
+        Ok(Self {
+            _lock_file: lock,
+            key,
+            db,
+            entries,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Open an existing vault at `path` with the given passphrase.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vault does not exist, the passphrase is wrong,
+    /// the vault is locked by another process, or the storage backend fails.
+    pub fn open(path: impl AsRef<Path>, passphrase: &[u8]) -> Result<Self, VaultError> {
+        let path = path.as_ref();
+
+        let header_path = path.join(HEADER_FILE);
+        if !header_path.exists() {
+            return Err(VaultError::NotFound {
+                path: path.to_path_buf(),
+            });
+        }
+
+        let lock = acquire_lock(path)?;
+        let header = read_header(&header_path)?;
+
+        let key = crypto::derive_key(passphrase, &header.salt, &header.kdf_params);
+
+        crypto::decrypt(&key, &header.verify_tag).map_err(|_| VaultError::WrongPassphrase)?;
+
+        let fjall_path = path.join(FJALL_DIR);
+        let db = fjall::Database::builder(&fjall_path)
+            .open()
+            .context(error::OpenDatabaseSnafu { path: fjall_path })?;
+        let entries = db
+            .keyspace(ENTRIES_PARTITION, fjall::KeyspaceCreateOptions::default)
+            .context(error::OpenKeyspaceSnafu)?;
+
+        Ok(Self {
+            _lock_file: lock,
+            key,
+            db,
+            entries,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Add a new entry to the vault.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encryption or storage fails.
+    pub fn add(
+        &self,
+        name: &str,
+        credential_type: CredentialType,
+        secret: &[u8],
+    ) -> Result<(), VaultError> {
+        let now_ms = jiff::Timestamp::now().as_millisecond();
+
+        let inner = VaultEntryInner {
+            metadata: EntryMetadata {
+                name: CompactString::new(name),
+                credential_type,
+                created_at_ms: now_ms,
+                rotated_at_ms: None,
+                tags: Vec::new(),
+            },
+            secret: secret.to_vec(),
+        };
+
+        let serialized = cbor_encode(&inner)?;
+        let encrypted =
+            crypto::encrypt(&self.key, &serialized).map_err(|source| VaultError::EntryEncrypt {
+                name: name.to_string(),
+                source,
+            })?;
+
+        self.entries
+            .insert(name.as_bytes(), encrypted)
+            .context(error::StorageSnafu)?;
+        self.db
+            .persist(fjall::PersistMode::SyncAll)
+            .context(error::StorageSnafu)?;
+
+        Ok(())
+    }
+
+    /// Get a decrypted entry by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry is not found, decryption fails, or storage fails.
+    pub fn get(&self, name: &str) -> Result<VaultEntry, VaultError> {
+        let raw = self
+            .entries
+            .get(name.as_bytes())
+            .context(error::StorageSnafu)?
+            .ok_or_else(|| VaultError::EntryNotFound {
+                name: name.to_string(),
+            })?;
+
+        let decrypted =
+            crypto::decrypt(&self.key, &raw).map_err(|source| VaultError::EntryDecrypt {
+                name: name.to_string(),
+                source,
+            })?;
+
+        let inner: VaultEntryInner = cbor_decode(&decrypted)?;
+
+        Ok(VaultEntry {
+            metadata: inner.metadata,
+            secret: inner.secret,
+        })
+    }
+
+    /// List all entry names and metadata (without decrypted secrets).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if iteration or decryption fails.
+    pub fn list(&self) -> Result<Vec<EntryMetadata>, VaultError> {
+        let mut result = Vec::new();
+
+        for guard in self.entries.iter() {
+            let (key, value) = guard.into_inner().context(error::StorageSnafu)?;
+            let decrypted =
+                crypto::decrypt(&self.key, &value).map_err(|source| VaultError::EntryDecrypt {
+                    name: String::from_utf8_lossy(&key).to_string(),
+                    source,
+                })?;
+            let inner: VaultEntryInner = cbor_decode(&decrypted)?;
+            result.push(inner.metadata);
+        }
+
+        Ok(result)
+    }
+
+    /// Remove an entry by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry is not found or storage fails.
+    pub fn remove(&self, name: &str) -> Result<(), VaultError> {
+        if self
+            .entries
+            .get(name.as_bytes())
+            .context(error::StorageSnafu)?
+            .is_none()
+        {
+            return Err(VaultError::EntryNotFound {
+                name: name.to_string(),
+            });
+        }
+
+        self.entries
+            .remove(name.as_bytes())
+            .context(error::StorageSnafu)?;
+        self.db
+            .persist(fjall::PersistMode::SyncAll)
+            .context(error::StorageSnafu)?;
+
+        Ok(())
+    }
+
+    /// Path to the vault directory.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn acquire_lock(vault_path: &Path) -> Result<File, VaultError> {
+    let lock_path = vault_path.join(LOCK_FILE);
+
+    // WHY: Create parent dir first — lock file creation needs the directory.
+    fs::create_dir_all(vault_path).context(error::CreateDirSnafu {
+        path: vault_path.to_path_buf(),
+    })?;
+
+    let file = File::create(&lock_path).context(error::LockAcquireSnafu { path: lock_path })?;
+
+    file.try_lock_exclusive().map_err(|_| VaultError::Locked {
+        path: vault_path.to_path_buf(),
+    })?;
+
+    Ok(file)
+}
+
+fn write_header(path: &Path, header: &VaultHeader) -> Result<(), VaultError> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(HEADER_MAGIC);
+
+    let mut cbor_buf = Vec::new();
+    ciborium::into_writer(header, &mut cbor_buf).map_err(|e| VaultError::WriteHeader {
+        path: path.to_path_buf(),
+        source: std::io::Error::other(e.to_string()),
+    })?;
+
+    buf.extend_from_slice(&(cbor_buf.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&cbor_buf);
+
+    fs::write(path, &buf).context(error::WriteHeaderSnafu {
+        path: path.to_path_buf(),
+    })
+}
+
+fn read_header(path: &Path) -> Result<VaultHeader, VaultError> {
+    let data = fs::read(path).context(error::ReadHeaderSnafu {
+        path: path.to_path_buf(),
+    })?;
+
+    if data.len() < HEADER_MAGIC.len() + 4 {
+        return Err(VaultError::InvalidHeader);
+    }
+
+    let (magic, rest) = data.split_at(HEADER_MAGIC.len());
+    if magic != HEADER_MAGIC {
+        return Err(VaultError::InvalidHeader);
+    }
+
+    let len_bytes: [u8; 4] = rest
+        .get(..4)
+        .ok_or(VaultError::InvalidHeader)?
+        .try_into()
+        .map_err(|_| VaultError::InvalidHeader)?;
+    let cbor_len = u32::from_le_bytes(len_bytes) as usize;
+
+    let cbor_data = rest.get(4..4 + cbor_len).ok_or(VaultError::InvalidHeader)?;
+    ciborium::from_reader(cbor_data).map_err(|_| VaultError::InvalidHeader)
+}
+
+fn cbor_encode(value: &impl serde::Serialize) -> Result<Vec<u8>, VaultError> {
+    let mut buf = Vec::new();
+    ciborium::into_writer(value, &mut buf).context(error::SerializeSnafu)?;
+    Ok(buf)
+}
+
+fn cbor_decode<T: serde::de::DeserializeOwned>(data: &[u8]) -> Result<T, VaultError> {
+    ciborium::from_reader(data).context(error::DeserializeSnafu)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fast_params() -> KdfParams {
+        KdfParams {
+            m_cost: 256,
+            t_cost: 1,
+            p_cost: 1,
+        }
+    }
+
+    #[test]
+    fn create_and_open_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+
+        {
+            let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+            vault
+                .add("test-key", CredentialType::ApiKey, b"secret123")
+                .unwrap();
+        }
+
+        let vault = Vault::open(&vault_path, b"pass").unwrap();
+        let entry = vault.get("test-key").unwrap();
+        assert_eq!(entry.secret, b"secret123");
+    }
+
+    #[test]
+    fn add_get_returns_original_secret() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+        let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        vault
+            .add("api", CredentialType::ApiKey, b"key-abc")
+            .unwrap();
+        vault.add("psk", CredentialType::Psk, b"psk-xyz").unwrap();
+        vault
+            .add("cert", CredentialType::Certificate, b"-----BEGIN CERT-----")
+            .unwrap();
+
+        let api = vault.get("api").unwrap();
+        assert_eq!(api.secret, b"key-abc");
+        assert_eq!(api.metadata.credential_type, CredentialType::ApiKey);
+
+        let psk = vault.get("psk").unwrap();
+        assert_eq!(psk.secret, b"psk-xyz");
+
+        let cert = vault.get("cert").unwrap();
+        assert_eq!(cert.secret, b"-----BEGIN CERT-----");
+    }
+
+    #[test]
+    fn list_returns_metadata_without_secrets() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+        let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        vault.add("alpha", CredentialType::ApiKey, b"s1").unwrap();
+        vault.add("beta", CredentialType::Psk, b"s2").unwrap();
+
+        let list = vault.list().unwrap();
+        assert_eq!(list.len(), 2);
+
+        let names: Vec<&str> = list.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"alpha"));
+        assert!(names.contains(&"beta"));
+    }
+
+    #[test]
+    fn remove_deletes_entry() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+        let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        vault.add("temp", CredentialType::ApiKey, b"data").unwrap();
+        assert!(vault.get("temp").is_ok());
+
+        vault.remove("temp").unwrap();
+
+        let err = vault.get("temp").unwrap_err();
+        assert!(
+            err.to_string().contains("not found"),
+            "expected 'not found', got: {err}"
+        );
+    }
+
+    #[test]
+    fn remove_nonexistent_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+        let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        let err = vault.remove("ghost").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn wrong_passphrase_on_open_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+
+        {
+            Vault::create_with_params(&vault_path, b"correct", &fast_params()).unwrap();
+        }
+
+        let err = Vault::open(&vault_path, b"wrong").unwrap_err();
+        assert!(
+            err.to_string().contains("passphrase"),
+            "expected passphrase error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn concurrent_open_fails_with_lock_error() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+
+        let _v1 = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        let err = Vault::open(&vault_path, b"pass").unwrap_err();
+        assert!(
+            err.to_string().contains("locked") || err.to_string().contains("lock"),
+            "expected lock error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn create_existing_vault_fails() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+
+        {
+            Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+        }
+
+        let err = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn open_nonexistent_vault_fails() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("nope");
+
+        let err = Vault::open(&vault_path, b"pass").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn add_get_binary_secret() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+        let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        let binary = (0..=255).collect::<Vec<u8>>();
+        vault
+            .add(
+                "bin",
+                CredentialType::Custom(CompactString::new("binary-blob")),
+                &binary,
+            )
+            .unwrap();
+
+        let entry = vault.get("bin").unwrap();
+        assert_eq!(entry.secret, binary);
+        assert_eq!(
+            entry.metadata.credential_type,
+            CredentialType::Custom(CompactString::new("binary-blob"))
+        );
+    }
+
+    #[test]
+    fn list_empty_vault_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let vault_path = dir.path().join("vault");
+        let vault = Vault::create_with_params(&vault_path, b"pass", &fast_params()).unwrap();
+
+        let list = vault.list().unwrap();
+        assert!(list.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `crates/kryphos/` credential vault crate with fjall storage backend, Argon2id key derivation, and ChaCha20-Poly1305 authenticated encryption
- Implement `Vault::create`, `Vault::open`, `add`, `get`, `list`, `remove` with per-entry encryption and CBOR serialization
- Advisory file locking via `fs2` prevents concurrent vault access; passphrase verification via encrypted known-plaintext tag

## Implementation

**Storage:** fjall v3 LSM-tree database stores encrypted entries keyed by name. Each entry is individually encrypted before storage.

**Crypto:** Argon2id (m=64MB, t=3, p=4 defaults) derives a 256-bit key from passphrase + 32-byte random salt. ChaCha20-Poly1305 with random nonce encrypts each entry. Key material is zeroed on drop.

**Header:** Binary format with magic bytes, CBOR-encoded header (version, salt, KDF params, verification tag). Verification tag is an encryption of known plaintext to detect wrong passphrase without leaking data.

**Errors:** snafu-based typed errors (`CryptoError`, `VaultError`) with context propagation.

## Test plan

- [x] `Vault::create` + `Vault::open` round-trip works
- [x] `add` → `get` returns original secret (API key, PSK, certificate, binary blob)
- [x] `list` returns metadata without decrypted secrets
- [x] `remove` deletes the entry; subsequent `get` returns not-found
- [x] Wrong passphrase on `open` returns error (not garbage data)
- [x] Concurrent `open` fails with lock error
- [x] Encrypt/decrypt round-trip, wrong key rejection, tampered ciphertext rejection
- [x] Empty plaintext, large payload (1MB), nonce uniqueness
- [x] All 22 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p kryphos --all-targets -- -D warnings` clean

## Observations

- **Debt:** `akroasis` CLI crate has pre-existing compile errors (`DcsCode::code()` should be `as_code()`) in `crates/akroasis/src/radio/export.rs:171,188` and `crates/akroasis/src/radio/read.rs:77`. Workspace-wide clippy/test cannot pass until fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)