### PR TITLE
feat(kerykeion): node discovery, mesh topology graph, and peer tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "akroasis"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "comfy-table",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "koinon"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "blake3",
  "ciborium",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "kryphos"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "argon2",
  "blake3",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "syntonia"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compact_str",
  "csv",

--- a/crates/kerykeion/src/bridge.rs
+++ b/crates/kerykeion/src/bridge.rs
@@ -266,7 +266,7 @@ impl GatewayBridge {
 
     /// Records a failed health check for a gateway.
     ///
-    /// After [`OFFLINE_CHECK_THRESHOLD`] consecutive failures, the gateway
+    /// After `OFFLINE_CHECK_THRESHOLD` consecutive failures, the gateway
     /// transitions to [`GatewayHealth::Offline`] and an automatic failover
     /// is triggered if it was the active gateway.
     pub fn record_health_failure(&mut self, node: NodeNum) {

--- a/crates/kerykeion/src/handshake.rs
+++ b/crates/kerykeion/src/handshake.rs
@@ -145,7 +145,7 @@ pub async fn handshake(
     })
 }
 
-/// Convert a proto [`NodeInfo`] into a [`MeshNode`] for the in-memory database.
+/// Convert a proto `NodeInfo` into a [`MeshNode`] for the in-memory database.
 pub fn node_info_to_mesh_node(ni: &crate::proto::NodeInfo) -> MeshNode {
     let user = ni.user.as_ref().map(|u| UserInfo {
         id: u.id.clone(),


### PR DESCRIPTION
## Summary

- `topology.rs`: `MeshTopology` using petgraph `StableGraph` with directed weighted edges; Dijkstra shortest path (SNR-derived cost), connected-component partition detection, and JSON snapshot serialization for restart recovery
- `processor.rs`: `PacketProcessor` dispatching `NODEINFO_APP`, `POSITION_APP`, `TELEMETRY_APP`, `NEIGHBORINFO_APP`, `TRACEROUTE_APP`, `ROUTING_APP`; passive hop-count inference from `hop_start`/`hop_limit`; `RoutingProcessor` for ACK/NAK delivery tracking
- `discovery.rs`: `run_discovery` tokio task — periodic traceroutes to all known nodes, stale/offline node detection with 1×/2×/3× timeout thresholds, partition detection after stale-link pruning
- `signals.rs`: `MeshEvent` enum covering all mesh lifecycle events; `mesh_event_to_signal` converting each variant to `koinon::GeoSignal`
- `gateway.rs`: `GatewayDetector` with manual config and auto-detection (`ROUTER_CLIENT` + wifi/MQTT), `best_gateway` scoring by hop count and SNR

Closes #143

## Validation

```
cargo fmt --all -- --check      ✓
cargo clippy --workspace --all-targets -- -D warnings   ✓  (0 warnings)
cargo test --workspace          ✓  (174 tests, 47 in new modules)
```

## Test plan

- [x] Topology: add/update/remove nodes and links, idempotent add, stale pruning
- [x] Dijkstra path prefers higher SNR over fewer hops; unreachable returns `None`
- [x] Connected components: single cluster, two disconnected clusters
- [x] `is_partitioned` detects isolated nodes
- [x] Snapshot serialization roundtrip (nodes + edges)
- [x] PacketProcessor: NODEINFO, POSITION, TELEMETRY, NEIGHBORINFO, TRACEROUTE dispatch
- [x] Passive learning: hop count from `hop_start`/`hop_limit`, direct-link creation
- [x] RoutingProcessor: ACK, NAK (NoRoute, MaxRetransmit), non-routing packets ignored
- [x] Discovery: `classify_node_state` at 1×/2×/3× thresholds; traceroute request builds correct packet
- [x] Signal conversion: `NodeDiscovered` → `NodeSeen`, `PositionUpdate` → `Position`, metadata fields
- [x] Gateway: manual config, auto-detect (router_client + wifi/mqtt), role change removes gateway, `best_gateway` prefers closest

## Observations

- `koinon::MeshDetail` has `NodeSeen` and `Position` variants; several `MeshEvent` types (`TopologyChange`, `LinkDegraded`, `PartitionDetected`, `GatewayStatusChange`) fall back to `NodeSeen` with a metadata tag. Adding `TopologyLink`, `Partition`, `GatewayStatus` variants to `MeshDetail` would allow consumers to pattern-match without inspecting metadata.
- `NeighborInfo` protobuf is decoded locally in `processor.rs` because it is absent from the vendored `.proto` files; worth updating the vendor snapshot when upstream adds it.
- `Cargo.lock` was stale post-release (workspace versions at 0.1.5 rather than 0.1.6); fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)