### PR TITLE
ci(security): ignore RUSTSEC-2026-0097 rand unsound

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,4 +10,10 @@ ignore = [
     # number_prefix unmaintained, transitive via indicatif; no safe
     # upgrade available upstream.
     "RUSTSEC-2025-0119",
+    # rand 0.9.2 unsound only when a custom logger re-enters rand::rng();
+    # akroasis uses tracing-subscriber with no custom logger that calls
+    # into rand, so the condition is unreachable. Pulled in transitively
+    # via ulid 1.2.1 (semaino/koinon/syntonia/kryphos/kerykeion) and
+    # proptest 1.11.0 (dev-only).
+    "RUSTSEC-2026-0097",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,10 @@ all-features = false
 id = "RUSTSEC-2025-0119"
 reason = "number_prefix unmaintained, transitive via indicatif; no safe upgrade available upstream."
 
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.9.2 unsound only when a custom logger re-enters rand::rng(); akroasis uses tracing-subscriber with no custom logger that calls into rand, so the condition is unreachable. Pulled in transitively via ulid 1.2.1 (semaino/koinon/syntonia/kryphos/kerykeion) and proptest 1.11.0 (dev-only)."
+
 [licenses]
 # WHY: AGPL-3.0-only is the workspace license itself (declared in
 # workspace.package). MPL-2.0, BSL-1.0, CC0-1.0 cover permissive


### PR DESCRIPTION
## Summary

The first main-branch Security run after PR#144 merge failed `cargo audit` on RUSTSEC-2026-0097 (rand 0.9.2 is unsound when a custom logger re-enters `rand::rng()` during seeding). akroasis uses `tracing-subscriber` with no custom logger that calls into rand, so the condition is unreachable.

rand 0.9.2 reaches akroasis transitively via:
- `ulid 1.2.1` (used by semaino/koinon/syntonia/kryphos/kerykeion)
- `proptest 1.11.0` (dev-dep)

No fixed upstream version yet.

## Change

Mirror the suppression into both `.cargo/audit.toml` (cargo-audit) and `deny.toml`'s `[[advisories.ignore]]` (cargo-deny) since the two tools read separate config files.

## Test plan

- [ ] Security workflow cargo audit job passes on this PR
- [ ] Security workflow cargo deny job continues to pass

Gate-Passed: kanon 0.1.0