### PR TITLE
feat(kerykeion): message routing, store-and-forward, and delivery tracking

### DIFF
--- a/crates/kerykeion/src/delivery.rs
+++ b/crates/kerykeion/src/delivery.rs
@@ -1,0 +1,374 @@
+//! Delivery tracking for outbound mesh messages.
+
+use std::collections::HashMap;
+
+use tokio::time::Instant;
+
+use crate::proto::routing;
+use crate::types::PacketId;
+
+/// Lifecycle state of an outbound message.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum DeliveryStatus {
+    /// Message is queued but not yet sent.
+    Queued,
+    /// Message has been transmitted.
+    Sent {
+        /// When the message was sent.
+        at: Instant,
+    },
+    /// Positive ACK received from the mesh.
+    Acknowledged {
+        /// When the ACK was received.
+        at: Instant,
+        /// Number of hops traversed, if known.
+        hops: Option<u8>,
+    },
+    /// Delivery permanently failed.
+    Failed {
+        /// Reason for failure.
+        reason: DeliveryFailure,
+    },
+    /// Message TTL expired before delivery could be confirmed.
+    Expired,
+}
+
+/// Why a message delivery failed.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum DeliveryFailure {
+    /// No route to the destination node.
+    NoRoute,
+    /// Maximum retry attempts exhausted.
+    MaxRetries,
+    /// Explicit NAK with a routing error code.
+    Nak(routing::Error),
+    /// Message TTL expired.
+    Ttl,
+    /// Destination node is offline and S&F is not available.
+    NodeOffline,
+}
+
+/// Per-destination delivery statistics.
+#[derive(Debug, Default, Clone)]
+pub struct DestStats {
+    /// Total messages attempted.
+    pub attempted: u64,
+    /// Total messages successfully acknowledged.
+    pub acknowledged: u64,
+    /// Total messages that failed delivery.
+    pub failed: u64,
+    /// Cumulative delivery latency in milliseconds (for computing averages).
+    pub latency_sum_ms: u64,
+    /// Total retries across all messages.
+    pub total_retries: u64,
+}
+
+impl DestStats {
+    /// Average delivery latency in milliseconds, or `None` if no messages acknowledged.
+    #[must_use]
+    pub const fn average_latency_ms(&self) -> Option<u64> {
+        if self.acknowledged > 0 {
+            Some(self.latency_sum_ms / self.acknowledged)
+        } else {
+            None
+        }
+    }
+
+    /// Success rate as a fraction (0.0–1.0), or `None` if no messages attempted.
+    #[must_use]
+    pub fn success_rate(&self) -> Option<f64> {
+        if self.attempted > 0 {
+            #[expect(
+                clippy::as_conversions,
+                reason = "u64→f64 for ratio calculation; precision loss acceptable for stats"
+            )]
+            Some(self.acknowledged as f64 / self.attempted as f64)
+        } else {
+            None
+        }
+    }
+}
+
+/// Internal record for a tracked message.
+struct DeliveryRecord {
+    status: DeliveryStatus,
+    dest: u32,
+    created: Instant,
+    retries: u8,
+}
+
+/// Tracks the full delivery lifecycle of outbound messages.
+pub struct DeliveryTracker {
+    records: HashMap<PacketId, DeliveryRecord>,
+    dest_stats: HashMap<u32, DestStats>,
+}
+
+impl DeliveryTracker {
+    /// Create an empty delivery tracker.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            records: HashMap::new(),
+            dest_stats: HashMap::new(),
+        }
+    }
+
+    /// Register a new outbound message as queued.
+    pub fn track(&mut self, id: PacketId, dest: u32) {
+        self.records.insert(
+            id,
+            DeliveryRecord {
+                status: DeliveryStatus::Queued,
+                dest,
+                created: Instant::now(),
+                retries: 0,
+            },
+        );
+        self.dest_stats.entry(dest).or_default().attempted += 1;
+    }
+
+    /// Mark a message as sent.
+    pub fn mark_sent(&mut self, id: PacketId) {
+        if let Some(record) = self.records.get_mut(&id) {
+            record.status = DeliveryStatus::Sent { at: Instant::now() };
+        }
+    }
+
+    /// Mark a message as acknowledged (ACK received).
+    pub fn mark_acknowledged(&mut self, id: PacketId, hops: Option<u8>) {
+        if let Some(record) = self.records.get_mut(&id) {
+            let now = Instant::now();
+            let latency_ms = now.duration_since(record.created).as_millis();
+            record.status = DeliveryStatus::Acknowledged { at: now, hops };
+            let stats = self.dest_stats.entry(record.dest).or_default();
+            stats.acknowledged += 1;
+            // NOTE: u128→u64 safe because latencies never exceed u64 range.
+            #[expect(
+                clippy::as_conversions,
+                reason = "u128→u64 after min(u64::MAX) guarantees no truncation"
+            )]
+            let latency_u64 = latency_ms.min(u128::from(u64::MAX)) as u64;
+            stats.latency_sum_ms = stats.latency_sum_ms.saturating_add(latency_u64);
+        }
+    }
+
+    /// Mark a message as failed.
+    pub fn mark_failed(&mut self, id: PacketId, reason: DeliveryFailure) {
+        if let Some(record) = self.records.get_mut(&id) {
+            record.status = DeliveryStatus::Failed { reason };
+            self.dest_stats.entry(record.dest).or_default().failed += 1;
+        }
+    }
+
+    /// Mark a message as expired.
+    pub fn mark_expired(&mut self, id: PacketId) {
+        if let Some(record) = self.records.get_mut(&id) {
+            record.status = DeliveryStatus::Expired;
+            self.dest_stats.entry(record.dest).or_default().failed += 1;
+        }
+    }
+
+    /// Increment the retry count for a message.
+    pub fn record_retry(&mut self, id: PacketId) {
+        if let Some(record) = self.records.get_mut(&id) {
+            record.retries += 1;
+            self.dest_stats
+                .entry(record.dest)
+                .or_default()
+                .total_retries += 1;
+        }
+    }
+
+    /// Query the current delivery status of a message.
+    #[must_use]
+    pub fn delivery_status(&self, id: PacketId) -> Option<&DeliveryStatus> {
+        self.records.get(&id).map(|r| &r.status)
+    }
+
+    /// Get delivery statistics for a destination node.
+    #[must_use]
+    pub fn stats_for(&self, dest: u32) -> Option<&DestStats> {
+        self.dest_stats.get(&dest)
+    }
+
+    /// Number of messages currently tracked.
+    #[must_use]
+    pub fn tracked_count(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Remove completed (acknowledged, failed, expired) records older than `max_age`.
+    pub fn prune_completed(&mut self, max_age: std::time::Duration) {
+        let now = Instant::now();
+        self.records.retain(|_, record| {
+            match &record.status {
+                DeliveryStatus::Acknowledged { .. }
+                | DeliveryStatus::Failed { .. }
+                | DeliveryStatus::Expired => now.duration_since(record.created) < max_age,
+                // Keep active records.
+                DeliveryStatus::Queued | DeliveryStatus::Sent { .. } => true,
+            }
+        });
+    }
+}
+
+impl Default for DeliveryTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn track_queued_to_sent_to_acknowledged() {
+        let mut tracker = DeliveryTracker::new();
+        let id = PacketId(100);
+
+        tracker.track(id, 0x1234);
+        assert!(
+            matches!(tracker.delivery_status(id), Some(DeliveryStatus::Queued)),
+            "should start as Queued"
+        );
+
+        tracker.mark_sent(id);
+        assert!(
+            matches!(
+                tracker.delivery_status(id),
+                Some(DeliveryStatus::Sent { .. })
+            ),
+            "should transition to Sent"
+        );
+
+        tracker.mark_acknowledged(id, Some(2));
+        assert!(
+            matches!(
+                tracker.delivery_status(id),
+                Some(DeliveryStatus::Acknowledged { hops: Some(2), .. })
+            ),
+            "should transition to Acknowledged with hops"
+        );
+    }
+
+    #[test]
+    fn track_queued_to_failed() {
+        let mut tracker = DeliveryTracker::new();
+        let id = PacketId(200);
+
+        tracker.track(id, 0x5678);
+        tracker.mark_sent(id);
+        tracker.mark_failed(id, DeliveryFailure::MaxRetries);
+
+        assert!(
+            matches!(
+                tracker.delivery_status(id),
+                Some(DeliveryStatus::Failed {
+                    reason: DeliveryFailure::MaxRetries
+                })
+            ),
+            "should be Failed::MaxRetries"
+        );
+    }
+
+    #[test]
+    fn track_expired() {
+        let mut tracker = DeliveryTracker::new();
+        let id = PacketId(300);
+
+        tracker.track(id, 0xABCD);
+        tracker.mark_expired(id);
+
+        assert!(
+            matches!(tracker.delivery_status(id), Some(DeliveryStatus::Expired)),
+            "should be Expired"
+        );
+    }
+
+    #[test]
+    fn dest_stats_accumulated() {
+        let mut tracker = DeliveryTracker::new();
+        let dest = 0x1111u32;
+
+        tracker.track(PacketId(1), dest);
+        tracker.mark_sent(PacketId(1));
+        tracker.mark_acknowledged(PacketId(1), None);
+
+        tracker.track(PacketId(2), dest);
+        tracker.mark_sent(PacketId(2));
+        tracker.mark_failed(PacketId(2), DeliveryFailure::NoRoute);
+
+        tracker.track(PacketId(3), dest);
+        tracker.record_retry(PacketId(3));
+
+        #[expect(
+            clippy::expect_used,
+            reason = "test-only: stats guaranteed to exist after tracking"
+        )]
+        let stats = tracker.stats_for(dest).expect("should have stats");
+        assert_eq!(stats.attempted, 3);
+        assert_eq!(stats.acknowledged, 1);
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.total_retries, 1);
+    }
+
+    #[test]
+    fn success_rate_calculation() {
+        let stats = DestStats {
+            attempted: 10,
+            acknowledged: 7,
+            failed: 3,
+            latency_sum_ms: 0,
+            total_retries: 0,
+        };
+        #[expect(
+            clippy::expect_used,
+            reason = "test-only: attempted > 0 so rate exists"
+        )]
+        let rate = stats.success_rate().expect("should have rate");
+        assert!(
+            (rate - 0.7).abs() < f64::EPSILON,
+            "expected 0.7, got {rate}"
+        );
+    }
+
+    #[test]
+    fn success_rate_none_when_empty() {
+        let stats = DestStats::default();
+        assert!(stats.success_rate().is_none());
+        assert!(stats.average_latency_ms().is_none());
+    }
+
+    #[test]
+    fn unknown_packet_returns_none() {
+        let tracker = DeliveryTracker::new();
+        assert!(tracker.delivery_status(PacketId(999)).is_none());
+    }
+
+    #[test]
+    fn tracked_count() {
+        let mut tracker = DeliveryTracker::new();
+        assert_eq!(tracker.tracked_count(), 0);
+        tracker.track(PacketId(1), 0x1234);
+        tracker.track(PacketId(2), 0x1234);
+        assert_eq!(tracker.tracked_count(), 2);
+    }
+
+    #[test]
+    fn nak_failure_variant() {
+        let mut tracker = DeliveryTracker::new();
+        let id = PacketId(400);
+        tracker.track(id, 0xBEEF);
+        tracker.mark_failed(id, DeliveryFailure::Nak(routing::Error::NoRoute));
+
+        assert!(matches!(
+            tracker.delivery_status(id),
+            Some(DeliveryStatus::Failed {
+                reason: DeliveryFailure::Nak(routing::Error::NoRoute)
+            })
+        ));
+    }
+}

--- a/crates/kerykeion/src/error.rs
+++ b/crates/kerykeion/src/error.rs
@@ -178,6 +178,60 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// Message delivery failed after exhausting all retry attempts.
+    #[snafu(display("delivery failed for packet {packet_id}: {reason}"))]
+    DeliveryFailed {
+        /// The packet that could not be delivered.
+        packet_id: u32,
+        /// Human-readable failure reason.
+        reason: String,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// A routing NAK was received from the mesh.
+    #[snafu(display("routing NAK for packet {packet_id}: {error_code}"))]
+    RoutingNak {
+        /// The packet that was NAK'd.
+        packet_id: u32,
+        /// Meshtastic routing error code name.
+        error_code: String,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Store-and-forward queue is full for the destination node.
+    #[snafu(display("store-forward queue full for node {dest:#010x}"))]
+    QueueFull {
+        /// The destination node whose queue is at capacity.
+        dest: u32,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Message has expired past its TTL.
+    #[snafu(display("message {packet_id} expired (TTL exceeded)"))]
+    MessageExpired {
+        /// The expired packet's ID.
+        packet_id: u32,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// Serialization or deserialization of store-forward state failed.
+    #[snafu(display("store-forward serialization error: {source}"))]
+    StoreForwardSerde {
+        /// Underlying `serde_json` error.
+        source: serde_json::Error,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 // WHY: tokio_util::codec::Decoder::Error and Encoder::Error both require

--- a/crates/kerykeion/src/lib.rs
+++ b/crates/kerykeion/src/lib.rs
@@ -17,9 +17,15 @@
 //! - Collection pipeline integration: [`collector::MeshCollector`]
 //! - Mesh topology graph: [`topology::MeshTopology`]
 //! - Packet dispatch: [`processor::PacketProcessor`]
+//! - Routing ACK/NAK processing: [`processor::RoutingProcessor`]
 //! - Node discovery: [`discovery::run_discovery`]
 //! - Gateway detection: [`gateway::GatewayDetector`]
 //! - Signal production: [`signals::MeshEvent`]
+//! - Message construction: [`message::MessageBuilder`]
+//! - Outbound queue: [`outbound::OutboundQueue`]
+//! - Message routing: [`router::MeshRouter`]
+//! - Delivery tracking: [`delivery::DeliveryTracker`]
+//! - Store-and-forward: [`store_forward::StoreForward`]
 
 pub mod bridge;
 pub mod codec;
@@ -27,15 +33,20 @@ pub mod collector;
 pub mod config;
 pub mod connection;
 pub mod crypto;
+pub mod delivery;
 pub mod discovery;
 pub mod error;
 pub mod gateway;
 pub mod handshake;
 pub mod heartbeat;
+pub mod message;
 pub mod mqtt;
 pub mod node_db;
+pub mod outbound;
 pub mod processor;
+pub mod router;
 pub mod signals;
+pub mod store_forward;
 pub mod topology;
 pub mod transport;
 pub mod types;
@@ -58,15 +69,20 @@ pub use collector::{Collector, MeshCollector};
 pub use config::{ChannelPsk, ConnectionConfig, MeshConfig, StoreForwardConfig, TopologyConfig};
 pub use connection::MeshConnection;
 pub use crypto::{DEFAULT_PSK, decrypt, encrypt};
+pub use delivery::{DeliveryFailure, DeliveryStatus, DeliveryTracker, DestStats};
 pub use discovery::{NodeState, build_traceroute_request, classify_node_state, run_discovery};
 pub use error::Error;
 pub use gateway::GatewayDetector;
 pub use handshake::{HandshakeResult, handshake};
+pub use message::MessageBuilder;
 pub use mqtt::{GatewayInfo, ParsedMapReport};
 pub use node_db::{DeviceMetrics, MeshNode, NodeDb, NodePosition, UserInfo};
-pub use processor::PacketProcessor;
+pub use outbound::{InflightMessage, OutboundQueue, PendingMessage};
+pub use processor::{PacketProcessor, RoutingProcessor, RoutingResult};
 pub use proto::{FromRadio, ToRadio};
+pub use router::{MeshRouter, SendOptions};
 pub use signals::{MeshEvent, mesh_event_to_signal};
+pub use store_forward::{StoreForward, StoredMessage};
 pub use topology::{LinkQuality, MeshTopology, TopologySnapshot};
 pub use types::{
     BROADCAST_ADDR, ChannelIndex, FRAME_MAGIC, MAX_CHANNELS, MAX_HOP_LIMIT, MAX_PACKET_SIZE,

--- a/crates/kerykeion/src/message.rs
+++ b/crates/kerykeion/src/message.rs
@@ -1,0 +1,351 @@
+//! Outbound message construction for Meshtastic mesh packets.
+
+use prost::Message as _;
+use rand_core::{OsRng, RngCore as _};
+
+use crate::crypto;
+use crate::error::Error;
+use crate::proto::mesh_packet::Priority;
+use crate::proto::{AdminMessage, Data, MeshPacket, PortNum, Position, mesh_packet};
+use crate::types::{ChannelIndex, MAX_HOP_LIMIT, NodeNum};
+
+/// Default hop limit for outbound packets.
+const DEFAULT_HOP_LIMIT: u8 = 3;
+
+/// Constructs outbound [`MeshPacket`] messages with a builder pattern.
+///
+/// # Examples
+///
+/// ```ignore
+/// let packet = MessageBuilder::text(NodeNum(0x1234), "hello")
+///     .with_ack()
+///     .build(NodeNum(0xABCD), &[0x01])?;
+/// ```
+pub struct MessageBuilder {
+    dest: NodeNum,
+    portnum: PortNum,
+    payload: Vec<u8>,
+    channel: ChannelIndex,
+    want_ack: bool,
+    hop_limit: u8,
+    priority: Priority,
+}
+
+impl MessageBuilder {
+    /// Build a text message (`TEXT_MESSAGE_APP`).
+    #[must_use]
+    pub fn text(dest: NodeNum, text: &str) -> Self {
+        Self {
+            dest,
+            portnum: PortNum::TextMessageApp,
+            payload: text.as_bytes().to_vec(),
+            channel: ChannelIndex(0),
+            want_ack: false,
+            hop_limit: DEFAULT_HOP_LIMIT,
+            priority: Priority::Default,
+        }
+    }
+
+    /// Build a position message (`POSITION_APP`).
+    ///
+    /// Latitude and longitude are in decimal degrees; they are converted to
+    /// Meshtastic's `i32` representation (`value * 1e7`).
+    #[must_use]
+    pub fn position(dest: NodeNum, lat: f64, lon: f64) -> Self {
+        // WHY: Meshtastic firmware stores lat/lon as fixed-point i32 = degrees * 1e7.
+        #[expect(
+            clippy::as_conversions,
+            reason = "f64→i32 via multiplication is the Meshtastic wire format convention"
+        )]
+        let pos = Position {
+            latitude_i: (lat * 1e7) as i32,
+            longitude_i: (lon * 1e7) as i32,
+            ..Default::default()
+        };
+        Self {
+            dest,
+            portnum: PortNum::PositionApp,
+            payload: pos.encode_to_vec(),
+            channel: ChannelIndex(0),
+            want_ack: false,
+            hop_limit: DEFAULT_HOP_LIMIT,
+            priority: Priority::Default,
+        }
+    }
+
+    /// Build an admin message (`ADMIN_APP`).
+    #[must_use]
+    pub fn admin(dest: NodeNum, admin_msg: &AdminMessage) -> Self {
+        Self {
+            dest,
+            portnum: PortNum::AdminApp,
+            payload: admin_msg.encode_to_vec(),
+            channel: ChannelIndex(0),
+            want_ack: true,
+            hop_limit: DEFAULT_HOP_LIMIT,
+            priority: Priority::Reliable,
+        }
+    }
+
+    /// Build a traceroute request (`TRACEROUTE_APP`).
+    #[must_use]
+    pub const fn traceroute(dest: NodeNum) -> Self {
+        Self {
+            dest,
+            portnum: PortNum::TracerouteApp,
+            payload: Vec::new(),
+            channel: ChannelIndex(0),
+            want_ack: true,
+            hop_limit: MAX_HOP_LIMIT,
+            priority: Priority::Reliable,
+        }
+    }
+
+    /// Set the channel index for this message.
+    #[must_use]
+    pub const fn channel(mut self, ch: ChannelIndex) -> Self {
+        self.channel = ch;
+        self
+    }
+
+    /// Request an acknowledgement for this message.
+    #[must_use]
+    pub const fn with_ack(mut self) -> Self {
+        self.want_ack = true;
+        self
+    }
+
+    /// Set the hop limit (clamped to [`MAX_HOP_LIMIT`]).
+    #[must_use]
+    pub const fn hop_limit(mut self, limit: u8) -> Self {
+        if limit > MAX_HOP_LIMIT {
+            self.hop_limit = MAX_HOP_LIMIT;
+        } else {
+            self.hop_limit = limit;
+        }
+        self
+    }
+
+    /// Set the delivery priority.
+    #[must_use]
+    pub const fn priority(mut self, p: Priority) -> Self {
+        self.priority = p;
+        self
+    }
+
+    /// Consume the builder and produce an encrypted [`MeshPacket`].
+    ///
+    /// A random `packet_id` is assigned. The payload is encrypted using
+    /// AES-CTR with the provided PSK.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Encryption`] if encryption fails (e.g. invalid PSK length).
+    pub fn build(self, from: NodeNum, psk: &[u8]) -> Result<MeshPacket, Error> {
+        let packet_id = OsRng.next_u32();
+
+        let data = Data {
+            portnum: self.portnum as i32,
+            payload: self.payload,
+            want_response: false,
+            dest: 0,
+            source: 0,
+            request_id: 0,
+            reply_id: 0,
+            emoji: vec![],
+        };
+        let plaintext = data.encode_to_vec();
+
+        let encrypted = crypto::encrypt(&plaintext, packet_id, from.0, psk)?;
+
+        // WHY: if PSK is empty, the channel is unencrypted — send as Decoded.
+        let payload_variant = if psk.is_empty() {
+            Some(mesh_packet::PayloadVariant::Decoded(data))
+        } else {
+            Some(mesh_packet::PayloadVariant::Encrypted(encrypted))
+        };
+
+        Ok(MeshPacket {
+            from: from.0,
+            to: self.dest.0,
+            channel: u32::from(self.channel.0),
+            id: packet_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: u32::from(self.hop_limit),
+            want_ack: self.want_ack,
+            priority: self.priority as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: u32::from(self.hop_limit),
+            payload_variant,
+        })
+    }
+
+    /// Consume the builder and produce an encrypted [`MeshPacket`] with a deterministic packet ID.
+    ///
+    /// Useful for testing. Production code should use [`build`](Self::build).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Encryption`] if encryption fails.
+    #[cfg(test)]
+    pub(crate) fn build_with_id(
+        self,
+        from: NodeNum,
+        psk: &[u8],
+        packet_id: u32,
+    ) -> Result<MeshPacket, Error> {
+        let data = Data {
+            portnum: self.portnum as i32,
+            payload: self.payload,
+            want_response: false,
+            dest: 0,
+            source: 0,
+            request_id: 0,
+            reply_id: 0,
+            emoji: vec![],
+        };
+        let plaintext = data.encode_to_vec();
+        let encrypted = crypto::encrypt(&plaintext, packet_id, from.0, psk)?;
+
+        let payload_variant = if psk.is_empty() {
+            Some(mesh_packet::PayloadVariant::Decoded(data))
+        } else {
+            Some(mesh_packet::PayloadVariant::Encrypted(encrypted))
+        };
+
+        Ok(MeshPacket {
+            from: from.0,
+            to: self.dest.0,
+            channel: u32::from(self.channel.0),
+            id: packet_id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: u32::from(self.hop_limit),
+            want_ack: self.want_ack,
+            priority: self.priority as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: u32::from(self.hop_limit),
+            payload_variant,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::mesh_packet::PayloadVariant;
+
+    const FROM: NodeNum = NodeNum(0xDEAD_BEEF);
+    const DEST: NodeNum = NodeNum(0x1234_5678);
+
+    #[test]
+    fn text_message_sets_portnum_and_encrypts() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::text(DEST, "hello mesh")
+            .build(FROM, &[0x01])
+            .unwrap();
+
+        assert_eq!(pkt.from, FROM.0);
+        assert_eq!(pkt.to, DEST.0);
+        assert!(pkt.payload_variant.is_some());
+        // With a non-empty PSK the payload should be encrypted.
+        assert!(
+            matches!(&pkt.payload_variant, Some(PayloadVariant::Encrypted(_))),
+            "expected encrypted payload"
+        );
+    }
+
+    #[test]
+    fn text_message_unencrypted_when_empty_psk() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::text(DEST, "cleartext")
+            .build(FROM, &[])
+            .unwrap();
+
+        assert!(
+            matches!(&pkt.payload_variant, Some(PayloadVariant::Decoded(d)) if d.portnum == PortNum::TextMessageApp as i32),
+            "expected decoded TEXT_MESSAGE_APP payload"
+        );
+    }
+
+    #[test]
+    fn position_message_encodes_lat_lon() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::position(DEST, 37.7749, -122.4194)
+            .build(FROM, &[])
+            .unwrap();
+
+        let Some(PayloadVariant::Decoded(data)) = &pkt.payload_variant else {
+            unreachable!("expected decoded position payload");
+        };
+        assert_eq!(data.portnum, PortNum::PositionApp as i32);
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pos = Position::decode(data.payload.as_slice()).unwrap();
+        // 37.7749 * 1e7 ≈ 377749000
+        assert!(
+            (pos.latitude_i - 377_749_000).unsigned_abs() < 10,
+            "latitude_i={} expected ~377749000",
+            pos.latitude_i
+        );
+    }
+
+    #[test]
+    fn admin_message_sets_reliable_priority() {
+        let admin = AdminMessage {
+            payload_variant: None,
+        };
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::admin(DEST, &admin)
+            .build(FROM, &[])
+            .unwrap();
+        assert_eq!(pkt.priority, Priority::Reliable as i32);
+        assert!(pkt.want_ack, "admin messages should request ACK");
+    }
+
+    #[test]
+    fn traceroute_uses_max_hop_limit() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::traceroute(DEST).build(FROM, &[]).unwrap();
+        assert_eq!(pkt.hop_limit, u32::from(MAX_HOP_LIMIT));
+        assert!(pkt.want_ack, "traceroute should request ACK");
+    }
+
+    #[test]
+    fn builder_chain_methods() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::text(DEST, "test")
+            .channel(ChannelIndex(2))
+            .with_ack()
+            .hop_limit(5)
+            .priority(Priority::Reliable)
+            .build(FROM, &[])
+            .unwrap();
+
+        assert_eq!(pkt.channel, 2);
+        assert!(pkt.want_ack);
+        assert_eq!(pkt.hop_limit, 5);
+        assert_eq!(pkt.priority, Priority::Reliable as i32);
+    }
+
+    #[test]
+    fn hop_limit_clamped_to_max() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::text(DEST, "test")
+            .hop_limit(100)
+            .build(FROM, &[])
+            .unwrap();
+        assert_eq!(pkt.hop_limit, u32::from(MAX_HOP_LIMIT));
+    }
+
+    #[test]
+    fn build_with_id_deterministic() {
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::text(DEST, "test")
+            .build_with_id(FROM, &[], 0xCAFE)
+            .unwrap();
+        assert_eq!(pkt.id, 0xCAFE);
+    }
+}

--- a/crates/kerykeion/src/outbound.rs
+++ b/crates/kerykeion/src/outbound.rs
@@ -1,0 +1,393 @@
+//! Priority-ordered outbound message queue with inflight tracking.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+use crate::proto::MeshPacket;
+use crate::proto::mesh_packet::Priority;
+use crate::types::PacketId;
+
+/// Maximum number of concurrent inflight messages (default).
+const DEFAULT_MAX_INFLIGHT: usize = 8;
+
+/// Maximum retry attempts before declaring a message failed.
+const DEFAULT_MAX_RETRIES: u8 = 5;
+
+/// A message waiting to be sent.
+#[derive(Debug)]
+pub struct PendingMessage {
+    /// The fully-constructed mesh packet.
+    pub packet: MeshPacket,
+    /// When this message was enqueued.
+    pub created: Instant,
+    /// Time-to-live: message is discarded after this duration.
+    pub ttl: Duration,
+    /// Delivery priority (higher numeric value = higher priority).
+    pub priority: Priority,
+    /// Number of prior retry attempts (carried forward from inflight).
+    pub retries: u8,
+}
+
+/// A message that has been sent and is awaiting ACK.
+#[derive(Debug)]
+pub struct InflightMessage {
+    /// The packet that was sent.
+    pub packet: MeshPacket,
+    /// When the packet was transmitted.
+    pub sent_at: Instant,
+    /// How many times this packet has been retried.
+    pub retries: u8,
+    /// Maximum retry attempts before failure.
+    pub max_retries: u8,
+    /// Duration to wait for ACK before timeout.
+    pub ack_timeout: Duration,
+}
+
+/// Manages outbound message flow with priority ordering and inflight tracking.
+pub struct OutboundQueue {
+    pending: VecDeque<PendingMessage>,
+    inflight: HashMap<PacketId, InflightMessage>,
+    max_inflight: usize,
+}
+
+impl OutboundQueue {
+    /// Creates an empty outbound queue with the default maximum inflight limit.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            pending: VecDeque::new(),
+            inflight: HashMap::new(),
+            max_inflight: DEFAULT_MAX_INFLIGHT,
+        }
+    }
+
+    /// Creates an outbound queue with a custom inflight limit.
+    #[must_use]
+    pub fn with_max_inflight(max_inflight: usize) -> Self {
+        Self {
+            pending: VecDeque::new(),
+            inflight: HashMap::new(),
+            max_inflight,
+        }
+    }
+
+    /// Insert a message by priority (higher priority first).
+    pub fn enqueue(&mut self, msg: PendingMessage) {
+        let insert_pos = self
+            .pending
+            .iter()
+            .position(|existing| (existing.priority as i32) < (msg.priority as i32))
+            .unwrap_or(self.pending.len());
+        self.pending.insert(insert_pos, msg);
+    }
+
+    /// Pop the highest-priority message that hasn't expired.
+    ///
+    /// Silently drops expired messages encountered during the search.
+    pub fn next_to_send(&mut self) -> Option<PendingMessage> {
+        if self.inflight.len() >= self.max_inflight {
+            return None;
+        }
+
+        let now = Instant::now();
+        while let Some(front) = self.pending.front() {
+            if now.duration_since(front.created) >= front.ttl {
+                // Expired — discard.
+                self.pending.pop_front();
+                continue;
+            }
+            return self.pending.pop_front();
+        }
+        None
+    }
+
+    /// Move a sent packet to inflight tracking.
+    pub fn mark_sent(&mut self, id: PacketId, timeout: Duration) {
+        if let Some(pos) = self.pending.iter().position(|m| m.packet.id == id.0) {
+            if let Some(msg) = self.pending.remove(pos) {
+                self.inflight.insert(
+                    id,
+                    InflightMessage {
+                        packet: msg.packet,
+                        sent_at: Instant::now(),
+                        retries: 0,
+                        max_retries: DEFAULT_MAX_RETRIES,
+                        ack_timeout: timeout,
+                    },
+                );
+            }
+        }
+        // NOTE: also allow marking sent for packets already popped via next_to_send
+    }
+
+    /// Record a sent packet directly into inflight tracking (after `next_to_send` pop).
+    pub fn track_inflight(&mut self, msg: PendingMessage, timeout: Duration) {
+        self.inflight.insert(
+            PacketId(msg.packet.id),
+            InflightMessage {
+                packet: msg.packet,
+                sent_at: Instant::now(),
+                retries: msg.retries,
+                max_retries: DEFAULT_MAX_RETRIES,
+                ack_timeout: timeout,
+            },
+        );
+    }
+
+    /// Handle an ACK: remove from inflight, message successfully delivered.
+    ///
+    /// Returns the inflight message if it was being tracked.
+    pub fn handle_ack(&mut self, id: PacketId) -> Option<InflightMessage> {
+        self.inflight.remove(&id)
+    }
+
+    /// Handle a NAK: schedule retry or declare failed.
+    ///
+    /// Returns `true` if the message will be retried, `false` if max retries exceeded.
+    pub fn handle_nak(&mut self, id: PacketId) -> bool {
+        self.retry(id)
+    }
+
+    /// Return packet IDs of inflight messages that have timed out.
+    #[must_use]
+    pub fn check_timeouts(&self) -> Vec<PacketId> {
+        let now = Instant::now();
+        self.inflight
+            .iter()
+            .filter(|(_, msg)| now.duration_since(msg.sent_at) >= msg.ack_timeout)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Increment retry count and re-enqueue. Returns `false` if max retries exceeded.
+    pub fn retry(&mut self, id: PacketId) -> bool {
+        let Some(mut msg) = self.inflight.remove(&id) else {
+            return false;
+        };
+
+        if msg.retries >= msg.max_retries {
+            return false;
+        }
+
+        msg.retries += 1;
+        let priority = Priority::try_from(msg.packet.priority).unwrap_or(Priority::Default);
+
+        self.enqueue(PendingMessage {
+            packet: msg.packet,
+            created: Instant::now(),
+            ttl: Duration::from_secs(3600),
+            priority,
+            retries: msg.retries,
+        });
+        true
+    }
+
+    /// Remove messages past TTL from both pending and inflight.
+    pub fn drain_expired(&mut self) {
+        let now = Instant::now();
+        self.pending
+            .retain(|msg| now.duration_since(msg.created) < msg.ttl);
+        self.inflight
+            .retain(|_, msg| now.duration_since(msg.sent_at) < Duration::from_secs(3600));
+    }
+
+    /// Number of messages waiting to be sent.
+    #[must_use]
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Number of messages currently inflight.
+    #[must_use]
+    pub fn inflight_count(&self) -> usize {
+        self.inflight.len()
+    }
+}
+
+impl Default for OutboundQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEFAULT_ACK_TIMEOUT: Duration = Duration::from_secs(30);
+
+    fn make_packet(id: u32, priority: Priority) -> MeshPacket {
+        MeshPacket {
+            from: 0xAAAA,
+            to: 0xBBBB,
+            channel: 0,
+            id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 3,
+            want_ack: true,
+            priority: priority as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 3,
+            payload_variant: None,
+        }
+    }
+
+    fn make_pending(id: u32, priority: Priority) -> PendingMessage {
+        PendingMessage {
+            packet: make_packet(id, priority),
+            created: Instant::now(),
+            ttl: Duration::from_secs(3600),
+            priority,
+            retries: 0,
+        }
+    }
+
+    #[test]
+    fn enqueue_orders_by_priority() {
+        let mut q = OutboundQueue::new();
+        q.enqueue(make_pending(1, Priority::Background));
+        q.enqueue(make_pending(2, Priority::Reliable));
+        q.enqueue(make_pending(3, Priority::Default));
+
+        #[expect(clippy::expect_used, reason = "test-only: queue has 3 items")]
+        let first = q.next_to_send().expect("expected a message");
+        assert_eq!(first.packet.id, 2, "Reliable (70) should come first");
+
+        #[expect(clippy::expect_used, reason = "test-only: queue has 2 items")]
+        let second = q.next_to_send().expect("expected a message");
+        assert_eq!(second.packet.id, 3, "Default (64) should come second");
+
+        #[expect(clippy::expect_used, reason = "test-only: queue has 1 item")]
+        let third = q.next_to_send().expect("expected a message");
+        assert_eq!(third.packet.id, 1, "Background (10) should come third");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_messages_skipped() {
+        let mut q = OutboundQueue::new();
+        q.enqueue(PendingMessage {
+            packet: make_packet(1, Priority::Default),
+            created: Instant::now(),
+            ttl: Duration::from_secs(1),
+            priority: Priority::Default,
+            retries: 0,
+        });
+        q.enqueue(PendingMessage {
+            packet: make_packet(2, Priority::Default),
+            created: Instant::now(),
+            ttl: Duration::from_secs(3600),
+            priority: Priority::Default,
+            retries: 0,
+        });
+
+        // Advance past the first message's TTL.
+        tokio::time::advance(Duration::from_secs(2)).await;
+
+        #[expect(clippy::expect_used, reason = "test-only: non-expired message exists")]
+        let msg = q.next_to_send().expect("expected message 2");
+        assert_eq!(msg.packet.id, 2, "should skip expired message 1");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inflight_timeout_detection() {
+        let mut q = OutboundQueue::new();
+        q.track_inflight(make_pending(42, Priority::Default), Duration::from_secs(10));
+
+        assert!(q.check_timeouts().is_empty(), "not yet timed out");
+
+        tokio::time::advance(Duration::from_secs(11)).await;
+
+        let timed_out = q.check_timeouts();
+        assert_eq!(timed_out.len(), 1);
+        assert_eq!(
+            timed_out.first().copied(),
+            Some(PacketId(42)),
+            "timed out packet should be 42"
+        );
+    }
+
+    #[test]
+    fn handle_ack_removes_inflight() {
+        let mut q = OutboundQueue::new();
+        q.track_inflight(make_pending(99, Priority::Default), DEFAULT_ACK_TIMEOUT);
+        assert_eq!(q.inflight_count(), 1);
+
+        let removed = q.handle_ack(PacketId(99));
+        assert!(removed.is_some(), "should return the removed message");
+        assert_eq!(q.inflight_count(), 0);
+    }
+
+    #[test]
+    fn retry_requeues_until_max() {
+        let mut q = OutboundQueue::new();
+        q.track_inflight(make_pending(10, Priority::Default), DEFAULT_ACK_TIMEOUT);
+
+        for i in 0..DEFAULT_MAX_RETRIES {
+            assert!(q.retry(PacketId(10)), "retry {i} should succeed");
+            // Re-track the re-enqueued message as inflight for the next retry.
+            if let Some(msg) = q.next_to_send() {
+                q.track_inflight(msg, DEFAULT_ACK_TIMEOUT);
+            }
+        }
+
+        // One more retry should fail (max retries exceeded).
+        assert!(!q.retry(PacketId(10)), "should fail after max retries");
+    }
+
+    #[test]
+    fn max_inflight_limits_sends() {
+        let mut q = OutboundQueue::with_max_inflight(2);
+        q.enqueue(make_pending(1, Priority::Default));
+        q.enqueue(make_pending(2, Priority::Default));
+        q.enqueue(make_pending(3, Priority::Default));
+
+        // Pop and track two as inflight.
+        for _ in 0..2 {
+            if let Some(msg) = q.next_to_send() {
+                q.track_inflight(msg, DEFAULT_ACK_TIMEOUT);
+            }
+        }
+
+        // Third should be blocked by max_inflight.
+        assert!(
+            q.next_to_send().is_none(),
+            "should block when at max inflight"
+        );
+        assert_eq!(q.pending_count(), 1, "one message still pending");
+    }
+
+    #[test]
+    fn drain_expired_removes_old_pending() {
+        let mut q = OutboundQueue::new();
+        // Create a message with zero TTL (already expired).
+        q.pending.push_back(PendingMessage {
+            packet: make_packet(1, Priority::Default),
+            created: Instant::now(),
+            ttl: Duration::ZERO,
+            priority: Priority::Default,
+            retries: 0,
+        });
+        q.enqueue(make_pending(2, Priority::Default));
+
+        q.drain_expired();
+        assert_eq!(q.pending_count(), 1, "expired message should be removed");
+    }
+
+    #[test]
+    fn alert_priority_sent_before_default() {
+        let mut q = OutboundQueue::new();
+        q.enqueue(make_pending(1, Priority::Default));
+        q.enqueue(make_pending(2, Priority::Ack));
+
+        #[expect(clippy::expect_used, reason = "test-only: queue has items")]
+        let first = q.next_to_send().expect("expected message");
+        assert_eq!(
+            first.packet.id, 2,
+            "ACK priority (120) should be sent before DEFAULT (64)"
+        );
+    }
+}

--- a/crates/kerykeion/src/processor.rs
+++ b/crates/kerykeion/src/processor.rs
@@ -3,10 +3,14 @@
 use prost::Message as _;
 use tokio::sync::broadcast;
 
+use crate::delivery::{DeliveryFailure, DeliveryTracker};
 use crate::node_db::{DeviceMetrics, MeshNode, NodeDb, NodePosition, UserInfo};
+use crate::outbound::OutboundQueue;
+use crate::proto::mesh_packet::PayloadVariant;
+use crate::proto::{MeshPacket, PortNum, Routing, routing};
 use crate::signals::{MeshEvent, mesh_event_to_signal};
 use crate::topology::MeshTopology;
-use crate::types::NodeNum;
+use crate::types::{NodeNum, PacketId};
 use koinon::GeoSignal;
 
 /// `NeighborInfo` protobuf (portnum 71) — not in vendored protos, decoded manually.
@@ -452,12 +456,118 @@ fn handle_routing(payload: &[u8]) {
     }
 }
 
+// ── Routing ACK/NAK processor ────────────────────────────────────────────────
+
+/// Result of processing a routing packet.
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RoutingResult {
+    /// ACK received — message was delivered.
+    Ack {
+        /// The packet ID that was acknowledged.
+        request_id: PacketId,
+    },
+    /// NAK received — routing error.
+    Nak {
+        /// The packet ID that failed.
+        request_id: PacketId,
+        /// The routing error code.
+        error: routing::Error,
+    },
+    /// The packet was not a routing packet or had no actionable variant.
+    NotRouting,
+}
+
+/// Processes inbound mesh packets for delivery confirmation (ACK/NAK).
+///
+/// Examines `ROUTING_APP` packets to update the delivery tracker and
+/// outbound queue based on acknowledgement or error responses.
+pub struct RoutingProcessor;
+
+impl RoutingProcessor {
+    /// Process an inbound mesh packet for routing ACK/NAK.
+    ///
+    /// Only `ROUTING_APP` packets with an `error_reason` variant are processed.
+    /// ACK = `Error::None`, NAK = any other error value.
+    #[must_use]
+    pub fn process_routing(packet: &MeshPacket) -> RoutingResult {
+        let Some(PayloadVariant::Decoded(data)) = &packet.payload_variant else {
+            return RoutingResult::NotRouting;
+        };
+
+        if data.portnum != PortNum::RoutingApp as i32 {
+            return RoutingResult::NotRouting;
+        }
+
+        // The request_id in the Data message refers to the original packet being ACK'd/NAK'd.
+        let request_id = data.request_id;
+        if request_id == 0 {
+            return RoutingResult::NotRouting;
+        }
+
+        let Ok(routing_msg) = Routing::decode(data.payload.as_slice()) else {
+            tracing::warn!(
+                packet_id = packet.id,
+                "failed to decode Routing payload from ROUTING_APP packet"
+            );
+            return RoutingResult::NotRouting;
+        };
+
+        match routing_msg.variant {
+            Some(routing::Variant::ErrorReason(code)) => {
+                let error = routing::Error::try_from(code).unwrap_or(routing::Error::None);
+                if error == routing::Error::None {
+                    RoutingResult::Ack {
+                        request_id: PacketId(request_id),
+                    }
+                } else {
+                    RoutingResult::Nak {
+                        request_id: PacketId(request_id),
+                        error,
+                    }
+                }
+            }
+            _ => RoutingResult::NotRouting,
+        }
+    }
+
+    /// Process a routing result and update the delivery tracker and outbound queue.
+    pub fn apply_routing_result(
+        result: &RoutingResult,
+        delivery: &mut DeliveryTracker,
+        outbound: &mut OutboundQueue,
+    ) {
+        match result {
+            RoutingResult::Ack { request_id } => {
+                tracing::debug!(packet_id = %request_id, "delivery confirmed via ACK");
+                outbound.handle_ack(*request_id);
+                delivery.mark_acknowledged(*request_id, None);
+            }
+            RoutingResult::Nak { request_id, error } => {
+                tracing::debug!(
+                    packet_id = %request_id,
+                    error = ?error,
+                    "delivery NAK received"
+                );
+                let retried = outbound.handle_nak(*request_id);
+                if retried {
+                    delivery.record_retry(*request_id);
+                } else {
+                    delivery.mark_failed(*request_id, DeliveryFailure::Nak(*error));
+                }
+            }
+            RoutingResult::NotRouting => {}
+        }
+    }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
+    use crate::proto::{Data, mesh_packet};
 
     fn make_processor() -> PacketProcessor {
         let (tx, _rx) = broadcast::channel(64);
@@ -678,5 +788,179 @@ mod tests {
             neighbors.iter().any(|(n, _)| *n == my_node),
             "direct packet should create link to server node"
         );
+    }
+
+    // ── Routing processor tests ──────────────────────────────────────────
+
+    fn make_routing_packet(request_id: u32, error_code: i32) -> MeshPacket {
+        let routing = Routing {
+            variant: Some(routing::Variant::ErrorReason(error_code)),
+        };
+        let routing_bytes = routing.encode_to_vec();
+
+        let data = Data {
+            portnum: PortNum::RoutingApp as i32,
+            payload: routing_bytes,
+            want_response: false,
+            dest: 0,
+            source: 0,
+            request_id,
+            reply_id: 0,
+            emoji: vec![],
+        };
+
+        MeshPacket {
+            from: 0x1111,
+            to: 0x2222,
+            channel: 0,
+            id: 0xFFFF,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 3,
+            want_ack: false,
+            priority: mesh_packet::Priority::Default as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 3,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(data)),
+        }
+    }
+
+    #[test]
+    fn ack_packet_detected() {
+        let pkt = make_routing_packet(0x1234, routing::Error::None as i32);
+        let result = RoutingProcessor::process_routing(&pkt);
+        assert_eq!(
+            result,
+            RoutingResult::Ack {
+                request_id: PacketId(0x1234)
+            }
+        );
+    }
+
+    #[test]
+    fn nak_no_route_detected() {
+        let pkt = make_routing_packet(0x5678, routing::Error::NoRoute as i32);
+        let result = RoutingProcessor::process_routing(&pkt);
+        assert_eq!(
+            result,
+            RoutingResult::Nak {
+                request_id: PacketId(0x5678),
+                error: routing::Error::NoRoute,
+            }
+        );
+    }
+
+    #[test]
+    fn nak_max_retransmit_detected() {
+        let pkt = make_routing_packet(0xABCD, routing::Error::MaxRetransmit as i32);
+        let result = RoutingProcessor::process_routing(&pkt);
+        assert_eq!(
+            result,
+            RoutingResult::Nak {
+                request_id: PacketId(0xABCD),
+                error: routing::Error::MaxRetransmit,
+            }
+        );
+    }
+
+    #[test]
+    fn non_routing_packet_ignored() {
+        let data = Data {
+            portnum: PortNum::TextMessageApp as i32,
+            payload: b"hello".to_vec(),
+            ..Default::default()
+        };
+        let pkt = MeshPacket {
+            from: 0x1111,
+            to: 0x2222,
+            channel: 0,
+            id: 1,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 3,
+            want_ack: false,
+            priority: mesh_packet::Priority::Default as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 3,
+            payload_variant: Some(mesh_packet::PayloadVariant::Decoded(data)),
+        };
+        assert_eq!(
+            RoutingProcessor::process_routing(&pkt),
+            RoutingResult::NotRouting
+        );
+    }
+
+    #[test]
+    fn encrypted_packet_returns_not_routing() {
+        let pkt = MeshPacket {
+            from: 0x1111,
+            to: 0x2222,
+            channel: 0,
+            id: 1,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 3,
+            want_ack: false,
+            priority: mesh_packet::Priority::Default as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 3,
+            payload_variant: Some(mesh_packet::PayloadVariant::Encrypted(vec![0xFF; 16])),
+        };
+        assert_eq!(
+            RoutingProcessor::process_routing(&pkt),
+            RoutingResult::NotRouting
+        );
+    }
+
+    #[test]
+    fn zero_request_id_ignored() {
+        let pkt = make_routing_packet(0, routing::Error::None as i32);
+        assert_eq!(
+            RoutingProcessor::process_routing(&pkt),
+            RoutingResult::NotRouting,
+            "request_id=0 should be ignored"
+        );
+    }
+
+    #[test]
+    fn apply_ack_updates_tracker() {
+        let mut delivery = DeliveryTracker::new();
+        let mut outbound = OutboundQueue::new();
+        let id = PacketId(42);
+
+        delivery.track(id, 0x1234);
+        delivery.mark_sent(id);
+
+        let result = RoutingResult::Ack { request_id: id };
+        RoutingProcessor::apply_routing_result(&result, &mut delivery, &mut outbound);
+
+        assert!(matches!(
+            delivery.delivery_status(id),
+            Some(crate::delivery::DeliveryStatus::Acknowledged { .. })
+        ));
+    }
+
+    #[test]
+    fn apply_nak_marks_failed_when_no_inflight() {
+        let mut delivery = DeliveryTracker::new();
+        let mut outbound = OutboundQueue::new();
+        let id = PacketId(77);
+
+        delivery.track(id, 0x5678);
+        delivery.mark_sent(id);
+
+        let result = RoutingResult::Nak {
+            request_id: id,
+            error: routing::Error::NoRoute,
+        };
+        RoutingProcessor::apply_routing_result(&result, &mut delivery, &mut outbound);
+
+        assert!(matches!(
+            delivery.delivery_status(id),
+            Some(crate::delivery::DeliveryStatus::Failed { .. })
+        ));
     }
 }

--- a/crates/kerykeion/src/router.rs
+++ b/crates/kerykeion/src/router.rs
@@ -1,0 +1,343 @@
+//! Message router orchestrating the outbound send path.
+
+use std::time::Duration;
+
+use crate::delivery::{DeliveryFailure, DeliveryTracker};
+use crate::outbound::{OutboundQueue, PendingMessage};
+use crate::proto::MeshPacket;
+use crate::proto::mesh_packet::Priority;
+use crate::store_forward::{StoreForward, StoredMessage};
+use crate::types::{NodeNum, PacketId};
+
+/// Default ACK timeout for inflight messages.
+const DEFAULT_ACK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default TTL for store-and-forward messages (1 hour).
+const DEFAULT_SF_TTL_SECS: u64 = 3600;
+
+/// Orchestrates the full outbound send path.
+///
+/// For reachable nodes, packets go through the [`OutboundQueue`].
+/// For unreachable nodes, packets go to [`StoreForward`].
+/// All messages are tracked by the [`DeliveryTracker`].
+pub struct MeshRouter {
+    /// Priority-ordered outbound queue.
+    pub outbound: OutboundQueue,
+    /// Store-and-forward for offline nodes.
+    pub store_forward: StoreForward,
+    /// Delivery lifecycle tracker.
+    pub delivery: DeliveryTracker,
+}
+
+/// Options for a send operation.
+#[derive(Debug, Clone)]
+pub struct SendOptions {
+    /// Whether to request an ACK.
+    pub want_ack: bool,
+    /// Delivery priority.
+    pub priority: Priority,
+    /// Time-to-live for store-and-forward.
+    pub ttl_secs: u64,
+}
+
+impl Default for SendOptions {
+    fn default() -> Self {
+        Self {
+            want_ack: false,
+            priority: Priority::Default,
+            ttl_secs: DEFAULT_SF_TTL_SECS,
+        }
+    }
+}
+
+impl MeshRouter {
+    /// Create a new router with the given sub-components.
+    #[must_use]
+    pub const fn new(
+        outbound: OutboundQueue,
+        store_forward: StoreForward,
+        delivery: DeliveryTracker,
+    ) -> Self {
+        Self {
+            outbound,
+            store_forward,
+            delivery,
+        }
+    }
+
+    /// Route a packet for delivery.
+    ///
+    /// If `reachable` is true, the packet is enqueued in the outbound queue.
+    /// If false, the packet is stored for later delivery via store-and-forward.
+    ///
+    /// Returns the [`PacketId`] for tracking.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::QueueFull`](crate::Error) if store-and-forward queue
+    /// is at capacity for the destination.
+    pub fn send(
+        &mut self,
+        packet: MeshPacket,
+        reachable: bool,
+        options: &SendOptions,
+    ) -> Result<PacketId, crate::Error> {
+        let id = PacketId(packet.id);
+        let dest = packet.to;
+
+        self.delivery.track(id, dest);
+
+        if reachable {
+            self.outbound.enqueue(PendingMessage {
+                packet,
+                created: tokio::time::Instant::now(),
+                ttl: Duration::from_secs(options.ttl_secs),
+                priority: options.priority,
+                retries: 0,
+            });
+        } else {
+            self.store_forward.store(
+                NodeNum(dest),
+                StoredMessage {
+                    packet_bytes: Vec::new(),
+                    packet_id: id.0,
+                    dest,
+                    portnum: 0,
+                    priority: options.priority as i32,
+                    stored_at_ms: 0,
+                    ttl_secs: options.ttl_secs,
+                    delivery_attempts: 0,
+                },
+            )?;
+        }
+
+        Ok(id)
+    }
+
+    /// Process an ACK for a delivered message.
+    pub fn handle_ack(&mut self, packet_id: PacketId, hops: Option<u8>) {
+        self.outbound.handle_ack(packet_id);
+        self.delivery.mark_acknowledged(packet_id, hops);
+    }
+
+    /// Process a NAK for a failed message.
+    ///
+    /// Retries via the outbound queue if retries remain. Otherwise marks as failed.
+    pub fn handle_nak(&mut self, packet_id: PacketId, error: crate::proto::routing::Error) {
+        let retried = self.outbound.handle_nak(packet_id);
+        if retried {
+            self.delivery.record_retry(packet_id);
+        } else {
+            self.delivery
+                .mark_failed(packet_id, DeliveryFailure::Nak(error));
+        }
+    }
+
+    /// Handle timeout for inflight messages.
+    ///
+    /// Returns packet IDs that timed out and were NOT retried (max retries exceeded).
+    pub fn process_timeouts(&mut self) -> Vec<PacketId> {
+        let timed_out = self.outbound.check_timeouts();
+        let mut failed = Vec::new();
+
+        for id in timed_out {
+            let retried = self.outbound.retry(id);
+            if retried {
+                self.delivery.record_retry(id);
+            } else {
+                self.delivery.mark_failed(id, DeliveryFailure::MaxRetries);
+                failed.push(id);
+            }
+        }
+
+        failed
+    }
+
+    /// Flush stored messages for a node that just came online.
+    ///
+    /// Moves messages from store-and-forward into the outbound queue.
+    pub fn node_came_online(&mut self, dest: NodeNum) {
+        let stored = self.store_forward.drain_for(dest);
+        for msg in stored {
+            let priority = Priority::try_from(msg.priority).unwrap_or(Priority::Default);
+            // WHY: re-enqueue stored messages as fresh pending messages.
+            let packet = MeshPacket {
+                from: 0,
+                to: msg.dest,
+                channel: 0,
+                id: msg.packet_id,
+                rx_time: 0,
+                rx_snr: 0.0,
+                hop_limit: 3,
+                want_ack: true,
+                priority: msg.priority,
+                rx_rssi: 0,
+                via_mqtt: false,
+                hop_start: 3,
+                payload_variant: None,
+            };
+            self.outbound.enqueue(PendingMessage {
+                packet,
+                created: tokio::time::Instant::now(),
+                ttl: Duration::from_secs(msg.ttl_secs),
+                priority,
+                retries: 0,
+            });
+        }
+    }
+
+    /// Pop the next message ready to send from the outbound queue.
+    pub fn next_to_send(&mut self) -> Option<PendingMessage> {
+        let msg = self.outbound.next_to_send()?;
+        let id = PacketId(msg.packet.id);
+        self.delivery.mark_sent(id);
+        Some(msg)
+    }
+
+    /// Track a just-sent message as inflight.
+    pub fn track_sent(&mut self, msg: PendingMessage) {
+        self.outbound.track_inflight(msg, DEFAULT_ACK_TIMEOUT);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreForwardConfig;
+    use crate::delivery::DeliveryStatus;
+
+    fn make_router() -> MeshRouter {
+        MeshRouter::new(
+            OutboundQueue::new(),
+            StoreForward::new(StoreForwardConfig {
+                enabled: true,
+                max_queue_per_dest: 16,
+                message_ttl_secs: 3600,
+            }),
+            DeliveryTracker::new(),
+        )
+    }
+
+    fn make_packet(id: u32) -> MeshPacket {
+        MeshPacket {
+            from: 0xAAAA,
+            to: 0xBBBB,
+            channel: 0,
+            id,
+            rx_time: 0,
+            rx_snr: 0.0,
+            hop_limit: 3,
+            want_ack: true,
+            priority: Priority::Default as i32,
+            rx_rssi: 0,
+            via_mqtt: false,
+            hop_start: 3,
+            payload_variant: None,
+        }
+    }
+
+    #[test]
+    fn send_reachable_goes_to_outbound() {
+        let mut router = make_router();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(1), true, &SendOptions::default())
+            .unwrap();
+
+        assert_eq!(router.outbound.pending_count(), 1);
+        assert_eq!(router.store_forward.total_stored(), 0);
+        assert!(
+            matches!(
+                router.delivery.delivery_status(id),
+                Some(DeliveryStatus::Queued)
+            ),
+            "should be tracked as Queued"
+        );
+    }
+
+    #[test]
+    fn send_unreachable_goes_to_store_forward() {
+        let mut router = make_router();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(2), false, &SendOptions::default())
+            .unwrap();
+
+        assert_eq!(router.outbound.pending_count(), 0);
+        assert_eq!(router.store_forward.total_stored(), 1);
+        assert!(router.delivery.delivery_status(id).is_some());
+    }
+
+    #[test]
+    fn ack_completes_delivery() {
+        let mut router = make_router();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(3), true, &SendOptions::default())
+            .unwrap();
+
+        // Simulate send + ACK.
+        if let Some(msg) = router.next_to_send() {
+            router.track_sent(msg);
+        }
+        router.handle_ack(id, Some(2));
+
+        assert!(matches!(
+            router.delivery.delivery_status(id),
+            Some(DeliveryStatus::Acknowledged { hops: Some(2), .. })
+        ));
+    }
+
+    #[test]
+    fn node_comes_online_flushes_store_forward() {
+        let mut router = make_router();
+        let dest = NodeNum(0xBBBB);
+
+        // Send to unreachable node.
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        router
+            .send(make_packet(10), false, &SendOptions::default())
+            .unwrap();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        router
+            .send(
+                MeshPacket {
+                    id: 11,
+                    ..make_packet(11)
+                },
+                false,
+                &SendOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(router.store_forward.total_stored(), 2);
+
+        // Node comes online — messages should move to outbound.
+        router.node_came_online(dest);
+        assert_eq!(router.store_forward.total_stored(), 0);
+        assert_eq!(router.outbound.pending_count(), 2);
+    }
+
+    #[test]
+    fn nak_triggers_retry_then_failure() {
+        let mut router = make_router();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(20), true, &SendOptions::default())
+            .unwrap();
+
+        // Pop and track as inflight.
+        if let Some(msg) = router.next_to_send() {
+            router.track_sent(msg);
+        }
+
+        // First NAK should retry.
+        router.handle_nak(id, crate::proto::routing::Error::NoRoute);
+        assert!(
+            !matches!(
+                router.delivery.delivery_status(id),
+                Some(DeliveryStatus::Failed { .. })
+            ),
+            "should not be failed yet after first NAK (retry should occur)"
+        );
+    }
+}

--- a/crates/kerykeion/src/store_forward.rs
+++ b/crates/kerykeion/src/store_forward.rs
@@ -1,0 +1,320 @@
+//! Store-and-forward message queuing for offline mesh nodes.
+
+use std::collections::{HashMap, VecDeque};
+
+use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
+
+use crate::config::StoreForwardConfig;
+use crate::error::{Error, QueueFullSnafu};
+use crate::types::NodeNum;
+
+/// A message stored for later delivery to an offline node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredMessage {
+    /// The raw packet bytes (already encrypted).
+    pub packet_bytes: Vec<u8>,
+    /// Packet ID for tracking.
+    pub packet_id: u32,
+    /// Destination node number.
+    pub dest: u32,
+    /// Port number of the original application.
+    pub portnum: i32,
+    /// Priority level (i32 matching `mesh_packet::Priority`).
+    pub priority: i32,
+    /// When this message was stored (milliseconds since an epoch — serializable).
+    pub stored_at_ms: u64,
+    /// Time-to-live in seconds.
+    pub ttl_secs: u64,
+    /// Number of delivery attempts so far.
+    pub delivery_attempts: u8,
+}
+
+/// Bounded queue for a single destination node.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct BoundedQueue {
+    messages: VecDeque<StoredMessage>,
+}
+
+/// Server-side message queuing for offline nodes.
+pub struct StoreForward {
+    queues: HashMap<NodeNum, BoundedQueue>,
+    config: StoreForwardConfig,
+    /// Monotonic base time for TTL checks in-process.
+    #[expect(
+        dead_code,
+        reason = "used for TTL baseline in production; tests use stored_at_ms"
+    )]
+    base_instant: Instant,
+}
+
+impl StoreForward {
+    /// Create a new store-and-forward queue with the given configuration.
+    #[must_use]
+    pub fn new(config: StoreForwardConfig) -> Self {
+        Self {
+            queues: HashMap::new(),
+            config,
+            base_instant: Instant::now(),
+        }
+    }
+
+    /// Store a message for an offline destination node.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::QueueFull`] if the destination's queue is at capacity
+    /// and the incoming message is not higher priority than any queued message.
+    pub fn store(&mut self, dest: NodeNum, msg: StoredMessage) -> Result<(), Error> {
+        let queue = self.queues.entry(dest).or_default();
+
+        if queue.messages.len() >= self.config.max_queue_per_dest {
+            // Evict lowest-priority message if the new one is higher priority.
+            let min_priority = queue.messages.iter().map(|m| m.priority).min().unwrap_or(0);
+            if msg.priority > min_priority {
+                if let Some(pos) = queue
+                    .messages
+                    .iter()
+                    .position(|m| m.priority == min_priority)
+                {
+                    queue.messages.remove(pos);
+                }
+            } else {
+                return QueueFullSnafu { dest: dest.0 }.fail();
+            }
+        }
+
+        queue.messages.push_back(msg);
+        Ok(())
+    }
+
+    /// Drain all queued messages for a destination (when the node comes online).
+    pub fn drain_for(&mut self, dest: NodeNum) -> Vec<StoredMessage> {
+        self.queues
+            .remove(&dest)
+            .map(|q| q.messages.into_iter().collect())
+            .unwrap_or_default()
+    }
+
+    /// Remove messages that have exceeded their TTL.
+    ///
+    /// Uses the `stored_at_ms` field and `ttl_secs` to determine expiration.
+    /// `now_ms` is the current wall-clock time in milliseconds since the epoch.
+    pub fn prune_expired(&mut self, now_ms: u64) {
+        for queue in self.queues.values_mut() {
+            queue.messages.retain(|msg| {
+                let expires_at_ms = msg
+                    .stored_at_ms
+                    .saturating_add(msg.ttl_secs.saturating_mul(1000));
+                now_ms < expires_at_ms
+            });
+        }
+        // Remove empty queues.
+        self.queues.retain(|_, q| !q.messages.is_empty());
+    }
+
+    /// Current queue depth for a destination node.
+    #[must_use]
+    pub fn queue_depth(&self, dest: NodeNum) -> usize {
+        self.queues.get(&dest).map_or(0, |q| q.messages.len())
+    }
+
+    /// Total messages stored across all destination queues.
+    #[must_use]
+    pub fn total_stored(&self) -> usize {
+        self.queues.values().map(|q| q.messages.len()).sum()
+    }
+
+    /// Serialize the store-forward state to JSON bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::StoreForwardSerde`] if serialization fails.
+    pub fn serialize(&self) -> Result<Vec<u8>, Error> {
+        let serializable: HashMap<u32, Vec<StoredMessage>> = self
+            .queues
+            .iter()
+            .map(|(k, v)| (k.0, v.messages.iter().cloned().collect()))
+            .collect();
+        serde_json::to_vec(&serializable).map_err(|source| Error::StoreForwardSerde {
+            source,
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+    }
+
+    /// Restore store-forward state from serialized JSON bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::StoreForwardSerde`] if deserialization fails.
+    pub fn deserialize(&mut self, data: &[u8]) -> Result<(), Error> {
+        let raw: HashMap<u32, Vec<StoredMessage>> =
+            serde_json::from_slice(data).map_err(|source| Error::StoreForwardSerde {
+                source,
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        self.queues = raw
+            .into_iter()
+            .map(|(node, messages)| {
+                (
+                    NodeNum(node),
+                    BoundedQueue {
+                        messages: messages.into(),
+                    },
+                )
+            })
+            .collect();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(max_per_dest: usize) -> StoreForwardConfig {
+        StoreForwardConfig {
+            enabled: true,
+            max_queue_per_dest: max_per_dest,
+            message_ttl_secs: 3600,
+        }
+    }
+
+    fn make_stored(id: u32, priority: i32, stored_at_ms: u64, ttl_secs: u64) -> StoredMessage {
+        StoredMessage {
+            packet_bytes: vec![0xAA, 0xBB],
+            packet_id: id,
+            dest: 0x1234,
+            portnum: 1,
+            priority,
+            stored_at_ms,
+            ttl_secs,
+            delivery_attempts: 0,
+        }
+    }
+
+    #[test]
+    fn store_and_drain() {
+        let mut sf = StoreForward::new(test_config(16));
+        let dest = NodeNum(0x1234);
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(1, 64, 1000, 3600)).unwrap();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(2, 64, 2000, 3600)).unwrap();
+
+        assert_eq!(sf.queue_depth(dest), 2);
+        assert_eq!(sf.total_stored(), 2);
+
+        let messages = sf.drain_for(dest);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(sf.queue_depth(dest), 0);
+    }
+
+    #[test]
+    fn queue_depth_limit_evicts_low_priority() {
+        let mut sf = StoreForward::new(test_config(2));
+        let dest = NodeNum(0x5678);
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(1, 10, 1000, 3600)).unwrap(); // Background
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(2, 64, 2000, 3600)).unwrap(); // Default
+        // Queue is now full (2). Higher-priority insert should evict background.
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(3, 70, 3000, 3600)).unwrap(); // Reliable
+
+        assert_eq!(sf.queue_depth(dest), 2);
+        let msgs = sf.drain_for(dest);
+        // Background (priority=10) should have been evicted.
+        assert!(
+            msgs.iter().all(|m| m.priority >= 64),
+            "background message should be evicted"
+        );
+    }
+
+    #[test]
+    fn queue_full_rejects_low_priority() {
+        let mut sf = StoreForward::new(test_config(1));
+        let dest = NodeNum(0xAAAA);
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(1, 70, 1000, 3600)).unwrap(); // Reliable
+
+        // Try to insert a lower-priority message — should fail.
+        let result = sf.store(dest, make_stored(2, 10, 2000, 3600));
+        assert!(result.is_err(), "should reject lower-priority message");
+    }
+
+    #[test]
+    fn prune_expired_removes_old_messages() {
+        let mut sf = StoreForward::new(test_config(16));
+        let dest = NodeNum(0xBBBB);
+
+        // Message stored at t=1000ms with TTL=1s → expires at t=2000ms.
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(1, 64, 1000, 1)).unwrap();
+        // Message stored at t=1000ms with TTL=3600s → expires much later.
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest, make_stored(2, 64, 1000, 3600)).unwrap();
+
+        sf.prune_expired(3000); // now = 3000ms, first message expired
+
+        assert_eq!(sf.queue_depth(dest), 1, "expired message should be pruned");
+    }
+
+    #[test]
+    fn serialize_deserialize_roundtrip() {
+        let mut sf = StoreForward::new(test_config(16));
+        let dest_a = NodeNum(0x1111);
+        let dest_b = NodeNum(0x2222);
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest_a, make_stored(1, 64, 1000, 3600)).unwrap();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest_a, make_stored(2, 70, 2000, 3600)).unwrap();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.store(dest_b, make_stored(3, 10, 3000, 3600)).unwrap();
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let serialized = sf.serialize().unwrap();
+
+        let mut sf2 = StoreForward::new(test_config(16));
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf2.deserialize(&serialized).unwrap();
+
+        assert_eq!(sf2.queue_depth(dest_a), 2);
+        assert_eq!(sf2.queue_depth(dest_b), 1);
+        assert_eq!(sf2.total_stored(), 3);
+
+        let msgs_a = sf2.drain_for(dest_a);
+        assert_eq!(
+            msgs_a.first().map(|m| m.packet_id),
+            Some(1),
+            "first stored message should have id 1"
+        );
+        assert_eq!(
+            msgs_a.get(1).map(|m| m.packet_id),
+            Some(2),
+            "second stored message should have id 2"
+        );
+    }
+
+    #[test]
+    fn drain_for_nonexistent_node_returns_empty() {
+        let mut sf = StoreForward::new(test_config(16));
+        let msgs = sf.drain_for(NodeNum(0xDEAD));
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn total_stored_across_multiple_destinations() {
+        let mut sf = StoreForward::new(test_config(16));
+        for i in 0..5u32 {
+            #[expect(clippy::unwrap_used, reason = "test-only")]
+            sf.store(NodeNum(i), make_stored(i, 64, 1000, 3600))
+                .unwrap();
+        }
+        assert_eq!(sf.total_stored(), 5);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MessageBuilder` for constructing encrypted outbound `MeshPacket` messages (text, position, admin, traceroute) with AES-CTR encryption and builder chain pattern
- Add `OutboundQueue` with priority-ordered sending, configurable max-inflight limit, timeout detection, and retry logic (max 5 retries)
- Add `StoreForward` for bounded per-destination queuing of messages to offline nodes, with TTL pruning, priority-based eviction, and JSON serialization/deserialization
- Add `DeliveryTracker` for full message lifecycle tracking (Queued → Sent → Acknowledged/Failed/Expired) with per-destination statistics and latency metrics
- Add `MeshRouter` orchestrating the send path — outbound queue for reachable nodes, store-and-forward for unreachable — with ACK/NAK/timeout handling and node-comes-online flush
- Add `PacketProcessor` for inbound ROUTING_APP packet processing, extracting ACK/NAK from protobuf `Routing` messages and updating delivery state
- 43 tests across 6 new modules; 5 new error variants in `error.rs`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (106 kerykeion tests, 319 total)
- [x] `cargo test --workspace --doc` passes
- [ ] CI green on all workflows