### PR TITLE
fix(akroasis): remove unwired daemon and mesh send surfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,10 +85,10 @@ Where the dependency does not yet exist, the contributor has two acceptable shap
 - Omit the surface entirely until the subsystem lands.
 - Stub the handler with a typed loud-error return (e.g., `NotImplementedYet`) whose message names the tracking issue. Never ship a silent fake success path (a print-only stub, an `awaiting ACK` message with no network work, an `Ok(())` short-circuit).
 
-Anti-pattern examples already tracked in this repo:
+Anti-pattern examples tracked in this repo:
 
-- #121 - `akroasis serve` daemon subcommand exists with no transport implementation; other subcommands funnel users toward it.
+- #121 - `akroasis serve` daemon subcommand existed with no transport implementation; other subcommands funneled users toward it.
 - #122 - radio hardware adapters are `StubHardware`-only; the Baofeng protocol is unwired but advertised.
-- #123 - `mesh send` prints `awaiting ACK` while doing no network work because no daemon receives the packet.
+- #123 - `mesh send` printed `awaiting ACK` while doing no network work because no daemon received the packet.
 
 Reviewers should block PRs that add a new surface ahead of its subsystem until either the subsystem lands in the same PR or the surface is downgraded to a loud-error stub per above.

--- a/crates/akroasis/src/cli.rs
+++ b/crates/akroasis/src/cli.rs
@@ -42,8 +42,6 @@ pub(crate) enum Command {
     Vault(VaultArgs),
     /// Privacy — VPN, anonymization, OPSEC assessment
     Privacy,
-    /// Serve the Akroasis daemon
-    Serve,
 }
 
 /// Radio subcommand arguments.

--- a/crates/akroasis/src/main.rs
+++ b/crates/akroasis/src/main.rs
@@ -121,7 +121,6 @@ fn dispatch(command: &Command, out: &mut dyn std::io::Write) -> Result<(), Error
         Command::Privacy => {
             writeln!(out, "lethe — privacy (not yet implemented)").context(IoSnafu)?;
         }
-        Command::Serve => writeln!(out, "daemon mode (not yet implemented)").context(IoSnafu)?,
     }
     Ok(())
 }

--- a/crates/akroasis/src/mesh/mod.rs
+++ b/crates/akroasis/src/mesh/mod.rs
@@ -34,23 +34,6 @@ pub enum MeshCommand {
     /// List all known mesh nodes
     Nodes,
 
-    /// Send a text message to a mesh node
-    Send {
-        /// Destination node number (hex, e.g. `0xdeadbeef`) or name
-        dest: String,
-
-        /// Message text
-        message: String,
-
-        /// Channel index to send on (default: primary channel 0)
-        #[arg(long, default_value = "0")]
-        channel: u8,
-
-        /// Fire-and-forget — do not wait for ACK
-        #[arg(long)]
-        no_ack: bool,
-    },
-
     /// Display mesh network topology
     Topology,
 }
@@ -70,12 +53,6 @@ pub fn dispatch(command: &MeshCommand, out: &mut dyn Write) -> Result<(), MeshEr
             print_nodes(out)?;
             Ok(())
         }
-        MeshCommand::Send {
-            dest,
-            message,
-            channel,
-            no_ack,
-        } => print_send(dest, message, *channel, *no_ack, out),
         MeshCommand::Topology => {
             print_topology(out)?;
             Ok(())
@@ -100,11 +77,7 @@ fn print_status(out: &mut dyn Write) -> Result<(), MeshError> {
 
     writeln!(out, "{table}").context(IoSnafu)?;
     writeln!(out).context(IoSnafu)?;
-    writeln!(
-        out,
-        "Start the daemon with `akroasis serve` for live mesh data."
-    )
-    .context(IoSnafu)?;
+    writeln!(out, "Live mesh transport is not wired in this CLI build.").context(IoSnafu)?;
     Ok(())
 }
 
@@ -125,36 +98,11 @@ fn print_nodes(out: &mut dyn Write) -> Result<(), MeshError> {
 
     writeln!(out, "{table}").context(IoSnafu)?;
     writeln!(out).context(IoSnafu)?;
-    writeln!(out, "No live connection. Start the daemon for node data.").context(IoSnafu)?;
-    Ok(())
-}
-
-/// Format and print a send command.
-fn print_send(
-    dest: &str,
-    message: &str,
-    channel: u8,
-    no_ack: bool,
-    out: &mut dyn Write,
-) -> Result<(), MeshError> {
-    let dest_num = parse_node_identifier(dest).ok_or_else(|| MeshError::NodeNotFound {
-        identifier: dest.to_string(),
-    })?;
-
-    writeln!(out, "Sending to {dest_num} on channel {channel}:").context(IoSnafu)?;
-    writeln!(out, "  \"{message}\"").context(IoSnafu)?;
-    if no_ack {
-        writeln!(out, "  (fire-and-forget — no ACK requested)").context(IoSnafu)?;
-    } else {
-        writeln!(out, "  (awaiting ACK...)").context(IoSnafu)?;
-    }
-    writeln!(out).context(IoSnafu)?;
     writeln!(
         out,
-        "Send requires a running daemon. Use `akroasis serve` first."
+        "No live connection. Live node collection is not wired yet."
     )
     .context(IoSnafu)?;
-
     Ok(())
 }
 
@@ -164,7 +112,7 @@ fn print_topology(out: &mut dyn Write) -> Result<(), MeshError> {
     writeln!(out, "─────────────").context(IoSnafu)?;
     writeln!(
         out,
-        "No live connection. Start the daemon for topology data."
+        "No live connection. Live topology collection is not wired yet."
     )
     .context(IoSnafu)?;
     writeln!(out).context(IoSnafu)?;
@@ -444,7 +392,7 @@ mod tests {
         dispatch(&MeshCommand::Status, &mut out).unwrap();
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("kerykeion"));
-        assert!(s.contains("Start the daemon"));
+        assert!(s.contains("Live mesh transport is not wired"));
     }
 
     #[test]
@@ -462,40 +410,5 @@ mod tests {
         dispatch(&MeshCommand::Topology, &mut out).unwrap();
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("Mesh Topology"));
-    }
-
-    #[test]
-    fn dispatch_send_valid_dest() {
-        let mut out = Vec::new();
-        assert!(
-            dispatch(
-                &MeshCommand::Send {
-                    dest: "0x1234".into(),
-                    message: "hello".into(),
-                    channel: 0,
-                    no_ack: false,
-                },
-                &mut out,
-            )
-            .is_ok()
-        );
-        let s = String::from_utf8(out).unwrap();
-        assert!(s.contains("Sending to"));
-        assert!(s.contains("hello"));
-    }
-
-    #[test]
-    fn dispatch_send_invalid_dest() {
-        let mut out = Vec::new();
-        let result = dispatch(
-            &MeshCommand::Send {
-                dest: "not_a_node".into(),
-                message: "hello".into(),
-                channel: 0,
-                no_ack: false,
-            },
-            &mut out,
-        );
-        assert!(result.is_err());
     }
 }

--- a/crates/akroasis/src/radio/import.rs
+++ b/crates/akroasis/src/radio/import.rs
@@ -245,9 +245,7 @@ fn parse_chirp_tone(tone_mode: &str, r_tone: &str, dtcs_code: &str, dtcs_pol: &s
     match tone_mode {
         "Tone" | "TSQL" => {
             let freq: f32 = r_tone.parse().unwrap_or(88.5);
-            syntonia::CtcssTone::new(freq)
-                .map(ToneMode::Ctcss)
-                .unwrap_or(ToneMode::None)
+            syntonia::CtcssTone::new(freq).map_or(ToneMode::None, ToneMode::Ctcss)
         }
         "DTCS" => {
             let code: u16 = dtcs_code.parse().unwrap_or(23);
@@ -255,9 +253,7 @@ fn parse_chirp_tone(tone_mode: &str, r_tone: &str, dtcs_code: &str, dtcs_pol: &s
                 "RR" | "RN" => syntonia::DcsPolarity::Inverted,
                 _ => syntonia::DcsPolarity::Normal,
             };
-            syntonia::DcsCode::new(code)
-                .map(|c| ToneMode::Dcs(c, polarity))
-                .unwrap_or(ToneMode::None)
+            syntonia::DcsCode::new(code).map_or(ToneMode::None, |c| ToneMode::Dcs(c, polarity))
         }
         _ => ToneMode::None,
     }

--- a/crates/kerykeion/src/delivery.rs
+++ b/crates/kerykeion/src/delivery.rs
@@ -69,11 +69,7 @@ impl DestStats {
     /// Average delivery latency in milliseconds, or `None` if no messages acknowledged.
     #[must_use]
     pub const fn average_latency_ms(&self) -> Option<u64> {
-        if self.acknowledged > 0 {
-            Some(self.latency_sum_ms / self.acknowledged)
-        } else {
-            None
-        }
+        self.latency_sum_ms.checked_div(self.acknowledged)
     }
 
     /// Success rate as a fraction (0.0–1.0), or `None` if no messages attempted.

--- a/crates/koinon/src/tamper_log.rs
+++ b/crates/koinon/src/tamper_log.rs
@@ -360,8 +360,7 @@ pub fn verify_chain(path: impl AsRef<Path>) -> Result<VerificationResult, Tamper
 
         if expected_hash != stored_hash {
             let sequence = ciborium::from_reader::<LogEntry, _>(cbor_bytes.as_slice())
-                .map(|e| e.sequence)
-                .unwrap_or(entries_verified);
+                .map_or(entries_verified, |e| e.sequence);
 
             return Ok(VerificationResult {
                 entries_verified,


### PR DESCRIPTION
## Summary
- remove the advertised `akroasis serve` command because no daemon transport exists
- remove the `akroasis mesh send` print stub so the CLI cannot emit ACK-shaped feedback without network I/O
- update mesh status/node/topology copy to state that live transport is not wired
- apply clippy rewrites required for `cargo clippy -p akroasis -- -D warnings`

Fixes #121.
Fixes #123.

## Verification
- `cargo fmt -p akroasis -p koinon -p kerykeion`
- `cargo check -p akroasis`
- `cargo clippy -p akroasis -- -D warnings`
- `cargo test -p akroasis`

Gate-Passed: kanon 0.1.0