### PR TITLE
feat(kryphos): add Ed25519 signing, vault storage, and tamper log integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,11 +802,13 @@ dependencies = [
  "compact_str",
  "ed25519-dalek",
  "jiff",
+ "koinon",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
  "snafu",
  "subtle",
+ "tempfile",
  "zeroize",
 ]
 

--- a/crates/kryphos/Cargo.toml
+++ b/crates/kryphos/Cargo.toml
@@ -23,6 +23,8 @@ compact_str.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+koinon = { path = "../koinon" }
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/kryphos/src/key.rs
+++ b/crates/kryphos/src/key.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use crate::error::KeyError;
+use ed25519_dalek::Signer;
+
+use crate::error::{CryptoError, KeyError};
 
 /// ChaCha20-Poly1305 symmetric key length in bytes.
 pub const VAULT_KEY_LEN: usize = 32;
@@ -60,6 +62,20 @@ impl SigningKey {
         }
     }
 
+    /// Signs a message and returns the signature.
+    #[must_use]
+    pub fn sign(&self, message: &[u8]) -> ed25519_dalek::Signature {
+        self.inner.sign(message)
+    }
+
+    /// Returns the raw 32-byte secret key material.
+    ///
+    /// Caller is responsible for zeroizing the returned bytes.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; SIGNING_KEY_LEN] {
+        self.inner.to_bytes()
+    }
+
     /// Borrows the underlying `ed25519_dalek::SigningKey`.
     #[must_use]
     pub const fn as_inner(&self) -> &ed25519_dalek::SigningKey {
@@ -107,6 +123,22 @@ impl VerifyingKey {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8; VERIFYING_KEY_LEN] {
         self.inner.as_bytes()
+    }
+
+    /// Verifies a signature against a message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CryptoError::SignatureInvalid`] if the signature does not match.
+    pub fn verify(
+        &self,
+        message: &[u8],
+        signature: &ed25519_dalek::Signature,
+    ) -> Result<(), CryptoError> {
+        use ed25519_dalek::Verifier;
+        self.inner
+            .verify(message, signature)
+            .map_err(|_| CryptoError::SignatureInvalid)
     }
 
     /// Borrows the underlying `ed25519_dalek::VerifyingKey`.
@@ -160,10 +192,43 @@ impl InstallationIdentity {
         &self.signing
     }
 
-    /// Returns a clone of the verifying (public) key.
+    /// Returns a reference to the verifying (public) key.
     #[must_use]
     pub const fn verifying_key(&self) -> &VerifyingKey {
         &self.verifying
+    }
+
+    /// Signs a message with this installation's private key.
+    #[must_use]
+    pub fn sign(&self, message: &[u8]) -> ed25519_dalek::Signature {
+        self.signing.sign(message)
+    }
+
+    /// Verifies a signature against a message using this installation's public key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CryptoError::SignatureInvalid`] if the signature does not match.
+    pub fn verify(
+        &self,
+        message: &[u8],
+        signature: &ed25519_dalek::Signature,
+    ) -> Result<(), CryptoError> {
+        self.verifying.verify(message, signature)
+    }
+
+    /// Returns the raw 32-byte public key for identity fingerprinting.
+    #[must_use]
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        *self.verifying.as_bytes()
+    }
+
+    /// Signs a tamper log entry hash, proving this installation produced it.
+    ///
+    /// `entry_hash` is the 32-byte BLAKE3 hash from [`koinon::tamper_log::encode_entry`].
+    #[must_use]
+    pub fn sign_entry(&self, entry_hash: &[u8; 32]) -> ed25519_dalek::Signature {
+        self.signing.sign(entry_hash)
     }
 }
 
@@ -325,6 +390,62 @@ mod tests {
         assert!(
             !dbg.contains("SigningKey("),
             "debug must not expose signing key innards"
+        );
+    }
+
+    #[test]
+    fn sign_verify_round_trip_succeeds() {
+        let id = InstallationIdentity::generate();
+        let message = b"tamper log entry hash";
+        let signature = id.sign(message);
+        assert!(
+            id.verify(message, &signature).is_ok(),
+            "verification must succeed for matching key"
+        );
+    }
+
+    #[test]
+    fn verify_with_wrong_key_fails() {
+        let id1 = InstallationIdentity::generate();
+        let id2 = InstallationIdentity::generate();
+        let message = b"some message";
+        let signature = id1.sign(message);
+        assert!(
+            id2.verify(message, &signature).is_err(),
+            "verification must fail with a different key"
+        );
+    }
+
+    #[test]
+    fn verify_with_wrong_message_fails() {
+        let id = InstallationIdentity::generate();
+        let signature = id.sign(b"original");
+        assert!(
+            id.verify(b"tampered", &signature).is_err(),
+            "verification must fail with a different message"
+        );
+    }
+
+    #[test]
+    fn public_key_bytes_returns_32_bytes() {
+        let id = InstallationIdentity::generate();
+        let bytes = id.public_key_bytes();
+        assert_eq!(bytes.len(), 32, "public key must be 32 bytes");
+        assert_eq!(
+            &bytes,
+            id.verifying_key().as_bytes(),
+            "public_key_bytes must match verifying key"
+        );
+    }
+
+    #[test]
+    fn sign_entry_signs_32_byte_hash() {
+        let id = InstallationIdentity::generate();
+        let entry_hash = [0xAB_u8; 32];
+        let signature = id.sign_entry(&entry_hash);
+        assert!(
+            id.verify(&entry_hash, &signature).is_ok(),
+            "sign_entry signature must verify against the same hash"
         );
     }
 

--- a/crates/kryphos/src/key.rs
+++ b/crates/kryphos/src/key.rs
@@ -225,7 +225,7 @@ impl InstallationIdentity {
 
     /// Signs a tamper log entry hash, proving this installation produced it.
     ///
-    /// `entry_hash` is the 32-byte BLAKE3 hash from [`koinon::tamper_log::encode_entry`].
+    /// `entry_hash` is the 32-byte BLAKE3 hash from `koinon::tamper_log::encode_entry`.
     #[must_use]
     pub fn sign_entry(&self, entry_hash: &[u8; 32]) -> ed25519_dalek::Signature {
         self.signing.sign(entry_hash)

--- a/crates/kryphos/src/lib.rs
+++ b/crates/kryphos/src/lib.rs
@@ -13,5 +13,5 @@ pub use error::{CryptoError, KeyError, VaultError};
 pub use key::{InstallationIdentity, SigningKey, VaultKey, VerifyingKey};
 pub use vault::{
     CredentialType, EntryMetadata, KdfParams, NONCE_LEN, SALT_LEN, VAULT_VERSION, VaultEntry,
-    VaultHeader,
+    VaultHeader, seal_signing_key, unseal_signing_key,
 };

--- a/crates/kryphos/src/vault.rs
+++ b/crates/kryphos/src/vault.rs
@@ -1,8 +1,13 @@
 //! Vault data model: entries, headers, and credential types.
 
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
 use compact_str::CompactString;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
+
+use crate::error::CryptoError;
+use crate::key::{InstallationIdentity, SigningKey, VaultKey};
 
 /// Size of the Argon2id salt in bytes.
 pub const SALT_LEN: usize = 16;
@@ -122,8 +127,61 @@ impl VaultHeader {
     }
 }
 
+/// Encrypts the signing key of an [`InstallationIdentity`] with the given vault
+/// key and nonce, returning the ciphertext.
+///
+/// The nonce must be unique per encryption operation with the same key.
+///
+/// # Errors
+///
+/// Returns [`CryptoError::EncryptionFailed`] if encryption fails.
+pub fn seal_signing_key(
+    identity: &InstallationIdentity,
+    vault_key: &VaultKey,
+    nonce: &[u8; NONCE_LEN],
+) -> Result<Vec<u8>, CryptoError> {
+    let cipher = ChaCha20Poly1305::new(vault_key.as_bytes().into());
+    let nonce = Nonce::from_slice(nonce);
+    let plaintext = identity.signing_key().to_bytes();
+
+    cipher
+        .encrypt(nonce, plaintext.as_ref())
+        .map_err(|e| CryptoError::EncryptionFailed {
+            reason: e.to_string(),
+        })
+}
+
+/// Decrypts a signing key from vault ciphertext, reconstructing the
+/// [`InstallationIdentity`].
+///
+/// # Errors
+///
+/// Returns [`CryptoError::DecryptionFailed`] if decryption fails (wrong key
+/// or tampered ciphertext).
+/// Returns [`crate::KeyError`] (wrapped in `CryptoError`) if the decrypted
+/// bytes are not a valid Ed25519 key.
+pub fn unseal_signing_key(
+    ciphertext: &[u8],
+    vault_key: &VaultKey,
+    nonce: &[u8; NONCE_LEN],
+) -> Result<InstallationIdentity, CryptoError> {
+    let cipher = ChaCha20Poly1305::new(vault_key.as_bytes().into());
+    let nonce = Nonce::from_slice(nonce);
+
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    let signing =
+        SigningKey::from_bytes(&plaintext).map_err(|e| CryptoError::EncryptionFailed {
+            reason: e.to_string(),
+        })?;
+
+    Ok(InstallationIdentity::from_signing_key(signing))
+}
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
 
@@ -272,5 +330,71 @@ mod tests {
         let json = serde_json::to_string(&entry).unwrap();
         let back: VaultEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(entry, back);
+    }
+
+    // -----------------------------------------------------------------
+    // Seal / unseal signing key
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn seal_unseal_round_trip_preserves_identity() {
+        let identity = InstallationIdentity::generate();
+        let vault_key = VaultKey::from_bytes([0x42; 32]);
+        let nonce = [0x01; NONCE_LEN];
+
+        let ciphertext = seal_signing_key(&identity, &vault_key, &nonce).unwrap();
+        let recovered = unseal_signing_key(&ciphertext, &vault_key, &nonce).unwrap();
+
+        assert_eq!(
+            identity.public_key_bytes(),
+            recovered.public_key_bytes(),
+            "recovered identity must have the same public key"
+        );
+
+        let message = b"round-trip test";
+        let sig = identity.sign(message);
+        assert!(
+            recovered.verify(message, &sig).is_ok(),
+            "recovered identity must verify signatures from the original"
+        );
+    }
+
+    #[test]
+    fn unseal_with_wrong_key_fails() {
+        let identity = InstallationIdentity::generate();
+        let vault_key = VaultKey::from_bytes([0x42; 32]);
+        let wrong_key = VaultKey::from_bytes([0xFF; 32]);
+        let nonce = [0x01; NONCE_LEN];
+
+        let ciphertext = seal_signing_key(&identity, &vault_key, &nonce).unwrap();
+        let result = unseal_signing_key(&ciphertext, &wrong_key, &nonce);
+        assert!(result.is_err(), "decryption must fail with wrong vault key");
+    }
+
+    #[test]
+    fn unseal_with_wrong_nonce_fails() {
+        let identity = InstallationIdentity::generate();
+        let vault_key = VaultKey::from_bytes([0x42; 32]);
+        let nonce = [0x01; NONCE_LEN];
+        let wrong_nonce = [0x02; NONCE_LEN];
+
+        let ciphertext = seal_signing_key(&identity, &vault_key, &nonce).unwrap();
+        let result = unseal_signing_key(&ciphertext, &vault_key, &wrong_nonce);
+        assert!(result.is_err(), "decryption must fail with wrong nonce");
+    }
+
+    #[test]
+    fn unseal_tampered_ciphertext_fails() {
+        let identity = InstallationIdentity::generate();
+        let vault_key = VaultKey::from_bytes([0x42; 32]);
+        let nonce = [0x01; NONCE_LEN];
+
+        let mut ciphertext = seal_signing_key(&identity, &vault_key, &nonce).unwrap();
+        ciphertext[0] ^= 0xFF;
+        let result = unseal_signing_key(&ciphertext, &vault_key, &nonce);
+        assert!(
+            result.is_err(),
+            "decryption must fail with tampered ciphertext"
+        );
     }
 }

--- a/crates/kryphos/src/vault.rs
+++ b/crates/kryphos/src/vault.rs
@@ -63,7 +63,7 @@ pub struct EntryMetadata {
 /// A single credential stored in the vault.
 ///
 /// The `encrypted_data` field holds the ciphertext produced by
-/// ChaCha20-Poly1305. Decryption requires the [`VaultKey`](super::VaultKey).
+/// ChaCha20-Poly1305. Decryption requires the [`VaultKey`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VaultEntry {
     /// Human-readable name for this credential.

--- a/crates/kryphos/tests/tamper_log_signing.rs
+++ b/crates/kryphos/tests/tamper_log_signing.rs
@@ -1,0 +1,107 @@
+//! Integration test: signing tamper log entries with an installation identity.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use compact_str::CompactString;
+
+use koinon::tamper_log::{LogEntry, LogEntryKind, TamperLog, encode_entry};
+use kryphos::InstallationIdentity;
+
+#[test]
+fn sign_tamper_log_entry_and_verify() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("signed.log");
+
+    let identity = InstallationIdentity::generate();
+    let mut log = TamperLog::open(&path).unwrap();
+
+    let kind = LogEntryKind::ActionTaken {
+        actor: CompactString::from("operator"),
+        action: CompactString::from("deploy"),
+        target: Some(CompactString::from("node-1")),
+    };
+
+    let seq = log.append(kind.clone()).unwrap();
+    assert_eq!(seq, 0, "first entry should be sequence 0");
+
+    // Reconstruct the entry to get its hash (simulates what a caller would do).
+    let entry = LogEntry {
+        sequence: 0,
+        timestamp_ms: 0, // hash depends on CBOR bytes, but we use last_hash() instead
+        kind,
+    };
+    let _ = entry; // entry reconstruction shown for documentation
+
+    // Use the log's last_hash, which is the actual on-disk entry hash.
+    let entry_hash = log.last_hash();
+    let signature = identity.sign_entry(entry_hash);
+
+    assert!(
+        identity.verify(entry_hash, &signature).is_ok(),
+        "signature on entry hash must verify with the same identity"
+    );
+
+    // A different identity must not verify.
+    let other = InstallationIdentity::generate();
+    assert!(
+        other.verify(entry_hash, &signature).is_err(),
+        "signature must not verify with a different identity"
+    );
+}
+
+#[test]
+fn sign_multiple_entries_each_verifiable() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("multi_signed.log");
+
+    let identity = InstallationIdentity::generate();
+    let mut log = TamperLog::open(&path).unwrap();
+
+    let mut signatures = Vec::new();
+    let mut hashes = Vec::new();
+
+    for i in 0..5_u64 {
+        let kind = LogEntryKind::ConfigChanged {
+            key: CompactString::from(format!("key-{i}")),
+            old_value: None,
+            new_value: CompactString::from(format!("val-{i}")),
+        };
+        log.append(kind).unwrap();
+
+        let hash = *log.last_hash();
+        let sig = identity.sign_entry(&hash);
+        hashes.push(hash);
+        signatures.push(sig);
+    }
+
+    for (hash, sig) in hashes.iter().zip(&signatures) {
+        assert!(
+            identity.verify(hash, sig).is_ok(),
+            "each signed entry hash must verify"
+        );
+    }
+}
+
+#[test]
+fn encode_entry_hash_matches_sign_entry_input() {
+    let identity = InstallationIdentity::generate();
+    let prev_hash = [0u8; 32];
+
+    let entry = LogEntry {
+        sequence: 0,
+        timestamp_ms: 1_000_000,
+        kind: LogEntryKind::AlertRaised {
+            alert_id: CompactString::from("ALT-001"),
+            severity: CompactString::from("warning"),
+            message: CompactString::from("test alert"),
+        },
+    };
+
+    let (_wire, entry_hash) = encode_entry(&entry, &prev_hash).unwrap();
+    let signature = identity.sign_entry(&entry_hash);
+
+    assert!(
+        identity.verify(&entry_hash, &signature).is_ok(),
+        "sign_entry on encode_entry hash must verify"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `sign()`, `verify()`, `public_key_bytes()`, and `sign_entry()` to `InstallationIdentity` for Ed25519 message and tamper log entry signing
- Add `seal_signing_key()` / `unseal_signing_key()` for encrypting/decrypting the private key with ChaCha20-Poly1305 using the vault key
- Add `verify()` to `VerifyingKey` for standalone signature verification

## Test plan

- [x] `sign` / `verify` round-trip succeeds
- [x] Verification with wrong key fails
- [x] Verification with wrong message fails
- [x] `public_key_bytes()` returns correct 32-byte key
- [x] `sign_entry()` signs 32-byte hash and verifies
- [x] Vault seal/unseal round-trip preserves identity
- [x] Unseal with wrong vault key fails
- [x] Unseal with wrong nonce fails
- [x] Unseal with tampered ciphertext fails
- [x] Integration: sign tamper log entry hash and verify
- [x] Integration: sign multiple entries, each verifiable
- [x] Integration: `encode_entry` hash matches `sign_entry` input
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (288 tests)

## Observations

- **Debt**: `CredentialType` has an `IdentityKey` variant missing; the installation signing key could be stored as a typed vault entry with a dedicated variant rather than using the raw `seal_signing_key` function. This would unify all credential storage through the same `VaultEntry` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)