### PR TITLE
chore(hygiene): milestone audit sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 | Area | Current / Planned |
 |------|-------------------|
 | Language | Rust edition 2024, MSRV 1.85 |
-| Version | 0.1.11 workspace package version |
+| Version | 0.1.12 workspace package version |
 | Errors | snafu context wrapping |
 | Async | tokio |
 | Storage | fjall for vault state; CBOR + BLAKE3 hash chains for tamper logs |


### PR DESCRIPTION
## Summary

Milestone-level QA audit sweep (2026-05-24). One safe-class fix:

- README Version row drifted from Cargo.toml after `release 0.1.12` (0.1.11 -> 0.1.12). Release-please updates Cargo.toml + manifest via `extra-files`, but the prose row in README isn't in scope, so it lagged a release.

## Test plan

- [ ] CI green
- [ ] No behavioral changes (docs only)

## Out of scope

Larger findings flagged to operator in audit report (placeholder paths in README/_llm, release-please tag-collision failure, etc.).