### PR TITLE
docs(_llm): resolve <canonical-state-doc> placeholders in 4 toml meta files

### DIFF
--- a/_llm/architecture.toml
+++ b/_llm/architecture.toml
@@ -7,7 +7,7 @@ source_docs = [
   "AGENTS.md",
   "CLAUDE.md",
   "Cargo.toml",
-  "<canonical-state-doc>/STATE.md",
+  "kanon:projects/akroasis/STATE.md",
 ]
 
 [architecture]

--- a/_llm/current_state.toml
+++ b/_llm/current_state.toml
@@ -4,7 +4,7 @@ repo = "forkwright/akroasis"
 generated = false
 source_docs = [
   "README.md",
-  "<canonical-state-doc>/STATE.md",
+  "kanon:projects/akroasis/STATE.md",
 ]
 
 [state]

--- a/_llm/decisions.toml
+++ b/_llm/decisions.toml
@@ -5,7 +5,7 @@ generated = false
 source_docs = [
   "README.md",
   "CLAUDE.md",
-  "<canonical-state-doc>/STATE.md",
+  "kanon:projects/akroasis/STATE.md",
 ]
 
 [decisions]

--- a/_llm/glossary.toml
+++ b/_llm/glossary.toml
@@ -5,7 +5,7 @@ generated = false
 source_docs = [
   "README.md",
   "docs/lexicon.md",
-  "<canonical-state-doc>/STATE.md",
+  "kanon:projects/akroasis/STATE.md",
 ]
 
 [glossary]


### PR DESCRIPTION
## Summary

Resolves #135. Substitutes the literal `<canonical-state-doc>/STATE.md` template strings with the canonical `kanon:projects/akroasis/STATE.md` pointer across the four `_llm/*.toml` meta files. Matches the README substitution shipped in #138 for the same audit finding.

## Files

| File | Line |
|------|------|
| `_llm/architecture.toml` | 10 |
| `_llm/current_state.toml` | 7 |
| `_llm/decisions.toml` | 8 |
| `_llm/glossary.toml` | 8 |

## Test plan

- [x] No literal placeholders remain (`grep -rn '<canonical-state-doc>\|<standards-doc>' _llm/` returns empty)
- [x] Gate-Passed trailer present

Closes #135