### PR TITLE
ci(security): add daily cargo-audit + cargo-deny workflow

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration.
+#
+# WHY: cargo-audit does not read deny.toml. This file mirrors the advisory
+# ignore list in deny.toml so both tools stay in sync. When adding or
+# removing an ignore here, update deny.toml's [[advisories.ignore]]
+# entries to match (and vice versa).
+
+[advisories]
+ignore = [
+    # number_prefix unmaintained, transitive via indicatif; no safe
+    # upgrade available upstream.
+    "RUSTSEC-2025-0119",
+]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,75 @@
+# WHY: Block merges on known vulnerabilities and license/source/ban
+# violations. Runs `cargo audit` (RustSec DB) and `cargo deny check`
+# (licenses, sources, bans, advisories) on every PR and daily against main
+# so newly-published CVEs against existing deps are caught even when no PR
+# is open. See standards/CI.md § Vulnerability scanning.
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # NOTE: Daily at 05:23 CST (11:23 UTC). Off-peak minute per global
+    # rule about avoiding :00/:30 cron schedules. Non-overlapping with
+    # stale (Sun 06:00 CST).
+    - cron: "23 11 * * *"
+  workflow_dispatch:
+
+# PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-deny:
+    # WHY: checks licenses, banned crates, source registries, and the
+    # RustSec advisory DB using deny.toml's ignore list. Any finding fails
+    # the job — suppressions require a deny.toml entry with a WHY comment,
+    # not silent --ignore flags.
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false # PROJECT: security hardening — never expose token to steps
+      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+        with:
+          # WHY: run every check explicitly so a schema regression in one
+          # section can't silently disable the others. cargo-deny expects
+          # the check subcommand followed by space-separated check names;
+          # `arguments:` passes post-subcommand flags only.
+          command: check advisories licenses bans sources
+          arguments: --all-features
+
+  cargo-audit:
+    # WHY: cargo-deny's advisories check overlaps but uses a different code
+    # path; running cargo-audit independently protects against bugs or
+    # config drift disabling one of the two. See standards/CI.md.
+    name: cargo audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cargo-audit
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version ^0.22
+      - name: cargo audit
+        # WHY: -D unmaintained,unsound,yanked escalates those categories
+        # to errors (default is warning only). Suppressions go through
+        # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
+        # entries — no silent --ignore flags here.
+        run: cargo audit --deny unmaintained --deny unsound --deny yanked

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Cargo build output
 /target/
 **/*.rs.bk
-.cargo/
+.cargo/*
+# WHY: track checked-in cargo-audit suppressions (mirrors deny.toml).
+!.cargo/audit.toml
 
 # Secrets
 *.env

--- a/deny.toml
+++ b/deny.toml
@@ -1,18 +1,21 @@
-# cargo-deny configuration
-# https://embarkstudios.github.io/cargo-deny/
-
 [graph]
 targets = []
 all-features = false
 
 [advisories]
+
+# WHY: keep in sync with .cargo/audit.toml's [advisories.ignore] array.
+# cargo-audit does not read deny.toml, so any ignore lives in both files.
+
 [[advisories.ignore]]
 id = "RUSTSEC-2025-0119"
-reason = "number_prefix unmaintained, transitive via indicatif; no safe upgrade"
+reason = "number_prefix unmaintained, transitive via indicatif; no safe upgrade available upstream."
 
 [licenses]
+# WHY: AGPL-3.0-only is the workspace license itself (declared in
+# workspace.package). MPL-2.0, BSL-1.0, CC0-1.0 cover permissive
+# transitive licenses surfaced by the dep tree.
 allow = [
-    "MPL-2.0",
     "MIT",
     "Apache-2.0",
     "AGPL-3.0-only",
@@ -21,6 +24,7 @@ allow = [
     "ISC",
     "Zlib",
     "Unicode-3.0",
+    "MPL-2.0",
     "BSL-1.0",
     "CC0-1.0",
 ]
@@ -29,8 +33,11 @@ confidence-threshold = 0.8
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"
+# WHY: known transitive duplicates from incompatible upstream ranges.
+# thiserror: prost stays on 1.x while the workspace uses 2.x.
+# getrandom/rand_core/windows-sys: pinned versions surface alongside
+# their newer counterparts via tokio/rustls/figment chains.
 skip = [
-    # thiserror: prost uses 1.x, workspace uses 2.x
     { name = "thiserror", version = "1" },
     { name = "thiserror", version = "2" },
     { name = "thiserror-impl", version = "1" },
@@ -39,3 +46,7 @@ skip = [
     { name = "rand_core", version = "=0.6.4" },
     { name = "windows-sys", version = "=0.59.0" },
 ]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary

Adds kanon's security-gate fan-out to akroasis (kanon#543): daily
`cargo audit` + `cargo deny` runs against `main`, plus per-PR + push
+ `workflow_dispatch` invocations so newly-published CVEs against
existing dependencies fail CI even when no PR is open.

## Changes

- `.github/workflows/security.yml` — new Security workflow. Stripped
  of kanon-specific `FLEET_REPO_TOKEN` + sibling `logismos` checkout
  steps because akroasis is a self-contained workspace (all path
  deps are intra-workspace under `crates/`).
- `.cargo/audit.toml` — new. Mirrors `deny.toml`'s
  `[[advisories.ignore]]` entries so `cargo-audit` and `cargo-deny`
  stay in sync. `.gitignore` updated with `!.cargo/audit.toml`
  negation so this single file is tracked while build output under
  `.cargo/` remains ignored.
- `deny.toml` — refreshed to kanon-template structure:
  - keep-in-sync note pointing at `.cargo/audit.toml`
  - new `[sources]` block (`unknown-registry = "deny"`,
    `unknown-git = "deny"`)
  - per-section WHY comments
  - preserves the pre-existing akroasis-specific suppressions:
    `RUSTSEC-2025-0119` (number_prefix unmaintained, via indicatif),
    `AGPL-3.0-only` license allow (workspace's own license),
    duplicate-version skips for thiserror 1/2, getrandom 0.2.17,
    rand_core 0.6.4, windows-sys 0.59.0.

## Test plan

- [ ] `Security / cargo deny` PR check green
- [ ] `Security / cargo audit` PR check green
- [ ] Scheduled daily run lands on `main` after merge

Gate-Passed: kanon 0.1.0