### PR TITLE
docs(CONTRIBUTING): codify backend-before-frontend ship-order rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,20 @@ kanon gate --stamp
 ## Branch naming and commit format
 
 Per `CLAUDE.md`: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `cleanup/`. Commit messages are `category(scope): description`. Squash merges keep main linear.
+
+## Backend-before-frontend ship-order
+
+Do not expose a CLI or UI surface for verb V before V's backing subsystem is callable end-to-end and reaches an operator-visible success state. Surfaces ship after their dependencies, never before.
+
+Where the dependency does not yet exist, the contributor has two acceptable shapes:
+
+- Omit the surface entirely until the subsystem lands.
+- Stub the handler with a typed loud-error return (e.g., `NotImplementedYet`) whose message names the tracking issue. Never ship a silent fake success path (a print-only stub, an `awaiting ACK` message with no network work, an `Ok(())` short-circuit).
+
+Anti-pattern examples already tracked in this repo:
+
+- #121 - `akroasis serve` daemon subcommand exists with no transport implementation; other subcommands funnel users toward it.
+- #122 - radio hardware adapters are `StubHardware`-only; the Baofeng protocol is unwired but advertised.
+- #123 - `mesh send` prints `awaiting ACK` while doing no network work because no daemon receives the packet.
+
+Reviewers should block PRs that add a new surface ahead of its subsystem until either the subsystem lands in the same PR or the surface is downgraded to a loud-error stub per above.


### PR DESCRIPTION
## Summary

Adds the **Backend-before-frontend ship-order** section to `CONTRIBUTING.md` per the explicit done-criteria in #133.

- New section codifies the rule verbatim: do not expose a CLI/UI surface for verb V before V's backing subsystem is callable end-to-end and reaches an operator-visible success state.
- Defines two acceptable shapes for incomplete deps: omit the surface, or stub with a typed loud-error return (`NotImplementedYet`) whose message names the tracking issue. No silent fake success paths.
- Cites #121, #122, #123 as anti-pattern examples already tracked in this repo.

Mechanical docs-only change; one file, 17 insertions, 0 deletions.

## Closes

- #133

## Test plan

- [x] `git diff` shows only the CONTRIBUTING.md append; no other file touched.
- [x] No em-dashes in the new prose (writing-standard compliance verified).
- [x] Anti-pattern citations resolve to live issues: #121, #122, #123 all open at time of merge.

Gate: docs-only, no Rust build needed; `Gate-Passed: kanon 0.1.0` trailer attached.