### PR TITLE
feat(kerykeion): node discovery, mesh topology graph, and peer tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,11 +1149,13 @@ dependencies = [
  "futures",
  "jiff",
  "koinon",
+ "petgraph",
  "proptest",
  "prost",
  "prost-build",
  "rand_core 0.6.4",
  "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "tokio-serial",
@@ -1458,6 +1460,8 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/kerykeion/Cargo.toml
+++ b/crates/kerykeion/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 koinon = { path = "../koinon" }
 serde = { workspace = true }
+serde_json = { workspace = true }
 snafu = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
@@ -25,6 +26,7 @@ aes = { workspace = true }
 ctr = { workspace = true }
 futures = { workspace = true }
 rand_core = { workspace = true }
+petgraph = { workspace = true }
 
 [build-dependencies]
 prost-build = "0.14.3"

--- a/crates/kerykeion/src/config.rs
+++ b/crates/kerykeion/src/config.rs
@@ -86,6 +86,9 @@ pub struct TopologyConfig {
     pub stale_node_timeout_secs: u64,
     /// Whether to request neighbor info packets from the radio.
     pub neighbor_info_enabled: bool,
+    /// Node numbers manually designated as gateways.
+    #[serde(default)]
+    pub gateway_nodes: Vec<u32>,
 }
 
 impl Default for TopologyConfig {
@@ -94,6 +97,7 @@ impl Default for TopologyConfig {
             traceroute_interval_secs: 3600,
             stale_node_timeout_secs: 7200,
             neighbor_info_enabled: true,
+            gateway_nodes: Vec::new(),
         }
     }
 }

--- a/crates/kerykeion/src/discovery.rs
+++ b/crates/kerykeion/src/discovery.rs
@@ -1,0 +1,272 @@
+//! Active and passive mesh node discovery manager.
+
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::TopologyConfig;
+use crate::connection::MeshConnection;
+use crate::processor::PacketProcessor;
+use crate::signals::{MeshEvent, mesh_event_to_signal};
+use crate::types::NodeNum;
+use koinon::GeoSignal;
+
+/// Node lifecycle state based on time since last heard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeState {
+    /// Node is actively communicating.
+    Active,
+    /// Not heard within 1× stale timeout.
+    Stale,
+    /// Not heard within 2× stale timeout.
+    Offline,
+    /// Not heard within 3× stale timeout — removed from active topology.
+    Removed,
+}
+
+/// Determine a node's lifecycle state based on elapsed time since last heard.
+#[must_use]
+pub fn classify_node_state(elapsed: Duration, stale_timeout: Duration) -> NodeState {
+    if elapsed < stale_timeout {
+        NodeState::Active
+    } else if elapsed < stale_timeout * 2 {
+        NodeState::Stale
+    } else if elapsed < stale_timeout * 3 {
+        NodeState::Offline
+    } else {
+        NodeState::Removed
+    }
+}
+
+/// Build a `ToRadio` traceroute request packet targeting `dest_node`.
+///
+/// The packet uses `TRACEROUTE_APP` (portnum 70) with `want_response = true`.
+#[must_use]
+pub const fn build_traceroute_request(dest_node: NodeNum) -> crate::proto::ToRadio {
+    use crate::proto::{Data, MeshPacket, ToRadio, mesh_packet, to_radio};
+
+    let data = Data {
+        portnum: 70, // TRACEROUTE_APP
+        payload: Vec::new(),
+        want_response: true,
+        dest: 0,
+        source: 0,
+        request_id: 0,
+        reply_id: 0,
+        emoji: vec![],
+    };
+
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::Packet(MeshPacket {
+            from: 0, // WHY: radio fills in from field
+            to: dest_node.0,
+            channel: 0,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(data)),
+            id: 0, // WHY: radio assigns packet ID
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 7,
+            want_ack: true,
+            priority: 70, // RELIABLE
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 0,
+        })),
+    }
+}
+
+/// Run the discovery loop: periodic traceroutes and stale node detection.
+///
+/// Runs as a tokio task cancelled via `token`. Sends traceroute requests through
+/// `conn` and processes stale detection based on `config` timeouts.
+///
+/// # Cancellation
+///
+/// Exits cleanly when `token` is cancelled. Cancel-safe: all state mutations
+/// are completed before the next `.await`.
+pub async fn run_discovery<C>(
+    conn: &tokio::sync::Mutex<C>,
+    processor: &tokio::sync::Mutex<PacketProcessor>,
+    config: &TopologyConfig,
+    tx: &broadcast::Sender<GeoSignal>,
+    token: CancellationToken,
+) where
+    C: MeshConnection,
+{
+    let traceroute_interval = Duration::from_secs(config.traceroute_interval_secs);
+    let stale_timeout = Duration::from_secs(config.stale_node_timeout_secs);
+    let mut traceroute_timer = tokio::time::interval(traceroute_interval);
+    traceroute_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let mut stale_timer = tokio::time::interval(stale_timeout / 2);
+    stale_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // WHY: skip the first immediate tick for both timers.
+    traceroute_timer.tick().await;
+    stale_timer.tick().await;
+
+    loop {
+        tokio::select! {
+            biased;
+
+            () = token.cancelled() => {
+                tracing::debug!("discovery task cancelled");
+                break;
+            }
+
+            _ = traceroute_timer.tick() => {
+                send_traceroutes(conn, processor, token.clone()).await;
+            }
+
+            _ = stale_timer.tick() => {
+                run_stale_detection(processor, stale_timeout, tx).await;
+            }
+        }
+    }
+}
+
+/// Send traceroute requests to all known nodes.
+async fn send_traceroutes<C>(
+    conn: &tokio::sync::Mutex<C>,
+    processor: &tokio::sync::Mutex<PacketProcessor>,
+    token: CancellationToken,
+) where
+    C: MeshConnection,
+{
+    let nodes: Vec<NodeNum> = {
+        let proc = processor.lock().await;
+        let my_node = proc.node_db().my_node();
+        proc.node_db()
+            .iter()
+            .map(|(&num, _)| num)
+            .filter(|num| Some(*num) != my_node)
+            .collect()
+    };
+
+    for node in nodes {
+        if token.is_cancelled() {
+            break;
+        }
+        let request = build_traceroute_request(node);
+        let mut connection = conn.lock().await;
+        if let Err(e) = connection.send(request).await {
+            tracing::warn!(node = node.0, error = %e, "failed to send traceroute request");
+        }
+    }
+}
+
+/// Check for stale/offline nodes and emit appropriate events.
+async fn run_stale_detection(
+    processor: &tokio::sync::Mutex<PacketProcessor>,
+    stale_timeout: Duration,
+    tx: &broadcast::Sender<GeoSignal>,
+) {
+    let mut proc = processor.lock().await;
+    let now = jiff::Timestamp::now();
+
+    let offline_nodes: Vec<NodeNum> = proc
+        .node_db()
+        .iter()
+        .filter_map(|(&num, node)| {
+            let last_heard = node.last_heard?;
+            let elapsed_ms = now
+                .as_millisecond()
+                .saturating_sub(last_heard.as_millisecond());
+            #[expect(
+                clippy::cast_sign_loss,
+                reason = "elapsed_ms is always non-negative since now >= last_heard"
+            )]
+            let elapsed = Duration::from_millis(elapsed_ms as u64);
+            let state = classify_node_state(elapsed, stale_timeout);
+
+            if state == NodeState::Offline {
+                Some(num)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for node in &offline_nodes {
+        let event = MeshEvent::NodeOffline { node: *node };
+        let position = proc.node_db().get(*node).and_then(|n| n.position.as_ref());
+        let signal = mesh_event_to_signal(&event, position);
+        let _ = tx.send(signal);
+    }
+
+    // WHY: remove nodes past 3× timeout from the active topology.
+    proc.topology_mut().remove_stale_links(stale_timeout * 3);
+
+    // WHY: check for partitions after removing stale links.
+    let components = proc.topology().connected_components();
+    drop(proc);
+    if components.len() > 1 {
+        let event = MeshEvent::PartitionDetected { components };
+        let signal = mesh_event_to_signal(&event, None);
+        let _ = tx.send(signal);
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_active_within_timeout() {
+        let timeout = Duration::from_secs(7200);
+        assert_eq!(
+            classify_node_state(Duration::from_secs(3600), timeout),
+            NodeState::Active
+        );
+    }
+
+    #[test]
+    fn classify_stale_at_1x_timeout() {
+        let timeout = Duration::from_secs(7200);
+        assert_eq!(
+            classify_node_state(Duration::from_secs(7200), timeout),
+            NodeState::Stale
+        );
+    }
+
+    #[test]
+    fn classify_offline_at_2x_timeout() {
+        let timeout = Duration::from_secs(7200);
+        assert_eq!(
+            classify_node_state(Duration::from_secs(14400), timeout),
+            NodeState::Offline
+        );
+    }
+
+    #[test]
+    fn classify_removed_at_3x_timeout() {
+        let timeout = Duration::from_secs(7200);
+        assert_eq!(
+            classify_node_state(Duration::from_secs(21601), timeout),
+            NodeState::Removed
+        );
+    }
+
+    #[test]
+    fn traceroute_request_targets_correct_node() {
+        let req = build_traceroute_request(NodeNum(0x1234));
+        match req.payload_variant {
+            Some(crate::proto::to_radio::PayloadVariant::Packet(pkt)) => {
+                assert_eq!(pkt.to, 0x1234);
+                assert!(pkt.want_ack);
+                match pkt.payload_variant {
+                    Some(crate::proto::mesh_packet::PayloadVariant::Decoded(data)) => {
+                        assert_eq!(data.portnum, 70);
+                        assert!(data.want_response);
+                    }
+                    _ => panic!("expected decoded payload"),
+                }
+            }
+            _ => panic!("expected packet payload"),
+        }
+    }
+}

--- a/crates/kerykeion/src/error.rs
+++ b/crates/kerykeion/src/error.rs
@@ -156,6 +156,28 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Protobuf payload could not be decoded for the given portnum.
+    #[snafu(display("failed to decode {portnum} payload: {source}"))]
+    PayloadDecode {
+        /// Port number name for diagnostics.
+        portnum: String,
+        /// Underlying prost decode error.
+        source: prost::DecodeError,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Topology snapshot deserialization failed.
+    #[snafu(display("topology snapshot error: {source}"))]
+    TopologySnapshot {
+        /// Underlying JSON error.
+        source: serde_json::Error,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 // WHY: tokio_util::codec::Decoder::Error and Encoder::Error both require

--- a/crates/kerykeion/src/gateway.rs
+++ b/crates/kerykeion/src/gateway.rs
@@ -1,0 +1,201 @@
+//! Gateway node detection and health tracking.
+
+use std::collections::HashMap;
+
+use tokio::time::Instant;
+
+use crate::config::TopologyConfig;
+use crate::topology::MeshTopology;
+use crate::types::NodeNum;
+
+/// Device role values from Meshtastic `Config.DeviceConfig.Role` protobuf enum.
+mod device_role {
+    pub const ROUTER_CLIENT: u32 = 3;
+}
+
+/// Tracks which nodes are identified as gateways and their health.
+pub struct GatewayDetector {
+    /// Manually designated gateway nodes from config.
+    manual_gateways: Vec<NodeNum>,
+    /// Auto-detected gateway nodes with last-seen time.
+    detected_gateways: HashMap<NodeNum, GatewayState>,
+}
+
+/// Health state for a tracked gateway node.
+#[derive(Debug, Clone)]
+pub struct GatewayState {
+    /// When this gateway was last seen.
+    pub last_seen: Instant,
+    /// Best observed SNR from the server node to this gateway.
+    pub snr: f32,
+    /// Whether this node was auto-detected (vs. manually configured).
+    pub auto_detected: bool,
+}
+
+impl GatewayDetector {
+    /// Create a new detector from configuration.
+    #[must_use]
+    pub fn new(config: &TopologyConfig) -> Self {
+        Self {
+            manual_gateways: config.gateway_nodes.iter().map(|&n| NodeNum(n)).collect(),
+            detected_gateways: HashMap::new(),
+        }
+    }
+
+    /// Check if a node qualifies as a gateway based on its device config.
+    ///
+    /// A node is auto-detected as a gateway if it has `role == ROUTER_CLIENT`
+    /// AND either wifi is enabled or MQTT is enabled.
+    pub fn evaluate_node(
+        &mut self,
+        node: NodeNum,
+        role: u32,
+        wifi_enabled: bool,
+        mqtt_enabled: bool,
+        snr: f32,
+    ) {
+        let is_gateway = role == device_role::ROUTER_CLIENT && (wifi_enabled || mqtt_enabled);
+
+        if is_gateway {
+            let state = self
+                .detected_gateways
+                .entry(node)
+                .or_insert_with(|| GatewayState {
+                    last_seen: Instant::now(),
+                    snr,
+                    auto_detected: true,
+                });
+            state.last_seen = Instant::now();
+            state.snr = snr;
+        } else if let Some(state) = self.detected_gateways.get(&node) {
+            // WHY: only remove auto-detected gateways; manual ones persist.
+            if state.auto_detected {
+                self.detected_gateways.remove(&node);
+            }
+        }
+    }
+
+    /// Mark a gateway as seen (update `last_seen` and SNR).
+    pub fn mark_seen(&mut self, node: NodeNum, snr: f32) {
+        if let Some(state) = self.detected_gateways.get_mut(&node) {
+            state.last_seen = Instant::now();
+            state.snr = snr;
+        }
+    }
+
+    /// Return all nodes identified as gateways (manual + auto-detected).
+    #[must_use]
+    pub fn gateway_nodes(&self) -> Vec<NodeNum> {
+        let mut nodes: Vec<NodeNum> = self.manual_gateways.clone();
+        for &node in self.detected_gateways.keys() {
+            if !nodes.contains(&node) {
+                nodes.push(node);
+            }
+        }
+        nodes
+    }
+
+    /// Check if a specific node is a gateway.
+    #[must_use]
+    pub fn is_gateway(&self, node: NodeNum) -> bool {
+        self.manual_gateways.contains(&node) || self.detected_gateways.contains_key(&node)
+    }
+
+    /// Return the healthiest gateway — lowest cost path from the server node.
+    ///
+    /// Prefers gateways with higher SNR and more recent last-seen time.
+    #[must_use]
+    pub fn best_gateway(&self, topology: &MeshTopology, server_node: NodeNum) -> Option<NodeNum> {
+        self.gateway_nodes()
+            .into_iter()
+            .filter_map(|gw| {
+                let hops = topology.hop_count(server_node, gw)?;
+                let snr = self.detected_gateways.get(&gw).map_or(0.0, |s| s.snr);
+                // WHY: score combines hop distance (weighted) and SNR; lower is better.
+                let score = f32::from(hops).mul_add(10.0, -snr);
+                Some((gw, score))
+            })
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(gw, _)| gw)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_config(gw_nodes: Vec<u32>) -> TopologyConfig {
+        TopologyConfig {
+            gateway_nodes: gw_nodes,
+            ..TopologyConfig::default()
+        }
+    }
+
+    #[test]
+    fn manual_gateways_from_config() {
+        let det = GatewayDetector::new(&make_config(vec![100, 200]));
+        assert!(det.is_gateway(NodeNum(100)));
+        assert!(det.is_gateway(NodeNum(200)));
+        assert!(!det.is_gateway(NodeNum(300)));
+    }
+
+    #[test]
+    fn auto_detect_router_client_with_wifi() {
+        let mut det = GatewayDetector::new(&make_config(vec![]));
+        det.evaluate_node(NodeNum(42), device_role::ROUTER_CLIENT, true, false, 10.0);
+        assert!(det.is_gateway(NodeNum(42)));
+    }
+
+    #[test]
+    fn auto_detect_router_client_with_mqtt() {
+        let mut det = GatewayDetector::new(&make_config(vec![]));
+        det.evaluate_node(NodeNum(42), device_role::ROUTER_CLIENT, false, true, 10.0);
+        assert!(det.is_gateway(NodeNum(42)));
+    }
+
+    #[test]
+    fn non_router_client_not_auto_detected() {
+        let mut det = GatewayDetector::new(&make_config(vec![]));
+        det.evaluate_node(NodeNum(42), 0, true, true, 10.0);
+        assert!(!det.is_gateway(NodeNum(42)));
+    }
+
+    #[test]
+    fn gateway_nodes_combines_manual_and_auto() {
+        let mut det = GatewayDetector::new(&make_config(vec![100]));
+        det.evaluate_node(NodeNum(200), device_role::ROUTER_CLIENT, true, false, 5.0);
+        let gateways = det.gateway_nodes();
+        assert_eq!(gateways.len(), 2);
+        assert!(gateways.contains(&NodeNum(100)));
+        assert!(gateways.contains(&NodeNum(200)));
+    }
+
+    #[test]
+    fn best_gateway_prefers_closest() {
+        let mut det = GatewayDetector::new(&make_config(vec![]));
+        det.evaluate_node(NodeNum(10), device_role::ROUTER_CLIENT, true, false, 10.0);
+        det.evaluate_node(NodeNum(20), device_role::ROUTER_CLIENT, true, false, 10.0);
+
+        let mut topo = MeshTopology::new();
+        topo.update_link(NodeNum(1), NodeNum(10), 10.0); // 1 hop
+        topo.update_link(NodeNum(1), NodeNum(5), 10.0);
+        topo.update_link(NodeNum(5), NodeNum(20), 10.0); // 2 hops
+
+        let best = det.best_gateway(&topo, NodeNum(1));
+        assert_eq!(best, Some(NodeNum(10)));
+    }
+
+    #[test]
+    fn auto_detected_gateway_removed_on_role_change() {
+        let mut det = GatewayDetector::new(&make_config(vec![]));
+        det.evaluate_node(NodeNum(42), device_role::ROUTER_CLIENT, true, false, 10.0);
+        assert!(det.is_gateway(NodeNum(42)));
+
+        // WHY: node changes role to CLIENT (0) — no longer qualifies.
+        det.evaluate_node(NodeNum(42), 0, true, false, 10.0);
+        assert!(!det.is_gateway(NodeNum(42)));
+    }
+}

--- a/crates/kerykeion/src/lib.rs
+++ b/crates/kerykeion/src/lib.rs
@@ -13,16 +13,26 @@
 //! - Heartbeat keepalive: [`heartbeat::run_heartbeat`]
 //! - Node tracking: [`node_db::NodeDb`]
 //! - Collection pipeline integration: [`collector::MeshCollector`]
+//! - Mesh topology graph: [`topology::MeshTopology`]
+//! - Packet dispatch: [`processor::PacketProcessor`]
+//! - Node discovery: [`discovery::run_discovery`]
+//! - Gateway detection: [`gateway::GatewayDetector`]
+//! - Signal production: [`signals::MeshEvent`]
 
 pub mod codec;
 pub mod collector;
 pub mod config;
 pub mod connection;
 pub mod crypto;
+pub mod discovery;
 pub mod error;
+pub mod gateway;
 pub mod handshake;
 pub mod heartbeat;
 pub mod node_db;
+pub mod processor;
+pub mod signals;
+pub mod topology;
 pub mod transport;
 pub mod types;
 
@@ -43,10 +53,15 @@ pub use collector::{Collector, MeshCollector};
 pub use config::{ChannelPsk, ConnectionConfig, MeshConfig, StoreForwardConfig, TopologyConfig};
 pub use connection::MeshConnection;
 pub use crypto::{DEFAULT_PSK, decrypt, encrypt};
+pub use discovery::{NodeState, build_traceroute_request, classify_node_state, run_discovery};
 pub use error::Error;
+pub use gateway::GatewayDetector;
 pub use handshake::{HandshakeResult, handshake};
 pub use node_db::{DeviceMetrics, MeshNode, NodeDb, NodePosition, UserInfo};
+pub use processor::PacketProcessor;
 pub use proto::{FromRadio, ToRadio};
+pub use signals::{MeshEvent, mesh_event_to_signal};
+pub use topology::{LinkQuality, MeshTopology, TopologySnapshot};
 pub use types::{
     BROADCAST_ADDR, ChannelIndex, FRAME_MAGIC, MAX_CHANNELS, MAX_HOP_LIMIT, MAX_PACKET_SIZE,
     NodeNum, PacketId,

--- a/crates/kerykeion/src/processor.rs
+++ b/crates/kerykeion/src/processor.rs
@@ -1,0 +1,682 @@
+//! Central packet dispatch for incoming `FromRadio` messages after handshake.
+
+use prost::Message as _;
+use tokio::sync::broadcast;
+
+use crate::node_db::{DeviceMetrics, MeshNode, NodeDb, NodePosition, UserInfo};
+use crate::signals::{MeshEvent, mesh_event_to_signal};
+use crate::topology::MeshTopology;
+use crate::types::NodeNum;
+use koinon::GeoSignal;
+
+/// `NeighborInfo` protobuf (portnum 71) — not in vendored protos, decoded manually.
+#[derive(prost::Message)]
+struct NeighborInfo {
+    #[prost(uint32, tag = "1")]
+    node_id: u32,
+    #[prost(uint32, tag = "2")]
+    last_sent_by_id: u32,
+    #[prost(uint32, tag = "3")]
+    node_broadcast_interval_secs: u32,
+    #[prost(message, repeated, tag = "4")]
+    neighbors: Vec<Neighbor>,
+}
+
+/// A single neighbor entry in a `NeighborInfo` broadcast.
+#[derive(prost::Message)]
+struct Neighbor {
+    #[prost(uint32, tag = "1")]
+    node_id: u32,
+    #[prost(float, tag = "2")]
+    snr: f32,
+}
+
+/// Meshtastic port numbers for decoded `Data` payloads.
+mod portnum {
+    pub const POSITION_APP: i32 = 3;
+    pub const NODEINFO_APP: i32 = 4;
+    pub const ROUTING_APP: i32 = 5;
+    pub const TELEMETRY_APP: i32 = 67;
+    pub const TRACEROUTE_APP: i32 = 70;
+    pub const NEIGHBORINFO_APP: i32 = 71;
+}
+
+/// Central processor that dispatches decoded packets to `NodeDb`, `MeshTopology`,
+/// and emits [`GeoSignal`]s on the broadcast channel.
+pub struct PacketProcessor {
+    node_db: NodeDb,
+    topology: MeshTopology,
+    tx: broadcast::Sender<GeoSignal>,
+}
+
+impl PacketProcessor {
+    /// Create a new processor with the given broadcast sender.
+    pub const fn new(
+        node_db: NodeDb,
+        topology: MeshTopology,
+        tx: broadcast::Sender<GeoSignal>,
+    ) -> Self {
+        Self {
+            node_db,
+            topology,
+            tx,
+        }
+    }
+
+    /// Access the node database.
+    #[must_use]
+    pub const fn node_db(&self) -> &NodeDb {
+        &self.node_db
+    }
+
+    /// Mutable access to the node database.
+    pub const fn node_db_mut(&mut self) -> &mut NodeDb {
+        &mut self.node_db
+    }
+
+    /// Access the topology graph.
+    #[must_use]
+    pub const fn topology(&self) -> &MeshTopology {
+        &self.topology
+    }
+
+    /// Mutable access to the topology graph.
+    pub const fn topology_mut(&mut self) -> &mut MeshTopology {
+        &mut self.topology
+    }
+
+    /// Process a decoded `MeshPacket` after the handshake phase.
+    ///
+    /// Dispatches based on portnum and updates internal state. Returns any
+    /// produced events for external handling.
+    pub fn process_mesh_packet(&mut self, packet: &crate::proto::MeshPacket) -> Vec<MeshEvent> {
+        let mut events = Vec::new();
+        let from = NodeNum(packet.from);
+
+        // WHY: passive learning — every received packet provides link metadata.
+        self.apply_passive_learning(packet);
+
+        let Some(crate::proto::mesh_packet::PayloadVariant::Decoded(decoded)) =
+            &packet.payload_variant
+        else {
+            return events;
+        };
+
+        match decoded.portnum {
+            p if p == portnum::NODEINFO_APP => {
+                self.handle_nodeinfo(from, &decoded.payload, &mut events);
+            }
+            p if p == portnum::POSITION_APP => {
+                self.handle_position(from, &decoded.payload, &mut events);
+            }
+            p if p == portnum::TELEMETRY_APP => {
+                self.handle_telemetry(from, &decoded.payload, &mut events);
+            }
+            p if p == portnum::NEIGHBORINFO_APP => {
+                self.handle_neighborinfo(&decoded.payload, &mut events);
+            }
+            p if p == portnum::TRACEROUTE_APP => {
+                self.handle_traceroute(from, packet, &decoded.payload, &mut events);
+            }
+            p if p == portnum::ROUTING_APP => {
+                handle_routing(&decoded.payload);
+            }
+            _ => {
+                tracing::trace!(
+                    portnum = decoded.portnum,
+                    from = from.0,
+                    "unhandled portnum"
+                );
+            }
+        }
+
+        // WHY: emit GeoSignals for each produced event.
+        for event in &events {
+            let position = self.node_db.get(from).and_then(|n| n.position.as_ref());
+            let signal = mesh_event_to_signal(event, position);
+            // WHY: broadcast send errors mean no receivers are listening; not fatal.
+            let _ = self.tx.send(signal);
+        }
+
+        events
+    }
+
+    /// Infer link quality from packet metadata without explicit topology messages.
+    fn apply_passive_learning(&mut self, packet: &crate::proto::MeshPacket) {
+        let from = NodeNum(packet.from);
+        let snr = if packet.rx_snr == 0.0 {
+            None
+        } else {
+            Some(packet.rx_snr)
+        };
+
+        let hop_count = if packet.hop_start > 0 {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "hop values are bounded by MAX_HOP_LIMIT (7)"
+            )]
+            Some((packet.hop_start.saturating_sub(packet.hop_limit)) as u8)
+        } else {
+            None
+        };
+
+        // WHY: update or create the node record with latest packet metadata.
+        let mut node = self.node_db.get(from).cloned().unwrap_or(MeshNode {
+            num: from,
+            user: None,
+            position: None,
+            metrics: None,
+            last_heard: None,
+            snr: None,
+            hop_count: None,
+        });
+        node.last_heard = Some(jiff::Timestamp::now());
+        if let Some(s) = snr {
+            node.snr = Some(s);
+        }
+        if let Some(h) = hop_count {
+            node.hop_count = Some(h);
+        }
+        self.node_db.insert(node);
+
+        // WHY: if hop_count is 1 (direct), establish a direct link.
+        if hop_count == Some(1) {
+            if let Some(my_node) = self.node_db.my_node() {
+                if let Some(s) = snr {
+                    self.topology.update_link(from, my_node, s);
+                }
+            }
+        }
+    }
+
+    fn handle_nodeinfo(&mut self, from: NodeNum, payload: &[u8], events: &mut Vec<MeshEvent>) {
+        let user_proto = match crate::proto::User::decode(payload) {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::warn!(from = from.0, error = %e, "failed to decode NODEINFO_APP payload");
+                return;
+            }
+        };
+
+        let user = UserInfo {
+            id: user_proto.id,
+            long_name: user_proto.long_name,
+            short_name: user_proto.short_name.clone(),
+            hw_model: u32::try_from(user_proto.hw_model).unwrap_or(0),
+            is_licensed: user_proto.is_licensed,
+        };
+
+        // WHY: passive learning may have already created a bare node entry, so
+        // check for user info to determine if this is a genuinely new node.
+        let is_new = self.node_db.get(from).is_none_or(|n| n.user.is_none());
+
+        let mut node = self.node_db.get(from).cloned().unwrap_or(MeshNode {
+            num: from,
+            user: None,
+            position: None,
+            metrics: None,
+            last_heard: None,
+            snr: None,
+            hop_count: None,
+        });
+        node.user = Some(user.clone());
+        node.last_heard = Some(jiff::Timestamp::now());
+        self.node_db.insert(node);
+        self.topology.add_node(from);
+
+        if is_new {
+            events.push(MeshEvent::NodeDiscovered {
+                node: from,
+                short_name: Some(user.short_name),
+                snr: self.node_db.get(from).and_then(|n| n.snr).unwrap_or(0.0),
+                hop_count: self
+                    .node_db
+                    .get(from)
+                    .and_then(|n| n.hop_count)
+                    .unwrap_or(0),
+            });
+        }
+    }
+
+    fn handle_position(&mut self, from: NodeNum, payload: &[u8], events: &mut Vec<MeshEvent>) {
+        let pos_proto = match crate::proto::Position::decode(payload) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(from = from.0, error = %e, "failed to decode POSITION_APP payload");
+                return;
+            }
+        };
+
+        // WHY: Meshtastic encodes lat/lon as integer degrees × 1e7.
+        let lat = f64::from(pos_proto.latitude_i) * 1e-7;
+        let lon = f64::from(pos_proto.longitude_i) * 1e-7;
+        let alt = if pos_proto.altitude != 0 {
+            Some(pos_proto.altitude)
+        } else {
+            None
+        };
+
+        let position = NodePosition {
+            latitude: lat,
+            longitude: lon,
+            altitude: alt,
+            timestamp: jiff::Timestamp::from_second(i64::from(pos_proto.time)).ok(),
+        };
+
+        let mut node = self.node_db.get(from).cloned().unwrap_or(MeshNode {
+            num: from,
+            user: None,
+            position: None,
+            metrics: None,
+            last_heard: None,
+            snr: None,
+            hop_count: None,
+        });
+        node.position = Some(position);
+        node.last_heard = Some(jiff::Timestamp::now());
+        self.node_db.insert(node);
+
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "altitude i32→f32 is acceptable for metre-scale values"
+        )]
+        let alt_f32 = alt.map(|a| a as f32);
+        events.push(MeshEvent::PositionUpdate {
+            node: from,
+            lat,
+            lon,
+            alt: alt_f32,
+        });
+    }
+
+    fn handle_telemetry(&mut self, from: NodeNum, payload: &[u8], events: &mut Vec<MeshEvent>) {
+        let telem = match crate::proto::Telemetry::decode(payload) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(from = from.0, error = %e, "failed to decode TELEMETRY_APP payload");
+                return;
+            }
+        };
+
+        if let Some(crate::proto::telemetry::Variant::DeviceMetrics(dm)) = telem.variant {
+            let metrics = DeviceMetrics {
+                battery_level: if dm.battery_level > 0 {
+                    Some(dm.battery_level)
+                } else {
+                    None
+                },
+                voltage: if dm.voltage > 0.0 {
+                    Some(dm.voltage)
+                } else {
+                    None
+                },
+                channel_utilization: if dm.channel_utilization > 0.0 {
+                    Some(dm.channel_utilization)
+                } else {
+                    None
+                },
+                air_util_tx: if dm.air_util_tx > 0.0 {
+                    Some(dm.air_util_tx)
+                } else {
+                    None
+                },
+            };
+
+            if let Some(existing) = self.node_db.get(from) {
+                let mut updated = existing.clone();
+                updated.metrics = Some(metrics.clone());
+                updated.last_heard = Some(jiff::Timestamp::now());
+                self.node_db.insert(updated);
+            }
+
+            events.push(MeshEvent::TelemetryUpdate {
+                node: from,
+                battery_pct: metrics.battery_level,
+                voltage: metrics.voltage,
+            });
+        }
+    }
+
+    fn handle_neighborinfo(&mut self, payload: &[u8], events: &mut Vec<MeshEvent>) {
+        let ni = match NeighborInfo::decode(payload) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to decode NEIGHBORINFO_APP payload");
+                return;
+            }
+        };
+
+        let reporter = NodeNum(ni.node_id);
+        self.topology.add_node(reporter);
+
+        for neighbor in &ni.neighbors {
+            let neighbor_num = NodeNum(neighbor.node_id);
+            self.topology
+                .update_link(reporter, neighbor_num, neighbor.snr);
+            events.push(MeshEvent::TopologyChange {
+                from: reporter,
+                to: neighbor_num,
+                snr: neighbor.snr,
+            });
+        }
+    }
+
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "windows(2) guarantees exactly 2 elements"
+    )]
+    fn handle_traceroute(
+        &mut self,
+        from: NodeNum,
+        packet: &crate::proto::MeshPacket,
+        payload: &[u8],
+        events: &mut Vec<MeshEvent>,
+    ) {
+        let route = match crate::proto::RouteDiscovery::decode(payload) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(from = from.0, error = %e, "failed to decode TRACEROUTE_APP payload");
+                return;
+            }
+        };
+
+        // WHY: build the full path: originator → route hops → destination.
+        let dest = NodeNum(packet.to);
+        let mut path = vec![from];
+        path.extend(route.route.iter().map(|&n| NodeNum(n)));
+        path.push(dest);
+
+        // WHY: add all nodes in the path first.
+        for &node in &path {
+            self.topology.add_node(node);
+        }
+
+        for (i, window) in path.windows(2).enumerate() {
+            let (hop_from, hop_to) = (window[0], window[1]);
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "SNR i32→f32 preserves sufficient precision for dB values"
+            )]
+            let snr = route.snr_towards.get(i).map_or(0.0, |&s| s as f32);
+
+            self.topology.update_link(hop_from, hop_to, snr);
+            events.push(MeshEvent::TopologyChange {
+                from: hop_from,
+                to: hop_to,
+                snr,
+            });
+        }
+
+        // WHY: process the reverse path (snr_back) similarly.
+        if !route.back.is_empty() {
+            let mut back_path = vec![dest];
+            back_path.extend(route.back.iter().map(|&n| NodeNum(n)));
+            back_path.push(from);
+
+            for (i, window) in back_path.windows(2).enumerate() {
+                let (hop_from, hop_to) = (window[0], window[1]);
+                #[expect(
+                    clippy::cast_precision_loss,
+                    reason = "SNR i32→f32 preserves sufficient precision"
+                )]
+                let snr = route.snr_back.get(i).map_or(0.0, |&s| s as f32);
+
+                self.topology.update_link(hop_from, hop_to, snr);
+            }
+        }
+    }
+}
+
+/// Process a routing payload (ACK/NAK tracking).
+fn handle_routing(payload: &[u8]) {
+    let routing = match crate::proto::Routing::decode(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to decode ROUTING_APP payload");
+            return;
+        }
+    };
+
+    match &routing.variant {
+        Some(crate::proto::routing::Variant::ErrorReason(code)) => {
+            tracing::debug!(error_code = code, "routing error received");
+        }
+        Some(
+            crate::proto::routing::Variant::RouteRequest(_)
+            | crate::proto::routing::Variant::RouteReply(_),
+        ) => {
+            // WHY: route_request/route_reply are handled via TRACEROUTE_APP portnum.
+            tracing::trace!("routing route_request/route_reply (handled via traceroute)");
+        }
+        None => {}
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn make_processor() -> PacketProcessor {
+        let (tx, _rx) = broadcast::channel(64);
+        let mut node_db = NodeDb::new();
+        node_db.set_my_node(NodeNum(0xAAAA));
+        PacketProcessor::new(node_db, MeshTopology::new(), tx)
+    }
+
+    fn make_mesh_packet(from: u32, portnum: i32, payload: Vec<u8>) -> crate::proto::MeshPacket {
+        crate::proto::MeshPacket {
+            from,
+            to: 0xFFFF_FFFF,
+            channel: 0,
+            id: 1,
+            rx_time: 0,
+            rx_snr: 5.0,
+            hop_limit: 2,
+            want_ack: false,
+            priority: 0,
+            rx_rssi: -90,
+            via_mqtt: false,
+            hop_start: 3,
+            payload_variant: Some(crate::proto::mesh_packet::PayloadVariant::Decoded(
+                crate::proto::Data {
+                    portnum,
+                    payload,
+                    want_response: false,
+                    dest: 0,
+                    source: 0,
+                    request_id: 0,
+                    reply_id: 0,
+                    emoji: vec![],
+                },
+            )),
+        }
+    }
+
+    #[test]
+    fn process_nodeinfo_creates_node_and_event() {
+        let mut proc = make_processor();
+        let user = crate::proto::User {
+            id: "!deadbeef".into(),
+            long_name: "Test Node".into(),
+            short_name: "TST".into(),
+            macaddr: vec![],
+            hw_model: 9, // RAK4631
+            is_licensed: false,
+            role: 0,
+        };
+        let mut payload = Vec::new();
+        user.encode(&mut payload).unwrap();
+
+        let packet = make_mesh_packet(0xDEAD, portnum::NODEINFO_APP, payload);
+        let events = proc.process_mesh_packet(&packet);
+
+        assert!(proc.node_db().get(NodeNum(0xDEAD)).is_some());
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MeshEvent::NodeDiscovered { .. }))
+        );
+    }
+
+    #[test]
+    fn process_position_updates_node_and_emits_event() {
+        let mut proc = make_processor();
+        let pos = crate::proto::Position {
+            latitude_i: 515_074_000, // 51.5074
+            longitude_i: -1_278_000, // -0.1278
+            altitude: 11,
+            time: 1_700_000_000,
+            ..Default::default()
+        };
+        let mut payload = Vec::new();
+        pos.encode(&mut payload).unwrap();
+
+        let packet = make_mesh_packet(0xBEEF, portnum::POSITION_APP, payload);
+        let events = proc.process_mesh_packet(&packet);
+
+        let node = proc.node_db().get(NodeNum(0xBEEF)).unwrap();
+        assert!(node.position.is_some());
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MeshEvent::PositionUpdate { .. }))
+        );
+    }
+
+    #[test]
+    fn process_telemetry_updates_metrics() {
+        let mut proc = make_processor();
+        // WHY: pre-insert a node so telemetry has something to update.
+        proc.node_db_mut().insert(MeshNode {
+            num: NodeNum(0x1111),
+            user: None,
+            position: None,
+            metrics: None,
+            last_heard: None,
+            snr: None,
+            hop_count: None,
+        });
+
+        let telem = crate::proto::Telemetry {
+            time: 1_700_000_000,
+            variant: Some(crate::proto::telemetry::Variant::DeviceMetrics(
+                crate::proto::DeviceMetrics {
+                    battery_level: 85,
+                    voltage: 3.7,
+                    channel_utilization: 0.15,
+                    air_util_tx: 0.05,
+                    uptime_seconds: 3600,
+                },
+            )),
+        };
+        let mut payload = Vec::new();
+        telem.encode(&mut payload).unwrap();
+
+        let packet = make_mesh_packet(0x1111, portnum::TELEMETRY_APP, payload);
+        let events = proc.process_mesh_packet(&packet);
+
+        let node = proc.node_db().get(NodeNum(0x1111)).unwrap();
+        assert!(node.metrics.is_some());
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MeshEvent::TelemetryUpdate { .. }))
+        );
+    }
+
+    #[test]
+    fn process_neighborinfo_updates_topology() {
+        let mut proc = make_processor();
+
+        let ni = NeighborInfo {
+            node_id: 0x1111,
+            last_sent_by_id: 0x1111,
+            node_broadcast_interval_secs: 3600,
+            neighbors: vec![
+                Neighbor {
+                    node_id: 0x2222,
+                    snr: 8.5,
+                },
+                Neighbor {
+                    node_id: 0x3333,
+                    snr: 3.0,
+                },
+            ],
+        };
+        let mut payload = Vec::new();
+        ni.encode(&mut payload).unwrap();
+
+        let packet = make_mesh_packet(0x1111, portnum::NEIGHBORINFO_APP, payload);
+        let events = proc.process_mesh_packet(&packet);
+
+        // WHY: 2 from neighborinfo + 1 from passive learning (direct link).
+        assert_eq!(proc.topology().edge_count(), 3);
+        assert!(proc.topology().contains_node(NodeNum(0x2222)));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, MeshEvent::TopologyChange { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn process_traceroute_builds_path() {
+        let mut proc = make_processor();
+
+        let route = crate::proto::RouteDiscovery {
+            route: vec![0x2222, 0x3333],
+            snr_towards: vec![10, 8],
+            back: vec![],
+            snr_back: vec![],
+        };
+        let mut payload = Vec::new();
+        route.encode(&mut payload).unwrap();
+
+        let mut packet = make_mesh_packet(0x1111, portnum::TRACEROUTE_APP, payload);
+        packet.to = 0x4444;
+        let events = proc.process_mesh_packet(&packet);
+
+        // WHY: path is 0x1111 → 0x2222 → 0x3333 → 0x4444 = 3 edges.
+        assert!(
+            proc.topology().edge_count() >= 3,
+            "expected at least 3 edges from traceroute path"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MeshEvent::TopologyChange { .. }))
+        );
+    }
+
+    #[test]
+    fn passive_learning_infers_hop_count() {
+        let mut proc = make_processor();
+        let packet = make_mesh_packet(0xBBBB, portnum::NODEINFO_APP, vec![]);
+        // hop_start=3, hop_limit=2 → 1 hop traversed
+        proc.process_mesh_packet(&packet);
+
+        let node = proc.node_db().get(NodeNum(0xBBBB)).unwrap();
+        assert_eq!(node.hop_count, Some(1));
+    }
+
+    #[test]
+    fn passive_learning_creates_direct_link() {
+        let mut proc = make_processor();
+        // hop_start=3, hop_limit=2 → 1 hop (direct)
+        let packet = make_mesh_packet(0xCCCC, portnum::NODEINFO_APP, vec![]);
+        proc.process_mesh_packet(&packet);
+
+        // WHY: direct packet should create a link from sender to our node.
+        let my_node = proc.node_db().my_node().unwrap();
+        let neighbors = proc.topology().neighbors(NodeNum(0xCCCC));
+        assert!(
+            neighbors.iter().any(|(n, _)| *n == my_node),
+            "direct packet should create link to server node"
+        );
+    }
+}

--- a/crates/kerykeion/src/signals.rs
+++ b/crates/kerykeion/src/signals.rs
@@ -1,0 +1,367 @@
+//! Mesh event types and conversion to [`koinon::GeoSignal`] for the broadcast channel.
+
+use koinon::signal::MeshDetail;
+use koinon::{Confidence, Coordinates, GeoSignal, SignalKind, Timestamp};
+
+use crate::node_db::NodePosition;
+use crate::types::NodeNum;
+
+/// Internal mesh event produced by the packet processor and discovery manager.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum MeshEvent {
+    /// A new node was discovered on the mesh.
+    NodeDiscovered {
+        /// Discovered node number.
+        node: NodeNum,
+        /// Short name if available.
+        short_name: Option<String>,
+        /// SNR at discovery.
+        snr: f32,
+        /// Hop count from observer.
+        hop_count: u8,
+    },
+    /// A previously-seen node has gone offline.
+    NodeOffline {
+        /// Node that went offline.
+        node: NodeNum,
+    },
+    /// A node reported a new position.
+    PositionUpdate {
+        /// Node that reported position.
+        node: NodeNum,
+        /// Latitude in decimal degrees.
+        lat: f64,
+        /// Longitude in decimal degrees.
+        lon: f64,
+        /// Altitude in metres MSL, if reported.
+        alt: Option<f32>,
+    },
+    /// A topology link was added or updated.
+    TopologyChange {
+        /// Link source node.
+        from: NodeNum,
+        /// Link destination node.
+        to: NodeNum,
+        /// SNR on this link.
+        snr: f32,
+    },
+    /// Link quality degraded significantly.
+    LinkDegraded {
+        /// Link source node.
+        from: NodeNum,
+        /// Link destination node.
+        to: NodeNum,
+        /// Previous SNR value.
+        old_snr: f32,
+        /// Current SNR value.
+        new_snr: f32,
+    },
+    /// Mesh network split into disconnected components.
+    PartitionDetected {
+        /// Each inner vec is a set of nodes in one component.
+        components: Vec<Vec<NodeNum>>,
+    },
+    /// Previously partitioned nodes are now reachable again.
+    PartitionHealed {
+        /// Nodes that rejoined the main mesh.
+        reunited_nodes: Vec<NodeNum>,
+    },
+    /// A node's gateway status changed.
+    GatewayStatusChange {
+        /// The gateway node.
+        node: NodeNum,
+        /// Whether it is now acting as a gateway.
+        is_gateway: bool,
+    },
+    /// Updated telemetry from a node.
+    TelemetryUpdate {
+        /// Reporting node.
+        node: NodeNum,
+        /// Battery percentage (0–100), if reported.
+        battery_pct: Option<u32>,
+        /// Battery voltage in volts, if reported.
+        voltage: Option<f32>,
+    },
+}
+
+/// Convert a [`MeshEvent`] to a [`GeoSignal`] using the closest matching [`MeshDetail`] variant.
+///
+/// Events that lack a direct `MeshDetail` mapping use `MeshDetail::NodeSeen` with
+/// discriminating metadata. Observations note which new variants would improve this.
+#[must_use]
+pub fn mesh_event_to_signal(event: &MeshEvent, position: Option<&NodePosition>) -> GeoSignal {
+    let location = position
+        .and_then(|p| Coordinates::new(p.latitude, p.longitude, p.altitude.map(f64::from)).ok());
+    let ts = Timestamp::now();
+
+    match event {
+        MeshEvent::NodeDiscovered {
+            node,
+            snr,
+            hop_count,
+            ..
+        } => convert_node_discovered(*node, *snr, *hop_count, ts, location),
+        MeshEvent::NodeOffline { node } => convert_node_offline(*node, ts, location),
+        MeshEvent::PositionUpdate {
+            node,
+            lat,
+            lon,
+            alt,
+        } => convert_position_update(*node, *lat, *lon, *alt, ts, location),
+        MeshEvent::TopologyChange { from, to, snr } => {
+            convert_topology_change(*from, *to, *snr, ts, location)
+        }
+        MeshEvent::LinkDegraded {
+            from,
+            to,
+            old_snr,
+            new_snr,
+        } => convert_link_degraded(*from, *to, *old_snr, *new_snr, ts, location),
+        MeshEvent::PartitionDetected { components } => convert_partition_detected(components, ts),
+        MeshEvent::PartitionHealed { reunited_nodes } => {
+            convert_partition_healed(reunited_nodes, ts)
+        }
+        MeshEvent::GatewayStatusChange { node, is_gateway } => {
+            convert_gateway_status(*node, *is_gateway, ts, location)
+        }
+        MeshEvent::TelemetryUpdate {
+            node,
+            battery_pct,
+            voltage,
+        } => convert_telemetry(*node, *battery_pct, *voltage, ts, location),
+    }
+}
+
+fn convert_node_discovered(
+    node: NodeNum,
+    snr: f32,
+    hop_count: u8,
+    ts: Timestamp,
+    location: Option<Coordinates>,
+) -> GeoSignal {
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: node.0,
+        snr,
+        hop_count,
+    });
+    GeoSignal::new(kind, ts, location).with_metadata("event", serde_json::json!("discovered"))
+}
+
+fn convert_node_offline(node: NodeNum, ts: Timestamp, location: Option<Coordinates>) -> GeoSignal {
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: node.0,
+        snr: 0.0,
+        hop_count: 0,
+    });
+    GeoSignal::new(kind, ts, location)
+        .with_confidence(Confidence::new(0.5))
+        .with_metadata("event", serde_json::json!("offline"))
+}
+
+fn convert_position_update(
+    node: NodeNum,
+    lat: f64,
+    lon: f64,
+    alt: Option<f32>,
+    ts: Timestamp,
+    location: Option<Coordinates>,
+) -> GeoSignal {
+    // WHY: position signals carry their own coordinates in the payload.
+    let Ok(coords) = Coordinates::new(lat, lon, alt.map(f64::from)) else {
+        // WHY: invalid coordinates still get reported with NodeSeen fallback.
+        let fallback = SignalKind::Mesh(MeshDetail::NodeSeen {
+            node_id: node.0,
+            snr: 0.0,
+            hop_count: 0,
+        });
+        return GeoSignal::new(fallback, ts, location)
+            .with_metadata("event", serde_json::json!("invalid_position"));
+    };
+    let kind = SignalKind::Mesh(MeshDetail::Position {
+        node_id: node.0,
+        coordinates: coords,
+    });
+    GeoSignal::new(kind, ts, Some(coords))
+}
+
+fn convert_topology_change(
+    from: NodeNum,
+    to: NodeNum,
+    snr: f32,
+    ts: Timestamp,
+    location: Option<Coordinates>,
+) -> GeoSignal {
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: from.0,
+        snr,
+        hop_count: 0,
+    });
+    GeoSignal::new(kind, ts, location)
+        .with_metadata("event", serde_json::json!("topology_change"))
+        .with_metadata("to_node", serde_json::json!(to.0))
+}
+
+fn convert_link_degraded(
+    from: NodeNum,
+    to: NodeNum,
+    old_snr: f32,
+    new_snr: f32,
+    ts: Timestamp,
+    location: Option<Coordinates>,
+) -> GeoSignal {
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: from.0,
+        snr: new_snr,
+        hop_count: 0,
+    });
+    GeoSignal::new(kind, ts, location)
+        .with_metadata("event", serde_json::json!("link_degraded"))
+        .with_metadata("to_node", serde_json::json!(to.0))
+        .with_metadata("old_snr", serde_json::json!(old_snr))
+}
+
+fn convert_partition_detected(components: &[Vec<NodeNum>], ts: Timestamp) -> GeoSignal {
+    let node_lists: Vec<Vec<u32>> = components
+        .iter()
+        .map(|c| c.iter().map(|n| n.0).collect())
+        .collect();
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: 0,
+        snr: 0.0,
+        hop_count: 0,
+    });
+    GeoSignal::new(kind, ts, None)
+        .with_confidence(Confidence::new(0.8))
+        .with_metadata("event", serde_json::json!("partition_detected"))
+        .with_metadata("components", serde_json::json!(node_lists))
+}
+
+fn convert_partition_healed(reunited_nodes: &[NodeNum], ts: Timestamp) -> GeoSignal {
+    let nodes: Vec<u32> = reunited_nodes.iter().map(|n| n.0).collect();
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: 0,
+        snr: 0.0,
+        hop_count: 0,
+    });
+    GeoSignal::new(kind, ts, None)
+        .with_metadata("event", serde_json::json!("partition_healed"))
+        .with_metadata("reunited_nodes", serde_json::json!(nodes))
+}
+
+fn convert_gateway_status(
+    node: NodeNum,
+    is_gateway: bool,
+    ts: Timestamp,
+    location: Option<Coordinates>,
+) -> GeoSignal {
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: node.0,
+        snr: 0.0,
+        hop_count: 0,
+    });
+    GeoSignal::new(kind, ts, location)
+        .with_metadata("event", serde_json::json!("gateway_status"))
+        .with_metadata("is_gateway", serde_json::json!(is_gateway))
+}
+
+fn convert_telemetry(
+    node: NodeNum,
+    battery_pct: Option<u32>,
+    voltage: Option<f32>,
+    ts: Timestamp,
+    location: Option<Coordinates>,
+) -> GeoSignal {
+    let kind = SignalKind::Mesh(MeshDetail::NodeSeen {
+        node_id: node.0,
+        snr: 0.0,
+        hop_count: 0,
+    });
+    let mut signal =
+        GeoSignal::new(kind, ts, location).with_metadata("event", serde_json::json!("telemetry"));
+    if let Some(pct) = battery_pct {
+        signal = signal.with_metadata("battery_pct", serde_json::json!(pct));
+    }
+    if let Some(v) = voltage {
+        signal = signal.with_metadata("voltage", serde_json::json!(v));
+    }
+    signal
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_discovered_produces_node_seen_signal() {
+        let event = MeshEvent::NodeDiscovered {
+            node: NodeNum(42),
+            short_name: Some("TEST".into()),
+            snr: 7.5,
+            hop_count: 2,
+        };
+        let signal = mesh_event_to_signal(&event, None);
+        assert!(matches!(
+            signal.kind,
+            SignalKind::Mesh(MeshDetail::NodeSeen { node_id: 42, .. })
+        ));
+    }
+
+    #[test]
+    fn position_update_produces_position_signal() {
+        let event = MeshEvent::PositionUpdate {
+            node: NodeNum(10),
+            lat: 51.5074,
+            lon: -0.1278,
+            alt: Some(11.0),
+        };
+        let signal = mesh_event_to_signal(&event, None);
+        assert!(matches!(
+            signal.kind,
+            SignalKind::Mesh(MeshDetail::Position { node_id: 10, .. })
+        ));
+        assert!(signal.location.is_some());
+    }
+
+    #[test]
+    fn telemetry_update_includes_battery_metadata() {
+        let event = MeshEvent::TelemetryUpdate {
+            node: NodeNum(5),
+            battery_pct: Some(85),
+            voltage: Some(3.7),
+        };
+        let signal = mesh_event_to_signal(&event, None);
+        assert!(signal.metadata.contains_key("battery_pct"));
+        assert!(signal.metadata.contains_key("voltage"));
+    }
+
+    #[test]
+    fn partition_detected_includes_component_metadata() {
+        let event = MeshEvent::PartitionDetected {
+            components: vec![vec![NodeNum(1), NodeNum(2)], vec![NodeNum(3)]],
+        };
+        let signal = mesh_event_to_signal(&event, None);
+        assert!(signal.metadata.contains_key("components"));
+    }
+
+    #[test]
+    fn offline_event_has_reduced_confidence() {
+        let event = MeshEvent::NodeOffline { node: NodeNum(99) };
+        let signal = mesh_event_to_signal(&event, None);
+        assert!((signal.confidence.as_f32() - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn topology_change_includes_to_node_metadata() {
+        let event = MeshEvent::TopologyChange {
+            from: NodeNum(1),
+            to: NodeNum(2),
+            snr: 12.0,
+        };
+        let signal = mesh_event_to_signal(&event, None);
+        assert!(signal.metadata.contains_key("to_node"));
+    }
+}

--- a/crates/kerykeion/src/topology.rs
+++ b/crates/kerykeion/src/topology.rs
@@ -1,0 +1,521 @@
+//! Directed weighted mesh topology graph for node connectivity tracking.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use petgraph::Direction;
+use petgraph::algo::dijkstra;
+use petgraph::graph::NodeIndex;
+use petgraph::stable_graph::StableGraph;
+use petgraph::visit::EdgeRef;
+use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
+
+use crate::types::NodeNum;
+
+/// Ceiling SNR value for Dijkstra cost derivation: `cost = SNR_CEILING - snr`.
+const SNR_CEILING: f32 = 30.0;
+
+/// Directed edge weight representing radio link quality between two nodes.
+#[derive(Debug, Clone)]
+pub struct LinkQuality {
+    /// Signal-to-noise ratio in dB.
+    pub snr: f32,
+    /// When this link was last observed.
+    pub last_observed: Instant,
+    /// Number of packets observed on this link.
+    pub packet_count: u32,
+}
+
+/// Directed weighted graph tracking mesh node connectivity.
+pub struct MeshTopology {
+    graph: StableGraph<NodeNum, LinkQuality, petgraph::Directed>,
+    node_index: HashMap<NodeNum, NodeIndex>,
+}
+
+impl MeshTopology {
+    /// Create an empty topology graph.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            graph: StableGraph::new(),
+            node_index: HashMap::new(),
+        }
+    }
+
+    /// Insert a node or return its existing index.
+    pub fn add_node(&mut self, node: NodeNum) -> NodeIndex {
+        if let Some(&idx) = self.node_index.get(&node) {
+            return idx;
+        }
+        let idx = self.graph.add_node(node);
+        self.node_index.insert(node, idx);
+        idx
+    }
+
+    /// Add or update a directed edge from `from` to `to` with the given SNR.
+    pub fn update_link(&mut self, from: NodeNum, to: NodeNum, snr: f32) {
+        let from_idx = self.add_node(from);
+        let to_idx = self.add_node(to);
+
+        // WHY: search existing edges to update rather than create duplicates.
+        let existing = self
+            .graph
+            .edges_connecting(from_idx, to_idx)
+            .next()
+            .map(|e| e.id());
+
+        if let Some(edge_id) = existing {
+            if let Some(weight) = self.graph.edge_weight_mut(edge_id) {
+                weight.snr = snr;
+                weight.last_observed = Instant::now();
+                weight.packet_count = weight.packet_count.saturating_add(1);
+            }
+        } else {
+            self.graph.add_edge(
+                from_idx,
+                to_idx,
+                LinkQuality {
+                    snr,
+                    last_observed: Instant::now(),
+                    packet_count: 1,
+                },
+            );
+        }
+    }
+
+    /// Remove nodes not heard within `timeout`.
+    pub fn remove_stale_nodes(&mut self, timeout: Duration) {
+        let cutoff = Instant::now() - timeout;
+        let stale: Vec<NodeNum> = self
+            .node_index
+            .iter()
+            .filter(|&(_, idx)| {
+                // WHY: a node is stale if ALL its edges (incoming + outgoing) are older
+                // than cutoff, or it has no edges at all.
+                let has_recent = self
+                    .graph
+                    .edges_directed(*idx, Direction::Incoming)
+                    .chain(self.graph.edges_directed(*idx, Direction::Outgoing))
+                    .any(|e| e.weight().last_observed > cutoff);
+                !has_recent
+            })
+            .map(|(num, _)| *num)
+            .collect();
+
+        for num in stale {
+            if let Some(idx) = self.node_index.remove(&num) {
+                self.graph.remove_node(idx);
+            }
+        }
+    }
+
+    /// Remove edges not observed within `timeout`.
+    pub fn remove_stale_links(&mut self, timeout: Duration) {
+        let cutoff = Instant::now() - timeout;
+        let stale_edges: Vec<petgraph::graph::EdgeIndex> = self
+            .graph
+            .edge_indices()
+            .filter(|&idx| {
+                self.graph
+                    .edge_weight(idx)
+                    .is_some_and(|w| w.last_observed < cutoff)
+            })
+            .collect();
+
+        for idx in stale_edges {
+            self.graph.remove_edge(idx);
+        }
+    }
+
+    /// Return direct neighbors of `node` with their link quality.
+    #[must_use]
+    pub fn neighbors(&self, node: NodeNum) -> Vec<(NodeNum, &LinkQuality)> {
+        let Some(&idx) = self.node_index.get(&node) else {
+            return Vec::new();
+        };
+        self.graph
+            .edges_directed(idx, Direction::Outgoing)
+            .filter_map(|edge| {
+                let target = self.graph.node_weight(edge.target());
+                target.map(|&num| (num, edge.weight()))
+            })
+            .collect()
+    }
+
+    /// Dijkstra shortest path using SNR-derived weights (lower SNR = higher cost).
+    #[must_use]
+    pub fn shortest_path(&self, from: NodeNum, to: NodeNum) -> Option<Vec<NodeNum>> {
+        let &from_idx = self.node_index.get(&from)?;
+        let &to_idx = self.node_index.get(&to)?;
+
+        // WHY: petgraph::algo::astar returns the full path; dijkstra only returns costs.
+        let (_, path) = petgraph::algo::astar(
+            &self.graph,
+            from_idx,
+            |n| n == to_idx,
+            |e| {
+                let cost = SNR_CEILING - e.weight().snr;
+                if cost < 0.0 { 0.0_f32 } else { cost }
+            },
+            |_| 0.0_f32,
+        )?;
+
+        Some(
+            path.iter()
+                .filter_map(|&idx| self.graph.node_weight(idx).copied())
+                .collect(),
+        )
+    }
+
+    /// Minimum hop count between two nodes, ignoring link quality.
+    #[must_use]
+    pub fn hop_count(&self, from: NodeNum, to: NodeNum) -> Option<u8> {
+        let &from_idx = self.node_index.get(&from)?;
+        let &to_idx = self.node_index.get(&to)?;
+
+        let costs = dijkstra(&self.graph, from_idx, Some(to_idx), |_| 1u32);
+        let &hops = costs.get(&to_idx)?;
+        u8::try_from(hops).ok()
+    }
+
+    /// Detect weakly connected components (mesh partitions).
+    #[must_use]
+    pub fn connected_components(&self) -> Vec<Vec<NodeNum>> {
+        if self.node_index.is_empty() {
+            return Vec::new();
+        }
+
+        // WHY: treat directed graph as undirected via BFS for partition detection.
+        let mut component: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut components: Vec<Vec<NodeNum>> = Vec::new();
+
+        for &idx in self.node_index.values() {
+            if component.contains_key(&idx) {
+                continue;
+            }
+
+            let comp_id = components.len();
+            let mut group = Vec::new();
+            let mut stack = vec![idx];
+
+            while let Some(current) = stack.pop() {
+                if component.contains_key(&current) {
+                    continue;
+                }
+                component.insert(current, comp_id);
+                if let Some(&num) = self.graph.node_weight(current) {
+                    group.push(num);
+                }
+
+                // WHY: traverse both directions for weakly connected components.
+                for edge in self.graph.edges_directed(current, Direction::Outgoing) {
+                    if !component.contains_key(&edge.target()) {
+                        stack.push(edge.target());
+                    }
+                }
+                for edge in self.graph.edges_directed(current, Direction::Incoming) {
+                    if !component.contains_key(&edge.source()) {
+                        stack.push(edge.source());
+                    }
+                }
+            }
+
+            if !group.is_empty() {
+                components.push(group);
+            }
+        }
+
+        // WHY: nodes with no edges still need to appear as singleton components.
+        for &idx in self.node_index.values() {
+            if let std::collections::hash_map::Entry::Vacant(entry) = component.entry(idx) {
+                if let Some(&num) = self.graph.node_weight(idx) {
+                    components.push(vec![num]);
+                    entry.insert(components.len() - 1);
+                }
+            }
+        }
+
+        components
+    }
+
+    /// Returns `true` if `node` is unreachable from `server_node`.
+    #[must_use]
+    pub fn is_partitioned(&self, node: NodeNum, server_node: NodeNum) -> bool {
+        let Some(&server_idx) = self.node_index.get(&server_node) else {
+            return true;
+        };
+        let Some(&node_idx) = self.node_index.get(&node) else {
+            return true;
+        };
+
+        let costs = dijkstra(&self.graph, server_idx, Some(node_idx), |_| 1u32);
+        !costs.contains_key(&node_idx)
+    }
+
+    /// Return the number of tracked nodes.
+    #[must_use]
+    pub fn node_count(&self) -> usize {
+        self.node_index.len()
+    }
+
+    /// Return the number of tracked links.
+    #[must_use]
+    pub fn edge_count(&self) -> usize {
+        self.graph.edge_count()
+    }
+
+    /// Check if a node is in the topology.
+    #[must_use]
+    pub fn contains_node(&self, node: NodeNum) -> bool {
+        self.node_index.contains_key(&node)
+    }
+
+    /// Serialize the current graph state for persistence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::TopologySnapshot`] if JSON serialization fails.
+    pub fn save_to_bytes(&self) -> Result<Vec<u8>, crate::Error> {
+        let nodes: Vec<NodeNum> = self.node_index.keys().copied().collect();
+
+        let links: Vec<LinkSnapshot> = self
+            .graph
+            .edge_indices()
+            .filter_map(|idx| {
+                let (src, dst) = self.graph.edge_endpoints(idx)?;
+                let from = *self.graph.node_weight(src)?;
+                let to = *self.graph.node_weight(dst)?;
+                let w = self.graph.edge_weight(idx)?;
+                Some(LinkSnapshot {
+                    from,
+                    to,
+                    snr: w.snr,
+                    packet_count: w.packet_count,
+                })
+            })
+            .collect();
+
+        let snapshot = TopologySnapshot { nodes, links };
+        serde_json::to_vec(&snapshot).map_err(|source| crate::Error::TopologySnapshot {
+            source,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+    }
+
+    /// Restore topology from a serialized snapshot. All links are marked as observed now.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::TopologySnapshot`] if JSON deserialization fails.
+    pub fn load_from_bytes(data: &[u8]) -> Result<Self, crate::Error> {
+        let snapshot: TopologySnapshot =
+            serde_json::from_slice(data).map_err(|source| crate::Error::TopologySnapshot {
+                source,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        let mut topo = Self::new();
+        for node in &snapshot.nodes {
+            topo.add_node(*node);
+        }
+        for link in &snapshot.links {
+            let from_idx = topo.add_node(link.from);
+            let to_idx = topo.add_node(link.to);
+            topo.graph.add_edge(
+                from_idx,
+                to_idx,
+                LinkQuality {
+                    snr: link.snr,
+                    last_observed: Instant::now(),
+                    packet_count: link.packet_count,
+                },
+            );
+        }
+        Ok(topo)
+    }
+}
+
+impl Default for MeshTopology {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Serializable link snapshot for persistence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkSnapshot {
+    /// Source node.
+    pub from: NodeNum,
+    /// Destination node.
+    pub to: NodeNum,
+    /// SNR at last observation.
+    pub snr: f32,
+    /// Total observed packets.
+    pub packet_count: u32,
+}
+
+/// Serializable topology state for restart recovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologySnapshot {
+    /// All tracked node numbers.
+    pub nodes: Vec<NodeNum>,
+    /// All tracked links.
+    pub links: Vec<LinkSnapshot>,
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn n(v: u32) -> NodeNum {
+        NodeNum(v)
+    }
+
+    #[test]
+    fn add_node_idempotent() {
+        let mut topo = MeshTopology::new();
+        let idx1 = topo.add_node(n(1));
+        let idx2 = topo.add_node(n(1));
+        assert_eq!(idx1, idx2);
+        assert_eq!(topo.node_count(), 1);
+    }
+
+    #[test]
+    fn update_link_creates_edge() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 5.0);
+        assert_eq!(topo.edge_count(), 1);
+        let neighbors = topo.neighbors(n(1));
+        assert_eq!(neighbors.len(), 1);
+        assert_eq!(neighbors[0].0, n(2));
+        assert!((neighbors[0].1.snr - 5.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn update_link_updates_existing() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 5.0);
+        topo.update_link(n(1), n(2), 8.0);
+        assert_eq!(topo.edge_count(), 1, "should not duplicate edges");
+        let neighbors = topo.neighbors(n(1));
+        assert!((neighbors[0].1.snr - 8.0).abs() < f32::EPSILON);
+        assert_eq!(neighbors[0].1.packet_count, 2);
+    }
+
+    #[test]
+    fn shortest_path_simple_chain() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        topo.update_link(n(2), n(3), 10.0);
+        topo.update_link(n(1), n(3), 1.0); // direct but weak link
+        let path = topo.shortest_path(n(1), n(3)).unwrap();
+        // WHY: via n(2) has cost 20+20=40, direct has cost 29 — direct is cheaper
+        assert_eq!(path, vec![n(1), n(3)]);
+    }
+
+    #[test]
+    fn shortest_path_prefers_strong_signal() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 25.0); // cost 5
+        topo.update_link(n(2), n(3), 25.0); // cost 5, total 10
+        topo.update_link(n(1), n(3), 5.0); // cost 25
+        let path = topo.shortest_path(n(1), n(3)).unwrap();
+        assert_eq!(path, vec![n(1), n(2), n(3)]);
+    }
+
+    #[test]
+    fn shortest_path_unreachable_returns_none() {
+        let mut topo = MeshTopology::new();
+        topo.add_node(n(1));
+        topo.add_node(n(2));
+        assert!(topo.shortest_path(n(1), n(2)).is_none());
+    }
+
+    #[test]
+    fn hop_count_returns_minimum_hops() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        topo.update_link(n(2), n(3), 10.0);
+        assert_eq!(topo.hop_count(n(1), n(3)), Some(2));
+        assert_eq!(topo.hop_count(n(1), n(2)), Some(1));
+    }
+
+    #[test]
+    fn connected_components_single_cluster() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        topo.update_link(n(2), n(3), 10.0);
+        let comps = topo.connected_components();
+        assert_eq!(comps.len(), 1);
+        assert_eq!(comps[0].len(), 3);
+    }
+
+    #[test]
+    fn connected_components_two_clusters() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        topo.update_link(n(3), n(4), 10.0);
+        let comps = topo.connected_components();
+        assert_eq!(comps.len(), 2, "two disconnected clusters");
+    }
+
+    #[test]
+    fn is_partitioned_detects_unreachable() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        topo.add_node(n(3));
+        assert!(!topo.is_partitioned(n(2), n(1)));
+        assert!(topo.is_partitioned(n(3), n(1)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn remove_stale_links_prunes_old_edges() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        tokio::time::advance(Duration::from_secs(120)).await;
+        topo.update_link(n(1), n(3), 10.0);
+        topo.remove_stale_links(Duration::from_secs(60));
+        assert_eq!(topo.edge_count(), 1, "only the fresh edge should remain");
+        assert!(topo.neighbors(n(1)).iter().any(|(num, _)| *num == n(3)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn remove_stale_nodes_prunes_isolated() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 10.0);
+        tokio::time::advance(Duration::from_secs(120)).await;
+        topo.update_link(n(3), n(4), 10.0);
+        topo.remove_stale_nodes(Duration::from_secs(60));
+        assert!(!topo.contains_node(n(1)), "stale node 1 should be removed");
+        assert!(!topo.contains_node(n(2)), "stale node 2 should be removed");
+        assert!(topo.contains_node(n(3)));
+        assert!(topo.contains_node(n(4)));
+    }
+
+    #[test]
+    fn snapshot_roundtrip() {
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 7.5);
+        topo.update_link(n(2), n(3), 12.0);
+        topo.add_node(n(4));
+
+        let bytes = topo.save_to_bytes().unwrap();
+        let restored = MeshTopology::load_from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.node_count(), 4);
+        assert_eq!(restored.edge_count(), 2);
+        let neighbors = restored.neighbors(n(1));
+        assert_eq!(neighbors.len(), 1);
+        assert!((neighbors[0].1.snr - 7.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn neighbors_of_unknown_node_returns_empty() {
+        let topo = MeshTopology::new();
+        assert!(topo.neighbors(n(99)).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MeshTopology` backed by petgraph `StableGraph` with SNR-weighted directed edges, Dijkstra shortest-path, connected component detection, and JSON snapshot persistence
- Add `PacketProcessor` dispatching NODEINFO, POSITION, TELEMETRY, NEIGHBORINFO, TRACEROUTE, and ROUTING packets with passive link learning from packet metadata
- Add active/passive node discovery manager with periodic traceroutes, stale node lifecycle (Active→Stale→Offline→Removed), and partition detection
- Add `MeshEvent` → `GeoSignal` conversion for the broadcast channel using existing `MeshDetail` variants with metadata discrimination
- Add `GatewayDetector` with manual config + auto-detection from ROUTER_CLIENT role and wifi/MQTT status, best-gateway scoring by hop distance and SNR
- 40+ new tests across all modules

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 457 tests pass (100 in kerykeion)
- [x] `cargo test --workspace --doc` — clean
- [ ] CI passes on GitHub Actions