### PR TITLE
docs(README): downgrade NixOS design-constraint claim to planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 - **Sovereignty.** Every protocol owned. No cloud dependencies, no subscriptions, no external trust.
 - **Security default.** Encrypted by default. Unencrypted is the opt-in.
 - **Auditable.** Tamper-evident logging with hash chains. Every action recorded. Evidence packaging with chain of custody.
-- **NixOS.** Reproducible builds, systemd hardening, declarative deployment from day one.
+- **Reproducible deployment (planned).** NixOS flake + systemd unit hardening + declarative deployment is the intended target shape; no deployment artifacts ship today. Tracked in #125.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #137. README:88 advertised NixOS reproducible builds + systemd hardening + declarative deployment as a shipped design constraint. No deployment artifacts (`*.nix`, `flake.nix`, `*.service`, `*.timer`) exist in the repo (per #125 audit). Restated as the planned target shape with a pointer to the open tracking issue.

#137 explicitly asked for a doc downgrade or extending #125 to cover both the deployment claim AND the constraint claim. This PR takes the lighter option: downgrade the constraint line, leave #125 open as the artifact-shipping tracker.

## Before
> - **NixOS.** Reproducible builds, systemd hardening, declarative deployment from day one.

## After
> - **Reproducible deployment (planned).** NixOS flake + systemd unit hardening + declarative deployment is the intended target shape; no deployment artifacts ship today. Tracked in #125.

## Test plan

- [x] No new claims of shipped NixOS/systemd artifacts in README
- [x] #125 remains the canonical tracker for the artifact work
- [x] Gate-Passed trailer present

Closes #137