### PR TITLE
chore(kerykeion): localize cross-repo TODO ref (#130)

### DIFF
--- a/crates/kerykeion/src/bridge.rs
+++ b/crates/kerykeion/src/bridge.rs
@@ -361,8 +361,7 @@ pub async fn run_health_monitor(
 ) -> Result<(), Error> {
     // WHY: lock once up front to capture the configured tick cadence. The
     // config is copied by value so we release the lock before entering the
-    // long-running loop; live reconfig is a future concern tracked in the
-    // parameter registry (aletheia #2306).
+    // long-running loop; live reconfig is a future concern tracked at TODO(#142).
     let tick_interval = bridge.lock().await.config.health_check_interval();
     let mut interval = tokio::time::interval(tick_interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);


### PR DESCRIPTION
## Summary

Replace cross-repo TODO ref (`aletheia #2306`) in `crates/kerykeion/src/bridge.rs:363-365` with a local `TODO(#142)` per the akroasis#130 done-criteria.

The bridge live-reconfig deferral is now discoverable from `git grep TODO` and follows the `TODO(#NNN)` convention used elsewhere in the repo (e.g. `crates/syntonia/src/yaesu/*.rs`).

## Closes

- akroasis#130 (cross-repo TODO localization audit)

## Linked tracker

- akroasis#142 — new local issue tracking the deferred live-reconfig work.

## Test plan

- [x] Comment-only edit in `bridge.rs`; `cargo check -p kerykeion` clean.
- [x] No semantic change.