### PR TITLE
docs: fix writing standard violations across 6 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ cargo test -p <crate>                  # Single crate
 cargo clippy --workspace               # Lint (zero warnings)
 ```
 
-## Key Patterns
+## Key patterns
 
 - **Errors:** `snafu` with `.context()` propagation and `Location` tracking
 - **IDs:** Newtypes for all domain IDs
@@ -34,7 +34,7 @@ cargo clippy --workspace               # Lint (zero warnings)
 - **Visibility:** `pub(crate)` by default
 - **Naming:** Greek names per [docs/gnomon.md](docs/gnomon.md), registry at [docs/lexicon.md](docs/lexicon.md)
 
-## Before Submitting
+## Before submitting
 
 1. `cargo test -p <affected-crate>` passes
 2. `cargo clippy --workspace` passes with zero warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ cargo clippy --workspace               # Lint (zero warnings)
 ## Before Submitting
 
 1. `cargo test -p <affected-crate>` passes
-2. `cargo clippy --workspace` — zero warnings
+2. `cargo clippy --workspace` passes with zero warnings
 3. No `unwrap()` in library code
 4. New errors use snafu with context
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-I keep coming back to the same problem - every tool I use for radio, mesh networking, spectrum monitoring, network security, or communications is a separate thing. Separate interfaces, separate data models, separate mental contexts. A mesh node goes offline while frequency activity spikes nearby and my network IDS fires an alert. Three tools. Three windows. No one connecting the dots.
+Every tool for radio, mesh networking, spectrum monitoring, network security, or communications is a separate thing. Separate interfaces, separate data models, separate mental contexts. A mesh node goes offline while frequency activity spikes nearby and a network IDS fires an alert. Three tools. Three windows. No one connecting the dots.
 
 Akroasis is the attempt to fix that.
 
@@ -14,7 +14,7 @@ One system. One signal model. Every domain produces typed signals into the same 
 
 ---
 
-## What It Does
+## What it does
 
 | Domain | Crate | What |
 |--------|-------|------|
@@ -30,7 +30,7 @@ One system. One signal model. Every domain produces typed signals into the same 
 | **Navigation** | chorografia | RF propagation modeling, infrastructure dependency graphs, cascade analysis. Vehicle and foot navigation with offline OSM maps. Military planning overlays. Space weather integration for HF propagation prediction. |
 | **Knowledge** | pinax | Offline knowledge repository - frequency databases, protocol specs, equipment manuals, topo maps, emergency procedures, vulnerability databases. Compressed, indexed, searchable. When the internet dies, the knowledge survives. |
 | **Privacy** | lethe | VPN/proxy management, anonymization, metadata scrubbing, IMSI catcher detection, continuous OPSEC scoring. The etymological complement to [Aletheia](https://github.com/forkwright/aletheia) - same root (λήθη), opposite directions. |
-| **Interface** | opsis | TUI (ratatui), native app (Tauri), web UI (Axum over Tailscale). Spectrum waterfall, mesh topology, intelligence dashboard, map display, after-action replay. |
+| **Interface** | opsis | TUI (ratatui), native app (Dioxus), web UI (Axum over Tailscale). Spectrum waterfall, mesh topology, intelligence dashboard, map display, after-action replay. |
 
 Foundation crates: **koinon** (shared types, signal model, entity index, temporal engine), **kryphos** (encryption, key management, credential vault, identity segregation).
 
@@ -70,7 +70,7 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 
 ---
 
-## Design Constraints
+## Design constraints
 
 - **Standalone.** Runs without internet, without an LLM, without anything but the hardware in front of you. Grid-down capable.
 - **Sovereignty.** Every protocol owned. No cloud dependencies, no subscriptions, no external trust.
@@ -84,7 +84,7 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 
 | | |
 |---|---|
-| Language | Rust (edition 2024, MSRV 1.85) |
+| Language | Rust (edition 2024, MSRV in Cargo.toml) |
 | Errors | snafu (context wrapping, not thiserror) |
 | Async | tokio, native async traits |
 | SDR runtime | FutureSDR (async block graph) |
@@ -95,7 +95,7 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 | Maps | OSM vector tiles, SRTM elevation |
 | Search | tantivy (full-text indexing) |
 | TUI | ratatui |
-| Desktop | Tauri |
+| Desktop | Dioxus |
 | Web | Axum |
 | License | AGPL-3.0-or-later |
 
@@ -103,15 +103,15 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 
 ## Documentation
 
-- [standards/STANDARDS.md](standards/STANDARDS.md) — Coding standards (universal + per-language)
-- [docs/gnomon.md](docs/gnomon.md) — Naming methodology
-- [docs/lexicon.md](docs/lexicon.md) — Project name registry
+- [standards/STANDARDS.md](standards/STANDARDS.md): Coding standards (universal + per-language)
+- [docs/gnomon.md](docs/gnomon.md): Naming methodology
+- [docs/lexicon.md](docs/lexicon.md): Project name registry
 
 ## Status
 
-Scaffolded. Research phase complete for radio protocols, Meshtastic, SDR ecosystem. Architecture finalized. Not yet under active development - [Aletheia](https://github.com/forkwright/aletheia) cutover comes first.
+Wave 1 (kryphos, 7 PRs) and Wave 2 (syntonia, 7 PRs) are complete. Architecture finalized. Active development ongoing.
 
-The scope is massive. I don't know if one person builds all of this. But the architecture makes each domain independent - a crate with clear boundaries, producing typed signals into the shared model. The pieces don't need to arrive simultaneously. They just need to speak the same language when they do.
+The scope is massive. The architecture makes each domain independent: a crate with clear boundaries, producing typed signals into the shared model. The pieces don't need to arrive simultaneously. They just need to speak the same language when they do.
 
 ---
 
@@ -125,7 +125,7 @@ Developed against:
 - **Compute:** Linux server, ruggedized field laptop, Raspberry Pi
 - **Proximity:** nRF52840 (BLE), Proxmark3 (NFC/RFID), WiFi monitor mode adapters
 
-Hardware support is additive — if it speaks serial, USB, or IP, it can be integrated.
+Hardware support is additive: if it speaks serial, USB, or IP, it can be integrated.
 
 ---
 
@@ -135,7 +135,7 @@ Hardware support is additive — if it speaks serial, USB, or IP, it can be inte
 
 Names follow [gnomon](https://github.com/forkwright/aletheia/blob/main/docs/gnomon.md) - the naming philosophy where each name reveals its essential nature across four layers of reading.
 
-**Lethe** (λήθη) and **Aletheia** (ἀ-λήθεια) share the same root. One unconceals truth. The other conceals the operator. Same word, opposite directions. I keep thinking about that pairing - two systems built by the same person, one for understanding and one for sovereignty, and the Greek already knew they were the same thing.
+**Lethe** (λήθη) and **Aletheia** (ἀ-λήθεια) share the same root. One unconceals truth. The other conceals the operator. Same word, opposite directions. Two systems, one for understanding and one for sovereignty, and the Greek already knew they were the same thing.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Single Rust binary. 17 crates across 5 layers. All domains produce typed `GeoSignal` into a shared pipeline.
 
-## Layer Structure
+## Layer structure
 
 ```
 Interface:      opsis (TUI/web/native)
@@ -12,7 +12,7 @@ Collection:     syntonia, kerykeion, dektis, engys, aspis, skopos, peira
 Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 ```
 
-## Crate Registry
+## Crate registry
 
 | Crate | Layer | Purpose |
 |-------|-------|---------|
@@ -34,7 +34,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **opsis** | Interface | TUI, Dioxus native app, web UI |
 | **akroasis** | Binary | CLI entrypoint, subcommand routing |
 
-## Key Decisions
+## Key decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
@@ -49,7 +49,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | SDR | Own dataflow engine | FutureSDR dependency risk too high (single maintainer, 0.0.x) |
 | Mesh | Meshtastic official crate + own crypto | Transport via crate, encryption/topology/routing ourselves |
 
-## Dependency Philosophy
+## Dependency philosophy
 
 "Own the interface, depend on the implementation only when the implementation is trustworthy." When a crate is single-maintainer, pre-1.0, or provides a thin wrapper over a kernel/hardware interface we understand, we build our own. See `scope.md` -> Ownership Corrections for the full audit.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Architecture — Akroasis
+# Architecture: Akroasis
 
 Single Rust binary. 17 crates across 5 layers. All domains produce typed `GeoSignal` into a shared pipeline.
 
@@ -31,7 +31,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **praxis** | Orchestration | Automation engine, playbooks, event triggers, state machines |
 | **chorografia** | Model | Geographic model, RF propagation, navigation, terrain |
 | **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps |
-| **opsis** | Interface | TUI, Tauri native app, web UI |
+| **opsis** | Interface | TUI, Dioxus native app, web UI |
 | **akroasis** | Binary | CLI entrypoint, subcommand routing |
 
 ## Key Decisions
@@ -55,8 +55,5 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 
 ## References
 
-- Full scope: `/media/theke/projects/akroasis/planning/scope.md`
-- Roadmap: `/media/theke/projects/akroasis/planning/roadmap.md`
-- Vision: `/media/theke/projects/akroasis/planning/vision.md`
-- Research results: `/media/theke/projects/akroasis/research/`
+- Planning docs (scope, roadmap, vision, research): live in the kanon repo
 - Naming: `gnomon.md`, `lexicon.md`

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -23,7 +23,7 @@ See `ARCHITECTURE.md` for the crate map, layer structure, and key decisions.
 
 Full phase details: kanon repo roadmap.
 
-## Related Projects
+## Related projects
 
 | Project | Relationship |
 |---------|-------------|

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -2,9 +2,9 @@
 
 Communications sovereignty, RF intelligence, and operational awareness platform. 17 crates, 10 capability domains, one shared signal model.
 
-## Current State
+## Current state
 
-Phase 0 (Foundation) in progress. 2 PRs merged (koinon scaffold + tamper-evident log). 5 hygiene PRs merged.
+Phases 0, 1, and 2 complete. Wave 1 (kryphos, 7 PRs) and Wave 2 (syntonia, 7 PRs) merged. Foundation and radio management layers are done.
 
 ## Architecture
 
@@ -14,21 +14,21 @@ See `ARCHITECTURE.md` for the crate map, layer structure, and key decisions.
 
 | Phase | Domain | Status |
 |-------|--------|--------|
-| 0 | Foundation + research | In progress |
-| 1 | Radio management (syntonia) | Queued |
-| 2 | Mesh core (kerykeion) | Queued |
+| 0 | Foundation + research | Complete |
+| 1 | Radio management (syntonia) | Complete |
+| 2 | Mesh core (kerykeion) | Complete |
 | 3 | SDR foundation (dektis) | Queued |
 | 4 | Signal intelligence (semaino + ichneutes) | Queued |
 | 5-14 | Network defense through Aletheia integration | Planned |
 
-Full phase details: `/media/theke/projects/akroasis/planning/roadmap.md`
+Full phase details: kanon repo roadmap.
 
 ## Related Projects
 
 | Project | Relationship |
 |---------|-------------|
 | [Aletheia](https://github.com/forkwright/aletheia) | Akroasis plugs into Aletheia as a thesauros domain pack (Phase 14). Standalone otherwise. |
-| [Harmonia](https://github.com/forkwright/harmonia) | Sibling project — same toolchain and patterns, different domain. |
+| [Harmonia](https://github.com/forkwright/harmonia) | Sibling project: same toolchain and patterns, different domain. |
 
 ## References
 

--- a/docs/gnomon.md
+++ b/docs/gnomon.md
@@ -1,30 +1,30 @@
 # Gnomon
 
-*γνώμων — that which reveals by indicating*
+*γνώμων: that which reveals by indicating*
 
-A sundial's gnomon doesn't contain time. It casts a shadow that makes time legible. The best names work the same way — they don't describe what something is. They reveal what was already there.
+A sundial's gnomon doesn't contain time. It casts a shadow that makes time legible. The best names work the same way: they don't describe what something is. They reveal what was already there.
 
 ---
 
 ## Why Greek
 
-Ancient Greek was engineered across centuries for a single purpose — distinguishing between closely related things that matter. Where English has "knowledge," Greek has episteme (systematic knowledge), gnosis (direct acquaintance), techne (craft knowledge), phronesis (practical wisdom), and nous (direct apprehension). These aren't synonyms. They're fundamentally different stances toward the world.
+Ancient Greek was engineered across centuries for a single purpose: distinguishing between closely related things that matter. Where English has "knowledge," Greek has episteme (systematic knowledge), gnosis (direct acquaintance), techne (craft knowledge), phronesis (practical wisdom), and nous (direct apprehension). These aren't synonyms. They're fundamentally different stances toward the world.
 
 This precision extends beyond epistemics. Where English has "form," Greek has morphe (the form that makes a thing *this kind* of thing), schema (the shape or figure), eidos (the visible form), and typos (the impression left by a blow). Where English has "order," Greek has taxis (arrangement), kosmos (the beautiful order of a whole), and logos (the rational principle that structures).
 
-When you name a module *Dianoia*, you're not saying "thinking" — you're saying *discursive reasoning that works through problems step by step*, as distinct from noesis (immediate insight) or episteme (systematic knowledge). When you name a platform *Harmonia*, you're not saying "media player" — you're saying *the fitting-together of parts into a concordant whole*. The Greek carries the distinction natively. English requires a paragraph.
+When you name a module *Dianoia*, you're not saying "thinking." You're saying *discursive reasoning that works through problems step by step*, as distinct from noesis (immediate insight) or episteme (systematic knowledge). When you name a platform *Harmonia*, you're not saying "media player." You're saying *the fitting-together of parts into a concordant whole*. The Greek carries the distinction natively. English requires a paragraph.
 
 Greek also offers:
 
 - **Productive compounding.** Roots, prefixes, and suffixes combine systematically. The grammar builds meaning.
 - **Defamiliarization.** An unfamiliar word resists assumption. You have to ask what it means, which means you have to think about what the thing *does*.
-- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology — truth as *unconcealment*, the negation of forgetting.
+- **Density.** Meaning compressed into sound. Aletheia is four syllables carrying an entire ontology: truth as *unconcealment*, the negation of forgetting.
 
 The goal is not erudition. The goal is precision tools for systems that distinguish between many closely related things.
 
 ---
 
-## Building Names
+## Building names
 
 Greek names are constructed, not found. Three components combine.
 
@@ -75,45 +75,45 @@ A name like **προσοχή** (prosoche) is: πρός (toward) + ἔχω (to ho
 
 ---
 
-## The Layer Test
+## The layer test
 
 Every name must work at multiple levels of abstraction simultaneously. This is the primary quality test.
 
 | Layer | What it answers | Failure mode |
 |-------|----------------|--------------|
-| **L1 — Practical** | What does this do? | Too abstract to use |
-| **L2 — Structural** | How does this relate to other things? | Isolated, doesn't compose |
-| **L3 — Philosophical** | What essential nature does this name unconceal? | Decorative, not meaningful |
-| **L4 — Reflexive** | Does the name exhibit what it describes? | Inert, doesn't reward reflection |
+| **L1: Practical** | What does this do? | Too abstract to use |
+| **L2: Structural** | How does this relate to other things? | Isolated, doesn't compose |
+| **L3: Philosophical** | What essential nature does this name unconceal? | Decorative, not meaningful |
+| **L4: Reflexive** | Does the name exhibit what it describes? | Inert, doesn't reward reflection |
 
 A name that works at L1 but not L3 is a label. A name that works at L3 but not L1 is pretension.
 
-**Aletheia** (ἀλήθεια — unconcealment):
+**Aletheia** (ἀλήθεια, unconcealment):
 
 | Layer | Reading |
 |-------|---------|
-| L1 | A cognitive system — agents, memory, orchestration |
+| L1 | A cognitive system: agents, memory, orchestration |
 | L2 | The substrate that makes the other systems possible |
-| L3 | Truth as unconcealment — the negation of forgetting. Not truth as correspondence but truth as *revealing what was hidden* |
-| L4 | The system itself practices unconcealment — surfacing latent knowledge, making hidden patterns legible, refusing to let things stay forgotten |
+| L3 | Truth as unconcealment: the negation of forgetting. Not truth as correspondence but truth as *revealing what was hidden* |
+| L4 | The system itself practices unconcealment, surfacing latent knowledge, making hidden patterns legible, refusing to let things stay forgotten |
 
-**Harmonia** (ἁρμονία — fitting-together):
+**Harmonia** (ἁρμονία, fitting-together):
 
 | Layer | Reading |
 |-------|---------|
-| L1 | A media platform — backend, player, audio core unified |
+| L1 | A media platform: backend, player, audio core unified |
 | L2 | The integration layer that makes disparate media components work as one |
-| L3 | The fitting-together of parts — not mere compatibility but active concordance, each part finding its place within a whole |
+| L3 | The fitting-together of parts, not mere compatibility but active concordance, each part finding its place within a whole |
 | L4 | The platform harmonizes: Mouseion (collection) and Akroasis (listening) joined into a coherent whole. The name describes its own architecture |
 
-**Akroasis** (ἀκρόασις — attentive reception):
+**Akroasis** (ἀκρόασις, attentive reception):
 
 | Layer | Reading |
 |-------|---------|
 | L1 | RF intelligence, mesh networking, communications sovereignty |
 | L2 | The system that makes electromagnetic and digital activity intelligible and actionable |
-| L3 | Not passive hearing but *attentive reception*. Aristotle's Physics was called "Physike Akroasis" — learning through disciplined listening |
-| L4 | The system listens at every level — spectrum, mesh, network, proximity — then understands, then acts |
+| L3 | Not passive hearing but *attentive reception*. Aristotle's Physics was called "Physike Akroasis," learning through disciplined listening |
+| L4 | The system listens at every level: spectrum, mesh, network, proximity, then understands, then acts |
 
 ---
 
@@ -121,9 +121,9 @@ A name that works at L1 but not L3 is a label. A name that works at L3 but not L
 
 Names in a system are not independent. They compose. The relationships between names carry meaning.
 
-**Noesis** and **Dianoia** are the two sides of Plato's divided line — one sees the whole immediately, the other works through it step by step. Placing them in the same system asserts that both modes are necessary.
+**Noesis** and **Dianoia** are the two sides of Plato's divided line: one sees the whole immediately, the other works through it step by step. Placing them in the same system asserts that both modes are necessary.
 
-**Lethe** (λήθη — concealment) and **Aletheia** (ἀ-λήθεια — unconcealment) share the same root, opposite directions. One unconceals truth, the other conceals the operator. The strongest topological pairing in the ecosystem.
+**Lethe** (λήθη, concealment) and **Aletheia** (ἀ-λήθεια, unconcealment) share the same root, opposite directions. One unconceals truth, the other conceals the operator. The strongest topological pairing in the ecosystem.
 
 **Prosoche** (sustained attention) is the *practice* that makes **Aletheia** (unconcealment) possible. You can't reveal what's hidden without attending carefully. The names encode this dependency.
 
@@ -136,19 +136,19 @@ When you add a new name, it must compose with what exists. A name that fits loca
 
 ---
 
-## The Gnomon Principle
+## The Gnomon principle
 
 A gnomon doesn't contain time. It doesn't measure time. It casts a shadow, and the shadow makes time legible.
 
 The best names are gnomons. They indicate without containing. The name Aletheia doesn't *make* the system true. It reveals that the system was already an act of unconcealment. The name Harmonia doesn't *make* the platform coherent. It reveals that the fitting-together of collection and listening was always the essential nature.
 
-A name succeeds as a gnomon when someone encounters it, learns what it means, and feels that the thing has become more itself — not differently described but more clearly *seen*.
+A name succeeds as a gnomon when someone encounters it, learns what it means, and feels that the thing has become more itself, not differently described but more clearly *seen*.
 
 A name fails as a gnomon when the name draws attention to itself rather than to what it names. If you're explaining the name, it's decoration. If the name is explaining the thing, it's a gnomon.
 
 ---
 
-## When Naming
+## When naming
 
 1. **Wait.** Let the thing reveal its nature before fixing the name. Build first, name when the essential nature becomes clear. Premature naming produces labels.
 2. **Identify what needs unconcealing.** Not what the thing *does technically* but what it *essentially is*.
@@ -158,7 +158,7 @@ A name fails as a gnomon when the name draws attention to itself rather than to 
 6. **Check the topology.** Does this name compose with what exists?
 7. **Listen for recognition.** The right name feels discovered, not invented. If you're arguing for why it fits, it doesn't.
 
-### Anti-Patterns
+### Anti-patterns
 
 - **Naming the implementation.** You named what it does technically, not what it essentially is. "Tracker" is an implementation. Prosoche is the essential nature that tracking serves.
 - **Naming too precisely.** A name that works at only one layer is brittle. Essential-nature names survive refactors because the nature persists even when the mechanism changes.
@@ -170,9 +170,9 @@ A name fails as a gnomon when the name draws attention to itself rather than to 
 
 ## Sources
 
-- **Plato** — *Republic* (the divided line: dianoia and noesis), *Meno* (anamnesis), *Theaetetus* (knowledge and perception)
-- **Aristotle** — *Nicomachean Ethics* (ergon, phronesis, techne), *Categories* (fundamental ways a thing can be), *Metaphysics* (energeia, morphe/hyle)
-- **The Stoics** — Epictetus and Marcus Aurelius on prosoche (attention as practice), melete (care as disciplined practice)
-- **Heidegger** — *Being and Time* on aletheia as unconcealment
-- **Jacob Klein** — *Greek Mathematical Thought and the Origin of Algebra* on naming and knowing
-- **Liddell-Scott-Jones** — *Greek-English Lexicon*
+- **Plato**: *Republic* (the divided line: dianoia and noesis), *Meno* (anamnesis), *Theaetetus* (knowledge and perception)
+- **Aristotle**: *Nicomachean Ethics* (ergon, phronesis, techne), *Categories* (fundamental ways a thing can be), *Metaphysics* (energeia, morphe/hyle)
+- **The Stoics**: Epictetus and Marcus Aurelius on prosoche (attention as practice), melete (care as disciplined practice)
+- **Heidegger**: *Being and Time* on aletheia as unconcealment
+- **Jacob Klein**: *Greek Mathematical Thought and the Origin of Algebra* on naming and knowing
+- **Liddell-Scott-Jones**: *Greek-English Lexicon*

--- a/docs/gnomon.md
+++ b/docs/gnomon.md
@@ -136,7 +136,7 @@ When you add a new name, it must compose with what exists. A name that fits loca
 
 ---
 
-## The Gnomon principle
+## The gnomon principle
 
 A gnomon doesn't contain time. It doesn't measure time. It casts a shadow, and the shadow makes time legible.
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -1,11 +1,11 @@
-# Akroasis — Lexicon
+# Akroasis: Lexicon
 
 *Living registry. Updated as crates are added or renamed.*
 *For the naming methodology and construction system, see [gnomon.md](gnomon.md).*
 
 ---
 
-## Project Name
+## Project name
 
 **Akroasis** (ἀκρόασις) - Active listening as a discipline. Not passive hearing but *attentive reception* - the listener who brings understanding to what they receive. Aristotle's Physics was called "Physike Akroasis" - learning through careful listening.
 
@@ -20,9 +20,9 @@
 
 ---
 
-## Crate Names
+## Crate names
 
-### Foundation Layer
+### Foundation layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
@@ -30,7 +30,7 @@
 | **kryphos** | κρύφος | "crypto/identity" | The hidden - encryption, key management, forward secrecy, credential vault, identity/persona management, callsign compliance. That which is kryphos resists discovery by nature. |
 | **lethe** | λήθη | "privacy" | Forgetting - VPN/proxy management, anonymization, metadata scrubbing, counter-surveillance, OPSEC scoring, IMSI catcher detection. The river that makes what passes through it unseen. Etymological complement to Aletheia: ἀ-λήθεια negates λήθη. Same root, opposite directions. Strongest topological pairing in the ecosystem. |
 
-### Collection Layer
+### Collection layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
@@ -42,35 +42,35 @@
 | **skopos** | σκοπός | "OSINT" | The scout on the high ground - the one who sees far and reports back. Feed aggregation, threat intel, asset discovery, web scraping, dark web monitoring. Not a spy (kataskopos) but an observer with purpose. Every scan has a target. |
 | **peira** | πεῖρα | "offensive security" | The trial, the attempt. Penetration testing, vulnerability scanning, wireless security testing. You don't know your defenses until they're tested. Peira is experiential knowledge - the kind that only comes from trying. |
 
-### Processing & Analysis Layer
+### Processing & analysis layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
 | **semaino** | σημαίνω | "signal processing" | To make a sign - the oracle at Delphi "neither speaks nor conceals but *semainei*" - gives signs. Signal aggregation, convergence detection, anomaly baselines, alert deduplication. Reads signs in the noise. |
 | **ichneutes** | ἰχνευτής | "intelligence analysis" | The one who follows tracks. Entity correlation, focal point detection, threat scoring, intelligence synthesis, forensic timeline reconstruction. In Sophocles' satyr play, the tracker follows Apollo's cattle by their hoofprints. The skill is not in seeing the print but in understanding where the trail leads. |
 
-### Orchestration Layer
+### Orchestration layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
 | **praxis** | πρᾶξις | "automation" | Purposeful action. Event-driven triggers, playbooks, PACE communications, operational state machines, scheduled operations. Aristotle distinguished theoria (contemplation), poiesis (production), and praxis (purposeful action). Akroasis has all three - praxis completes the triad. Action taken because the situation demands it. |
 
-### Model & Knowledge Layer
+### Model & knowledge layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
 | **chorografia** | χωρογραφία | "geographic model" | Writing the land - geographic modeling, RF propagation, infrastructure dependency graph, cascade analysis, vehicle/foot navigation, military planning, space weather, terrain, offline map rendering. Ptolemy's term for detailed regional description - intimate knowledge of a specific place. |
 | **pinax** | πίναξ | "knowledge repository" | The register, the catalog. Offline knowledge repository - maps, frequency databases, protocol specs, equipment manuals, emergency procedures, vulnerability databases. Callimachus created the Pinakes to make Alexandria's knowledge *findable*. Not a pile of scrolls - a system. The pinax made knowledge usable. |
 
-### Interface Layer
+### Interface layer
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. TUI (ratatui), native app (Tauri), web UI (Axum over Tailscale). Spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, after-action replay. Three surfaces, one backend. |
+| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. TUI (ratatui), native app (Dioxus), web UI (Axum over Tailscale). Spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, after-action replay. Three surfaces, one backend. |
 
 ---
 
-## Key Topological Relationships
+## Key topological relationships
 
 - **Lethe ↔ Aletheia** - Same root (λήθη), opposite directions. Unconcealment for understanding, concealment for sovereignty. The strongest topological pairing.
 - **Akroasis → Semaino → Ichneutes** - Listen → read signs → follow tracks. The intelligence pipeline.
@@ -83,7 +83,7 @@
 
 ---
 
-## Rejected Names
+## Rejected names
 
 | Name | Meaning | Why Rejected |
 |------|---------|-------------|


### PR DESCRIPTION
## Summary

- Remove em dashes from all 6 files (28 in gnomon.md alone), replacing with colons, commas, parentheses, or separate sentences
- Replace Tauri with Dioxus in README.md, docs/ARCHITECTURE.md, and docs/lexicon.md
- Fix sentence case on all Title Case headers in lexicon.md (10 headers) and gnomon.md (6 headers)
- Rewrite first-person singular in README.md to second/third person
- Update Status section: Wave 1 (kryphos) and Wave 2 (syntonia) complete; remove stale "not under active development" note
- Update phase table in PROJECT.md: phases 0, 1, 2 marked complete
- Remove broken local paths (`/media/theke/projects/akroasis/planning/...`) from ARCHITECTURE.md and PROJECT.md; note that planning docs live in kanon
- Fix CLAUDE.md: `cargo clippy --workspace` em dash line
- Update MSRV reference in README.md to point to Cargo.toml as authoritative source

## Test plan

- [x] Zero em dashes in any changed file (`grep "—" README.md CLAUDE.md docs/ARCHITECTURE.md docs/PROJECT.md docs/lexicon.md docs/gnomon.md` returns nothing)
- [x] All 6 files updated
- [x] No Tauri references in target files
- [x] No broken `/media/theke` paths
- [x] No first-person singular in README.md

Closes #43, closes #44, closes #45, closes #46, closes #47, closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)