### PR TITLE
chore(security): allowlist HIGH (c) false-positives in .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -32,3 +32,10 @@ paths = [
   '''vendor/''',
   '''\.gitleaks\.toml''',
 ]
+regexes = [
+  '''sk-secret-123''', # WHY: A2 - vault unit-test fixture; see small-repo-security-triage-2026-05-21.md
+  '''plain-key-value''', # WHY: A3 - test fixture; see small-repo-security-triage-2026-05-21.md
+  '''vault:nonexistent_key''', # WHY: A4 - vault sentinel test fixture; see small-repo-security-triage-2026-05-21.md
+  '''vault:some_key''', # WHY: A5 - vault sentinel test fixture; see small-repo-security-triage-2026-05-21.md
+  '''ChaCha20-Poly1305''', # WHY: A1 - doc-comment cipher-name false-positive; see small-repo-security-triage-2026-05-21.md
+]


### PR DESCRIPTION
## Summary
- Add regex allowlist entries for HIGH class-(c) gitleaks false-positives from /home/ck/metis-ops/projects/_recovery/small-repo-security-triage-2026-05-21.md.
- Covered findings: A1, A2, A3, A4, A5.

## Validation
- gitleaks detect --source . --config .gitleaks.toml --no-banner --redact
- cargo check --workspace --no-default-features
- kanon lint --summary: n/a on verda per dispatcher footer