### PR TITLE
feat(kryphos): add fjall-backed vault storage with advisory locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,10 +203,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "byteview"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "castaway"
@@ -368,6 +380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "compare"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +418,31 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -490,6 +533,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +622,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,10 +682,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fjall"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cf071a6f6090e99f3e095aaca9d38f78ad6fcf40bca736dc4cf7cbe15e4438"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "dashmap",
+ "flume",
+ "log",
+ "lsm-tree",
+ "lz4_flex",
+ "tempfile",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "generic-array"
@@ -664,6 +769,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -681,7 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -710,6 +821,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "interval-heap"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6"
+dependencies = [
+ "compare",
 ]
 
 [[package]]
@@ -801,6 +921,8 @@ dependencies = [
  "chacha20poly1305",
  "compact_str",
  "ed25519-dalek",
+ "fjall",
+ "fs2",
  "jiff",
  "koinon",
  "rand_core 0.6.4",
@@ -850,6 +972,37 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsm-tree"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97484b43ad0b232eaaeb83ee6edbf5d2e3602a389eee4205997b4ad3f6d3ace"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "crossbeam-skiplist",
+ "enum_dispatch",
+ "interval-heap",
+ "log",
+ "lz4_flex",
+ "quick_cache",
+ "rustc-hash",
+ "self_cell",
+ "sfa",
+ "tempfile",
+ "varint-rs",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "matchers"
@@ -1075,6 +1228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick_cache"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1382,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -1270,6 +1445,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sfa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175"
+dependencies = [
+ "byteorder-lite",
+ "log",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1358,6 +1544,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1589,6 +1784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1860,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "varint-rs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
 
 [[package]]
 name = "version_check"
@@ -1869,6 +2076,12 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,5 +78,11 @@ toml = { version = "0.8", features = ["preserve_order"] }
 # Serial
 serialport = "4"
 
+# Embedded KV store
+fjall = "3"
+
+# File locking
+fs2 = "0.4"
+
 # Testing
 tempfile = "3"

--- a/crates/kryphos/Cargo.toml
+++ b/crates/kryphos/Cargo.toml
@@ -20,6 +20,8 @@ snafu.workspace = true
 subtle.workspace = true
 jiff.workspace = true
 compact_str.workspace = true
+fjall.workspace = true
+fs2.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/kryphos/src/error.rs
+++ b/crates/kryphos/src/error.rs
@@ -43,6 +43,38 @@ pub enum VaultError {
         /// Underlying I/O error.
         source: std::io::Error,
     },
+
+    /// The passphrase is incorrect (key check decryption failed).
+    #[snafu(display("wrong passphrase: decryption of key check failed"))]
+    WrongPassphrase,
+
+    /// The vault is already locked by another process.
+    #[snafu(display("vault is locked by another process: {path}", path = path.display()))]
+    Locked {
+        /// Path to the vault directory.
+        path: std::path::PathBuf,
+    },
+
+    /// The vault already exists at this path.
+    #[snafu(display("vault already exists at {path}", path = path.display()))]
+    AlreadyExists {
+        /// Path to the existing vault directory.
+        path: std::path::PathBuf,
+    },
+
+    /// The storage backend (fjall) returned an error.
+    #[snafu(display("storage backend error: {message}"))]
+    StorageBackend {
+        /// Human-readable explanation.
+        message: String,
+    },
+
+    /// A cryptographic operation on a vault entry failed.
+    #[snafu(display("entry crypto error: {source}"))]
+    EntryCrypto {
+        /// Underlying crypto error.
+        source: CryptoError,
+    },
 }
 
 /// Errors from key generation, derivation, or loading.

--- a/crates/kryphos/src/lib.rs
+++ b/crates/kryphos/src/lib.rs
@@ -1,16 +1,19 @@
 //! κρυφός — credential vault and installation identity.
 //!
-//! Provides the data model for encrypted credential storage
+//! Provides encrypted credential storage with a fjall-backed vault,
+//! Argon2id key derivation, ChaCha20-Poly1305 encryption,
 //! and Ed25519-based installation identity.
 
 pub mod crypto;
 pub mod error;
 pub mod key;
+pub mod storage;
 pub mod vault;
 
 pub use crypto::{decrypt, derive_key, encrypt, generate_salt};
 pub use error::{CryptoError, KeyError, VaultError};
 pub use key::{InstallationIdentity, SigningKey, VaultKey, VerifyingKey};
+pub use storage::{DecryptedEntry, EntryInfo, Vault};
 pub use vault::{
     CredentialType, EntryMetadata, KdfParams, NONCE_LEN, SALT_LEN, VAULT_VERSION, VaultEntry,
     VaultHeader, seal_signing_key, unseal_signing_key,

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -1,0 +1,520 @@
+//! Vault storage backend: encrypted credential CRUD over fjall.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+use compact_str::CompactString;
+use fs2::FileExt;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::crypto::{self, decrypt, encrypt};
+use crate::error::{
+    AlreadyExistsSnafu, EntryCryptoSnafu, IoSnafu, SerializationSnafu, VaultError,
+    WrongPassphraseSnafu,
+};
+use crate::key::VaultKey;
+use crate::vault::{CredentialType, EntryMetadata, KdfParams, VAULT_VERSION};
+
+/// Well-known plaintext used to verify the passphrase on open.
+const KEY_CHECK_PLAINTEXT: &[u8] = b"kryphos-vault-key-check-v1";
+
+/// Name of the header file within the vault directory.
+const HEADER_FILE: &str = "header.json";
+
+/// Name of the lock file within the vault directory.
+const LOCK_FILE: &str = "vault.lock";
+
+/// Subdirectory for the fjall keyspace.
+const DATA_DIR: &str = "data";
+
+/// On-disk vault header stored as JSON.
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredHeader {
+    version: u32,
+    salt: Vec<u8>,
+    kdf_params: KdfParams,
+    key_check: Vec<u8>,
+}
+
+/// Entry as stored in fjall (JSON-serialized value).
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredEntry {
+    credential_type: CredentialType,
+    encrypted_secret: Vec<u8>,
+    metadata: EntryMetadata,
+}
+
+/// A decrypted credential retrieved from the vault.
+#[derive(Debug, Clone)]
+pub struct DecryptedEntry {
+    /// Human-readable name for this credential.
+    pub name: CompactString,
+    /// What kind of credential this is.
+    pub credential_type: CredentialType,
+    /// The decrypted secret bytes.
+    pub secret: Vec<u8>,
+    /// Associated metadata.
+    pub metadata: EntryMetadata,
+}
+
+/// Summary of a vault entry (no secret material).
+#[derive(Debug, Clone)]
+pub struct EntryInfo {
+    /// Human-readable name for this credential.
+    pub name: CompactString,
+    /// What kind of credential this is.
+    pub credential_type: CredentialType,
+    /// Associated metadata.
+    pub metadata: EntryMetadata,
+}
+
+/// Encrypted credential vault backed by fjall.
+///
+/// Each entry is individually encrypted with ChaCha20-Poly1305 using a
+/// key derived from the user's passphrase via Argon2id. The vault
+/// directory is advisory-locked to prevent concurrent access.
+pub struct Vault {
+    db: fjall::Database,
+    keyspace: fjall::Keyspace,
+    key: VaultKey,
+    _lock: File,
+    path: PathBuf,
+}
+
+impl Vault {
+    /// Creates a new vault at the given path.
+    ///
+    /// Generates a random salt, derives a key from the passphrase,
+    /// writes the header, and initializes the fjall keyspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::AlreadyExists`] if the path already exists.
+    /// Returns [`VaultError::Io`] on filesystem errors.
+    /// Returns [`VaultError::StorageBackend`] if fjall initialization fails.
+    pub fn create(path: impl AsRef<Path>, passphrase: &[u8]) -> Result<Self, VaultError> {
+        let path = path.as_ref();
+        if path.exists() {
+            return AlreadyExistsSnafu { path }.fail();
+        }
+
+        fs::create_dir_all(path).context(IoSnafu { path })?;
+
+        let lock = acquire_lock(path)?;
+        let salt = crypto::generate_salt();
+        let key = crypto::derive_key(passphrase, &salt);
+
+        let key_check = encrypt(&key, KEY_CHECK_PLAINTEXT).context(EntryCryptoSnafu)?;
+
+        let header = StoredHeader {
+            version: VAULT_VERSION,
+            salt: salt.to_vec(),
+            kdf_params: KdfParams::default(),
+            key_check,
+        };
+
+        let header_json = serde_json::to_string_pretty(&header).context(SerializationSnafu)?;
+        fs::write(path.join(HEADER_FILE), header_json).context(IoSnafu { path })?;
+
+        let (db, keyspace) = open_fjall(&path.join(DATA_DIR))?;
+
+        Ok(Self {
+            db,
+            keyspace,
+            key,
+            _lock: lock,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Opens an existing vault.
+    ///
+    /// Reads the header, derives the key from the passphrase, and verifies
+    /// the key check value before opening the fjall keyspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::WrongPassphrase`] if the passphrase is incorrect.
+    /// Returns [`VaultError::Locked`] if another process holds the lock.
+    /// Returns [`VaultError::InvalidHeader`] if the header is malformed.
+    pub fn open(path: impl AsRef<Path>, passphrase: &[u8]) -> Result<Self, VaultError> {
+        let path = path.as_ref();
+        let lock = acquire_lock(path)?;
+
+        let header_bytes = fs::read(path.join(HEADER_FILE)).context(IoSnafu { path })?;
+        let header: StoredHeader =
+            serde_json::from_slice(&header_bytes).context(SerializationSnafu)?;
+
+        if header.version != VAULT_VERSION {
+            return Err(VaultError::InvalidHeader {
+                reason: format!(
+                    "unsupported version {}, expected {VAULT_VERSION}",
+                    header.version
+                ),
+            });
+        }
+
+        let key = crypto::derive_key(passphrase, &header.salt);
+
+        let plaintext =
+            decrypt(&key, &header.key_check).map_err(|_| VaultError::WrongPassphrase)?;
+        if plaintext != KEY_CHECK_PLAINTEXT {
+            return WrongPassphraseSnafu.fail();
+        }
+
+        let (db, keyspace) = open_fjall(&path.join(DATA_DIR))?;
+
+        Ok(Self {
+            db,
+            keyspace,
+            key,
+            _lock: lock,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Stores a new credential in the vault.
+    ///
+    /// The secret is encrypted before writing to the backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::DuplicateEntry`] if an entry with this name exists.
+    /// Returns [`VaultError::EntryCrypto`] if encryption fails.
+    pub fn add(
+        &self,
+        name: &str,
+        credential_type: CredentialType,
+        secret: &[u8],
+    ) -> Result<(), VaultError> {
+        if self.keyspace.get(name).map_err(fjall_err)?.is_some() {
+            return Err(VaultError::DuplicateEntry {
+                name: name.to_owned(),
+            });
+        }
+
+        let encrypted_secret = encrypt(&self.key, secret).context(EntryCryptoSnafu)?;
+
+        let entry = StoredEntry {
+            credential_type,
+            encrypted_secret,
+            metadata: EntryMetadata {
+                created_at: Timestamp::now(),
+                rotated_at: None,
+                tags: Vec::new(),
+            },
+        };
+
+        let value = serde_json::to_vec(&entry).context(SerializationSnafu)?;
+        self.keyspace.insert(name, value).map_err(fjall_err)?;
+        self.db
+            .persist(fjall::PersistMode::SyncAll)
+            .map_err(fjall_err)?;
+
+        Ok(())
+    }
+
+    /// Retrieves and decrypts a credential by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::EntryNotFound`] if no entry with this name exists.
+    /// Returns [`VaultError::EntryCrypto`] if decryption fails.
+    pub fn get(&self, name: &str) -> Result<DecryptedEntry, VaultError> {
+        let raw = self.keyspace.get(name).map_err(fjall_err)?.ok_or_else(|| {
+            VaultError::EntryNotFound {
+                name: name.to_owned(),
+            }
+        })?;
+
+        let entry: StoredEntry = serde_json::from_slice(&raw).context(SerializationSnafu)?;
+
+        let secret = decrypt(&self.key, &entry.encrypted_secret).context(EntryCryptoSnafu)?;
+
+        Ok(DecryptedEntry {
+            name: CompactString::from(name),
+            credential_type: entry.credential_type,
+            secret,
+            metadata: entry.metadata,
+        })
+    }
+
+    /// Lists all entries in the vault (names and metadata only).
+    ///
+    /// No secrets are decrypted or returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::StorageBackend`] on iteration errors.
+    pub fn list(&self) -> Result<Vec<EntryInfo>, VaultError> {
+        let mut entries = Vec::new();
+
+        for guard in self.keyspace.iter() {
+            let (key, value) = guard.into_inner().map_err(fjall_err)?;
+            let name = std::str::from_utf8(&key).map_err(|e| VaultError::StorageBackend {
+                message: format!("invalid UTF-8 key: {e}"),
+            })?;
+            let entry: StoredEntry = serde_json::from_slice(&value).context(SerializationSnafu)?;
+
+            entries.push(EntryInfo {
+                name: CompactString::from(name),
+                credential_type: entry.credential_type,
+                metadata: entry.metadata,
+            });
+        }
+
+        Ok(entries)
+    }
+
+    /// Removes a credential from the vault.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::EntryNotFound`] if no entry with this name exists.
+    pub fn remove(&self, name: &str) -> Result<(), VaultError> {
+        if self.keyspace.get(name).map_err(fjall_err)?.is_none() {
+            return Err(VaultError::EntryNotFound {
+                name: name.to_owned(),
+            });
+        }
+
+        self.keyspace.remove(name).map_err(fjall_err)?;
+        self.db
+            .persist(fjall::PersistMode::SyncAll)
+            .map_err(fjall_err)?;
+
+        Ok(())
+    }
+
+    /// Returns the filesystem path of this vault.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::fmt::Debug for Vault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Vault")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Acquires an advisory lock on the vault directory.
+fn acquire_lock(vault_path: &Path) -> Result<File, VaultError> {
+    let lock_path = vault_path.join(LOCK_FILE);
+
+    // WHY: create_dir_all is idempotent and needed when called from open()
+    // before the lock file exists.
+    fs::create_dir_all(vault_path).context(IoSnafu { path: vault_path })?;
+
+    let file = File::create(&lock_path).context(IoSnafu { path: vault_path })?;
+
+    file.try_lock_exclusive().map_err(|_| VaultError::Locked {
+        path: vault_path.to_path_buf(),
+    })?;
+
+    Ok(file)
+}
+
+/// Opens or creates a fjall database and keyspace at the given path.
+fn open_fjall(data_path: &Path) -> Result<(fjall::Database, fjall::Keyspace), VaultError> {
+    let db =
+        fjall::Database::builder(data_path)
+            .open()
+            .map_err(|e| VaultError::StorageBackend {
+                message: format!("fjall open: {e}"),
+            })?;
+
+    let keyspace = db
+        .keyspace("entries", fjall::KeyspaceCreateOptions::default)
+        .map_err(|e| VaultError::StorageBackend {
+            message: format!("fjall keyspace: {e}"),
+        })?;
+
+    Ok((db, keyspace))
+}
+
+/// Converts a fjall error into a `VaultError::StorageBackend`.
+fn fjall_err(e: impl std::fmt::Display) -> VaultError {
+    VaultError::StorageBackend {
+        message: e.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions use unwrap for clarity")]
+mod tests {
+    use super::*;
+
+    const TEST_PASSPHRASE: &[u8] = b"correct horse battery staple";
+
+    #[test]
+    fn create_and_open_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("test-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        drop(vault);
+
+        let vault = Vault::open(&vault_path, TEST_PASSPHRASE).unwrap();
+        assert_eq!(vault.path(), vault_path);
+    }
+
+    #[test]
+    fn create_fails_if_path_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("existing-vault");
+
+        Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        // Drop implicitly releases the lock.
+
+        let result = Vault::create(&vault_path, TEST_PASSPHRASE);
+        assert!(
+            result.is_err(),
+            "creating a vault at an existing path must fail"
+        );
+    }
+
+    #[test]
+    fn open_with_wrong_passphrase_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("wrong-pass-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        drop(vault);
+
+        let result = Vault::open(&vault_path, b"wrong passphrase");
+        assert!(
+            result.is_err(),
+            "opening with wrong passphrase must return an error"
+        );
+    }
+
+    #[test]
+    fn add_and_get_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("add-get-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+        let secret = b"sk-1234567890abcdef";
+        vault
+            .add("openai-key", CredentialType::ApiKey, secret)
+            .unwrap();
+
+        let entry = vault.get("openai-key").unwrap();
+        assert_eq!(entry.name, "openai-key");
+        assert_eq!(entry.credential_type, CredentialType::ApiKey);
+        assert_eq!(entry.secret, secret);
+    }
+
+    #[test]
+    fn add_duplicate_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("dup-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        vault
+            .add("key-1", CredentialType::Psk, b"secret-a")
+            .unwrap();
+
+        let result = vault.add("key-1", CredentialType::Psk, b"secret-b");
+        assert!(result.is_err(), "adding a duplicate entry name must fail");
+    }
+
+    #[test]
+    fn get_missing_entry_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("missing-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+        let result = vault.get("nonexistent");
+        assert!(result.is_err(), "getting a nonexistent entry must fail");
+    }
+
+    #[test]
+    fn list_returns_metadata_without_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("list-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        vault
+            .add("cred-a", CredentialType::ApiKey, b"secret-a")
+            .unwrap();
+        vault
+            .add("cred-b", CredentialType::Psk, b"secret-b")
+            .unwrap();
+
+        let entries = vault.list().unwrap();
+        assert_eq!(entries.len(), 2, "list must return all entries");
+
+        for info in &entries {
+            assert!(
+                info.name == "cred-a" || info.name == "cred-b",
+                "list must contain expected entry names"
+            );
+        }
+    }
+
+    #[test]
+    fn remove_deletes_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("remove-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        vault
+            .add("disposable", CredentialType::RadioKey, b"key-data")
+            .unwrap();
+
+        vault.remove("disposable").unwrap();
+
+        let result = vault.get("disposable");
+        assert!(result.is_err(), "get after remove must fail");
+
+        let entries = vault.list().unwrap();
+        assert!(entries.is_empty(), "list after remove must be empty");
+    }
+
+    #[test]
+    fn remove_missing_entry_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("remove-missing-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+        let result = vault.remove("ghost");
+        assert!(result.is_err(), "removing a nonexistent entry must fail");
+    }
+
+    #[test]
+    fn entries_persist_across_open_close() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("persist-vault");
+
+        let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+        vault
+            .add("persistent", CredentialType::Certificate, b"cert-pem")
+            .unwrap();
+        drop(vault);
+
+        let vault = Vault::open(&vault_path, TEST_PASSPHRASE).unwrap();
+        let entry = vault.get("persistent").unwrap();
+        assert_eq!(entry.secret, b"cert-pem", "secret must survive close/open");
+    }
+
+    #[test]
+    fn concurrent_open_fails_with_lock_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault_path = dir.path().join("lock-vault");
+
+        let _vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+        let result = Vault::open(&vault_path, TEST_PASSPHRASE);
+        assert!(result.is_err(), "concurrent open must fail with lock error");
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `Vault` struct backed by fjall for encrypted credential CRUD
- `create`/`open` with Argon2id key derivation and ChaCha20-Poly1305 key check verification
- `add`/`get`/`list`/`remove` for credential management, each entry individually encrypted
- Advisory file locking (fs2) to prevent concurrent vault access
- 10 tests covering all acceptance criteria: round-trip, wrong passphrase rejection, duplicate detection, persistence, concurrent open detection

## Test plan

- [x] `Vault::create` + `Vault::open` round-trip works
- [x] `add` → `get` returns original secret
- [x] `list` returns metadata without decrypted secrets
- [x] `remove` deletes the entry
- [x] Wrong passphrase on `open` returns error (not garbage data)
- [x] Concurrent `open` fails with lock error
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (307 tests, 0 failures)

## Observations

- **Debt**: Two `SALT_LEN` constants exist (`vault::SALT_LEN = 16`, `crypto::SALT_LEN = 32`). The vault header used 16-byte salts; the new storage module uses 32-byte salts from `crypto::generate_salt()`. Should unify. (`crates/kryphos/src/vault.rs:12`, `crates/kryphos/src/crypto.rs:14`)
- **Idea**: `DecryptedEntry.secret` is a plain `Vec<u8>`. Consider wrapping in `zeroize::Zeroizing<Vec<u8>>` so secrets are cleared on drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)