### PR TITLE
docs: AGENTS.md + doc audit (closes #103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# akroasis
+
+Communications sovereignty and RF intelligence platform. Rust workspace, single binary, grid-down capable.
+
+## Commands
+
+- `cargo build`  -  debug build
+- `cargo test --workspace`  -  all tests
+- `cargo test -p <crate>`  -  single crate
+- `cargo clippy --workspace --all-targets -- -D warnings`  -  lint (zero warnings required)
+- `cargo fmt --all -- --check`  -  format gate
+- `kanon lint . --summary`  -  project-specific lint rules (standards enforcement)
+
+## Rules
+
+- Use `snafu` with `.context()` and `Location` tracking for errors  -  not `thiserror`, not `anyhow`; snafu carries source + location without boilerplate
+- Use `jiff` for time, `ulid` for IDs, `compact_str` for small strings  -  chrono is banned; ulid sorts lexicographically; compact_str avoids heap for short strings
+- Newtypes for all domain IDs (`SignalId`, `DeviceId`, `NodeId`)  -  raw `String`/`u64` lets mismatches pass the type checker
+- Use `#[expect(lint, reason = "...")]` not `#[allow]`  -  `#[expect]` warns when the suppression becomes stale
+- Conventional commits: `type(scope): description` where scope is the crate name  -  release-please parses these
+- `pub(crate)` by default, `pub` only for workspace-public API  -  narrow visibility keeps refactors local
+- No `unwrap()`, `expect()`, or `panic!()` in library code  -  workspace lints deny these; use `?` with snafu context
+
+## Architecture
+
+- Foundation: `koinon` (shared types, signal model), `kryphos` (crypto, identity)
+- Collection crates produce typed `GeoSignal` into the shared pipeline  -  add a domain, add a crate, signals flow automatically
+- Async: tokio, native async traits
+- Mesh: clean-room Meshtastic stack via `prost` protobuf  -  not the official `meshtastic` crate (GPL-3, ~15% coverage)
+
+## Where to add things
+
+- New crate: `crates/<greek-name>/`, register in root `Cargo.toml` members, follow `standards/GNOMON.md` for naming, add entry to `docs/lexicon.md`
+- New signal type: extend `GeoSignal` enum in `koinon`; downstream crates match exhaustively
+- New standard or convention: `standards/<TOPIC>.md`; cross-link from `standards/STANDARDS.md`
+
+## Boundaries
+
+- Always: run `cargo fmt` + `cargo clippy -D warnings` before pushing, rebase onto main (linear history), squash merge
+- Ask first: changes to `GeoSignal` enum, crypto primitives in `kryphos`, workspace-wide dependency bumps
+- Never: push to upstream with `--force`, bypass CI with `--admin`, commit secrets (see `.gitleaks.toml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,7 @@ Writing: [standards/WRITING.md](standards/WRITING.md)
 
 ## Structure
 
-6 crates shipped (koinon, kryphos, syntonia, kerykeion, semaino, akroasis), 12 planned. 10 capability domains. See README.md for the full domain map with status markers.
-
-Foundation: `koinon` (shared types, signal model), `kryphos` (encryption, identity).
+Foundation layer: `koinon` (shared types, signal model), `kryphos` (encryption, identity). See README.md for the full domain map with status markers and `docs/ARCHITECTURE.md` for layer structure.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Akroasis is the attempt to fix that.
 
 One system. One signal model. Every domain produces typed signals into the same pipeline. Radio anomalies correlate with network threats correlate with proximity intelligence correlate with OSINT. The convergence is where the intelligence lives - not in any single domain but in the relationships between them.
 
-6 crates shipped, 12 planned. 10 capability domains. Rust from the ground up.
+Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, offensive security, signal intelligence, and geospatial modeling. Rust from the ground up. See the domain table below for shipped (✓) vs planned (◻).
 
 ---
 
@@ -107,14 +107,14 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 ## Documentation
 
 - [standards/STANDARDS.md](standards/STANDARDS.md): Coding standards (universal + per-language)
-- [docs/gnomon.md](docs/gnomon.md): Naming methodology
+- [standards/GNOMON.md](standards/GNOMON.md): Naming methodology
 - [docs/lexicon.md](docs/lexicon.md): Project name registry
 
 ## Status
 
-Wave 1 (kryphos), Wave 2 (syntonia + kerykeion), and Wave 3 (semaino) are complete. 6 crates shipping ~25K LOC with 600+ tests. Architecture finalized. Active development ongoing.
+Architecture finalized. Active development ongoing. See the domain table above for shipped vs planned crates; merged waves are visible via `gh pr list --state merged --repo forkwright/akroasis`.
 
-The scope is massive. Each domain is independent: one crate with clear boundaries, producing typed signals into the shared model. Pieces do not need to arrive simultaneously. They only need to speak the same language when they do.
+The scope is massive. Each domain is independent: a crate with clear boundaries, producing typed signals into the shared model. Pieces don't need to arrive simultaneously. They just need to speak the same language when they do.
 
 ---
 
@@ -142,7 +142,7 @@ Names follow [gnomon](https://github.com/forkwright/aletheia/blob/main/docs/gnom
 
 ---
 
-*See [docs/gnomon.md](docs/gnomon.md) for the complete name registry.*
+*See [docs/lexicon.md](docs/lexicon.md) for the complete name registry and [standards/GNOMON.md](standards/GNOMON.md) for the naming methodology.*
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 # Architecture: Akroasis
 
-Single Rust binary. 17 crates across 5 layers. All domains produce typed `GeoSignal` into a shared pipeline.
+Single Rust binary. Five layers. All domains produce typed `GeoSignal` into a shared pipeline.
+
+Run `cargo metadata --format-version 1 | jq '.workspace_members | length'` for current crate count.
 
 ## Layer structure
 
@@ -56,4 +58,4 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 ## References
 
 - Planning docs (scope, roadmap, vision, research): live in the kanon repo
-- Naming: `gnomon.md`, `lexicon.md`
+- Naming: `../standards/GNOMON.md`, `lexicon.md`

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,10 +1,10 @@
 # Akroasis - Project Overview
 
-Communications sovereignty, RF intelligence, and operational awareness platform. 17 crates, 10 capability domains, one shared signal model.
+Communications sovereignty, RF intelligence, and operational awareness platform. Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, offensive security, and signal intelligence, unified by one shared signal model.
 
 ## Current state
 
-Phases 0, 1, and 2 complete. Wave 1 (kryphos, 7 PRs) and Wave 2 (syntonia, 7 PRs) merged. Foundation and radio management layers are done.
+See the status markers in [../README.md](../README.md) for shipped vs planned crates. Phase and wave status lives in the kanon repo roadmap  -  single source of truth.
 
 ## Architecture
 
@@ -12,16 +12,7 @@ See `ARCHITECTURE.md` for the crate map, layer structure, and key decisions.
 
 ## Phases
 
-| Phase | Domain | Status |
-|-------|--------|--------|
-| 0 | Foundation + research | Complete |
-| 1 | Radio management (syntonia) | Complete |
-| 2 | Mesh core (kerykeion) | Complete |
-| 3 | SDR foundation (dektis) | Queued |
-| 4 | Signal intelligence (semaino + ichneutes) | Queued |
-| 5-14 | Network defense through Aletheia integration | Planned |
-
-Full phase details: kanon repo roadmap.
+Phase index lives in the kanon repo roadmap. Wave status is reflected in merged PRs (`gh pr list --state merged --repo forkwright/akroasis`) and the shipped/planned markers in README.md. Duplicating phase tables here produces stale content  -  intentionally omitted.
 
 ## Related projects
 
@@ -35,7 +26,7 @@ Full phase details: kanon repo roadmap.
 | Document | Purpose |
 |----------|---------|
 | `ARCHITECTURE.md` | Crate map, layer structure, key decisions |
-| `gnomon.md` | Greek naming methodology |
+| `../standards/GNOMON.md` | Greek naming methodology |
 | `lexicon.md` | Domain terms and name registry |
 | `../standards/STANDARDS.md` | Universal coding standards |
 | `../standards/RUST.md` | Rust conventions |

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -1,7 +1,7 @@
 # Akroasis: Lexicon
 
 *Living registry. Updated as crates are added or renamed.*
-*For the naming methodology and construction system, see [gnomon.md](gnomon.md).*
+*For the naming methodology and construction system, see [../standards/GNOMON.md](../standards/GNOMON.md).*
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,12 +4,12 @@
 
 Rust workspace for vehicle systems, radio programming, communications infrastructure, and field preparedness tools. Designed for a 1997 Dodge Ram 2500 12V Cummins platform.
 
-17 crates across 10 capability domains: radio programming, signal intelligence, navigation, network security, communications, vehicle telemetry, field operations, encryption, power management, and shared foundations.
+Capability domains: radio programming, signal intelligence, navigation, network security, communications, vehicle telemetry, field operations, encryption, power management, and shared foundations.
 
 ## Documentation
 
 - [CLAUDE.md](CLAUDE.md): Project conventions
 - [README.md](README.md): Domain map and crate overview
 - [standards/STANDARDS.md](standards/STANDARDS.md): Coding standards
-- [docs/gnomon.md](docs/gnomon.md): Greek naming methodology
+- [standards/GNOMON.md](standards/GNOMON.md): Greek naming methodology
 - [docs/lexicon.md](docs/lexicon.md): Project name registry


### PR DESCRIPTION
## Summary

Closes #103.

Adds a cross-tool AGENTS.md and audits the existing documentation for stale counts, broken links, and derivable metrics per the kanon AGENT-DOCS.md and WRITING.md standards.

## Commits

1. **`docs: add AGENTS.md for cross-tool agent orientation`** (11a3740)
   - New AGENTS.md at repo root (41 lines). Agents.md open standard — read by Claude Code, Cursor, Windsurf, Copilot, Codex, and others. Self-contained, no CLAUDE.md references.
   - Sections: Commands, Rules (with WHY on each), Architecture, Where to add things, Boundaries.
   - `_llm/` directory: skipped. akroasis is a small workspace (6 crates present, 17 planned) and CLAUDE.md is 47 lines — well under the 100-line threshold from the kanon REPO-SETUP project-type matrix. Architecture is already well-documented in README.md, docs/ARCHITECTURE.md, and docs/lexicon.md. Revisit when CLAUDE.md exceeds 100 lines or crate count exceeds 10.

2. **`docs: audit for stale counts, broken links, and derivable metrics`** (fcf2c58)
   - Fixed 5 broken `docs/gnomon.md` links — the file does not exist in this repo; the naming methodology lives at `standards/GNOMON.md`. Updated README.md, llms.txt, docs/lexicon.md, docs/ARCHITECTURE.md, docs/PROJECT.md.
   - Removed embedded crate counts ("17 crates", "6 crates shipped, 12 planned", "10 capability domains") from CLAUDE.md, README.md, llms.txt, docs/ARCHITECTURE.md, docs/PROJECT.md. Replaced with references to the domain table (shipped/planned status markers) and the `cargo metadata` command per kanon "no derivable metrics in docs" rule.
   - Fixed stale wave status in docs/PROJECT.md (claimed Wave 3 still queued; Wave 3 semaino is merged). Replaced duplicated phase table with pointer to the kanon roadmap (single source of truth) and the `gh pr list` command.
   - Removed drift-prone "~25K LOC with 600+ tests" from README.md.
   - Fixed a pre-existing WRITING/repeated-sentence-start violation at README.md line 117.

## Gate evidence

- `kanon lint <each-changed-file> --summary` — no violations on any modified file
- `cargo fmt --all -- --check` — passes (no Rust changes)
- Pre-existing lint debt elsewhere in the repo (699 violations) is being addressed by a separate cleanup agent; none introduced by this PR

## Test plan

- [ ] `kanon lint AGENTS.md README.md CLAUDE.md llms.txt docs/ --summary` — zero violations on changed files
- [ ] All `docs/gnomon.md` references resolve (now point to `standards/GNOMON.md`)
- [ ] CI passes