### PR TITLE
feat(kerykeion): instrument runtime async entrypoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ snafu = "0.8"
 tokio = { version = "1", features = ["full"] }
 
 # Logging
-tracing = "0.1"
+tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Time

--- a/crates/kerykeion/src/bridge.rs
+++ b/crates/kerykeion/src/bridge.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
+use tracing::instrument;
 
 use crate::config::BridgeConfig;
 use crate::error::Error;
@@ -355,6 +356,7 @@ impl Default for GatewayBridge {
 /// # Errors
 ///
 /// Returns [`Error::SendFailed`] if the bridge encounters an unrecoverable error.
+#[instrument(level = "debug", skip(bridge, token))]
 pub async fn run_health_monitor(
     bridge: &tokio::sync::Mutex<GatewayBridge>,
     token: CancellationToken,

--- a/crates/kerykeion/src/collector.rs
+++ b/crates/kerykeion/src/collector.rs
@@ -12,6 +12,7 @@ use koinon::GeoSignal;
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument as _, instrument};
 
 use crate::bridge::{self, GatewayBridge};
 use crate::config::MeshConfig;
@@ -245,15 +246,21 @@ impl MeshCollector {
             let conn = Arc::clone(conn);
             let token = cancel.child_token();
             let heartbeat_cfg = self.config.heartbeat.clone();
-            tasks.spawn(async move {
-                heartbeat::run_heartbeat_with_config(&*conn, &heartbeat_cfg, token).await
-            });
+            tasks.spawn(
+                async move {
+                    heartbeat::run_heartbeat_with_config(&*conn, &heartbeat_cfg, token).await
+                }
+                .instrument(tracing::info_span!("kerykeion.heartbeat")),
+            );
         }
 
         // Gateway health monitor.
         let bridge = Arc::clone(&self.bridge);
         let token = cancel.child_token();
-        tasks.spawn(async move { bridge::run_health_monitor(&bridge, token).await });
+        tasks.spawn(
+            async move { bridge::run_health_monitor(&bridge, token).await }
+                .instrument(tracing::info_span!("kerykeion.gateway_health")),
+        );
 
         // Discovery manager: periodic traceroutes + stale node detection.
         if let Some(primary) = connections.first() {
@@ -262,10 +269,13 @@ impl MeshCollector {
             let topo_cfg = self.config.topology.clone();
             let tx_clone = tx.clone();
             let token = cancel.child_token();
-            tasks.spawn(async move {
-                run_discovery(&*conn, &proc, &topo_cfg, &tx_clone, token).await;
-                Ok(())
-            });
+            tasks.spawn(
+                async move {
+                    run_discovery(&*conn, &proc, &topo_cfg, &tx_clone, token).await;
+                    Ok(())
+                }
+                .instrument(tracing::info_span!("kerykeion.discovery")),
+            );
         }
 
         // Router flush: drain outbound queue and process timeouts.
@@ -274,7 +284,10 @@ impl MeshCollector {
             let conn = Arc::clone(primary);
             let token = cancel.child_token();
             let flush_interval = self.config.collector.router_flush_interval();
-            tasks.spawn(async move { run_router_flush(router, conn, flush_interval, token).await });
+            tasks.spawn(
+                async move { run_router_flush(router, conn, flush_interval, token).await }
+                    .instrument(tracing::info_span!("kerykeion.router_flush")),
+            );
         }
     }
 }
@@ -285,6 +298,11 @@ impl Collector for MeshCollector { // kanon:ignore ARCHITECTURE/trait-impl-coloc
         "kerykeion"
     }
 
+    #[instrument(
+        level = "debug",
+        skip(self),
+        fields(connections = self.config.connections.len())
+    )]
     async fn probe(&self) -> bool {
         if self.config.connections.is_empty() {
             return false;
@@ -316,6 +334,11 @@ impl Collector for MeshCollector { // kanon:ignore ARCHITECTURE/trait-impl-coloc
         false
     }
 
+    #[instrument(
+        level = "debug",
+        skip(self, tx, cancel),
+        fields(connections = self.config.connections.len())
+    )]
     async fn run(
         &mut self,
         tx: broadcast::Sender<GeoSignal>,
@@ -425,6 +448,11 @@ impl Collector for MeshCollector { // kanon:ignore ARCHITECTURE/trait-impl-coloc
 /// # Cancellation Safety
 ///
 /// Exits cleanly when `token` is cancelled at the next iteration boundary.
+#[instrument(
+    level = "debug",
+    skip(router, conn, token),
+    fields(tick_interval_ms = tick_interval.as_millis())
+)]
 async fn run_router_flush<C>(
     router: Arc<Mutex<MeshRouter>>,
     conn: Arc<Mutex<C>>,

--- a/crates/kerykeion/src/discovery.rs
+++ b/crates/kerykeion/src/discovery.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use koinon::GeoSignal;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
+use tracing::instrument;
 
 use crate::config::TopologyConfig;
 use crate::connection::MeshConnection;
@@ -86,6 +87,14 @@ pub const fn build_traceroute_request(dest_node: NodeNum) -> crate::proto::ToRad
 ///
 /// Exits cleanly when `token` is cancelled. Cancel-safe: all state mutations
 /// are completed before the next `.await`.
+#[instrument(
+    level = "debug",
+    skip(conn, processor, config, tx, token),
+    fields(
+        traceroute_interval_secs = config.traceroute_interval_secs,
+        stale_node_timeout_secs = config.stale_node_timeout_secs
+    )
+)]
 pub async fn run_discovery<C>(
     conn: &tokio::sync::Mutex<C>,
     processor: &tokio::sync::Mutex<PacketProcessor>,

--- a/crates/kerykeion/src/handshake.rs
+++ b/crates/kerykeion/src/handshake.rs
@@ -16,6 +16,7 @@
 
 use rand_core::{OsRng, RngCore as _};
 use tokio::time::timeout;
+use tracing::instrument;
 
 use crate::Error;
 use crate::config::HandshakeConfig;
@@ -46,6 +47,7 @@ pub struct HandshakeResult {
 ///
 /// Returns [`Error::HandshakeFailed`] if the handshake times out or if the
 /// radio does not complete the config dump with a matching ID.
+#[instrument(level = "debug", skip(conn, node_db))]
 pub async fn handshake(
     conn: &mut impl MeshConnection,
     node_db: &mut NodeDb,
@@ -64,6 +66,11 @@ pub async fn handshake(
 ///
 /// Returns [`Error::HandshakeFailed`] if the handshake times out or if the
 /// radio does not complete the config dump with a matching ID.
+#[instrument(
+    level = "debug",
+    skip(conn, node_db, config),
+    fields(timeout_secs = config.timeout_secs)
+)]
 pub async fn handshake_with_config(
     conn: &mut impl MeshConnection,
     node_db: &mut NodeDb,

--- a/crates/kerykeion/src/heartbeat.rs
+++ b/crates/kerykeion/src/heartbeat.rs
@@ -17,6 +17,7 @@
 use tokio::sync::Mutex;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
+use tracing::instrument;
 
 use crate::Error;
 use crate::config::HeartbeatConfig;
@@ -33,6 +34,7 @@ use crate::proto::ToRadio;
 ///
 /// Returns the first send error encountered.  The caller should cancel the
 /// token and reconnect the underlying connection.
+#[instrument(level = "debug", skip(conn, token))]
 pub async fn run_heartbeat<C>(conn: &Mutex<C>, token: CancellationToken) -> Result<(), Error>
 where
     C: MeshConnection,
@@ -50,6 +52,11 @@ where
 ///
 /// Returns the first send error encountered.  The caller should cancel the
 /// token and reconnect the underlying connection.
+#[instrument(
+    level = "debug",
+    skip(conn, config, token),
+    fields(interval_secs = config.interval_secs)
+)]
 pub async fn run_heartbeat_with_config<C>(
     conn: &Mutex<C>,
     config: &HeartbeatConfig,

--- a/crates/kerykeion/src/transport/mod.rs
+++ b/crates/kerykeion/src/transport/mod.rs
@@ -14,6 +14,7 @@ use crate::config::{ConnectionConfig, TransportConfig};
 use crate::connection::MeshConnection;
 use crate::error::BleConnectSnafu;
 use crate::proto::{FromRadio, ToRadio};
+use tracing::instrument;
 
 /// A concrete, enum-dispatched connection to a Meshtastic radio.
 ///
@@ -64,6 +65,7 @@ impl MeshConnection for ConnectionHandle {
 /// # Errors
 ///
 /// Returns a transport-specific connection error if the initial connect fails.
+#[instrument(level = "debug", skip(config), fields(connection = ?config))]
 pub async fn connect(config: &ConnectionConfig) -> Result<ConnectionHandle, Error> {
     connect_with_config(config, &TransportConfig::default()).await
 }
@@ -74,6 +76,11 @@ pub async fn connect(config: &ConnectionConfig) -> Result<ConnectionHandle, Erro
 /// # Errors
 ///
 /// Returns a transport-specific connection error if the initial connect fails.
+#[instrument(
+    level = "debug",
+    skip(config, transport_config),
+    fields(connection = ?config)
+)]
 pub async fn connect_with_config(
     config: &ConnectionConfig,
     transport_config: &TransportConfig,

--- a/crates/kerykeion/src/transport/serial.rs
+++ b/crates/kerykeion/src/transport/serial.rs
@@ -6,6 +6,7 @@
 use futures::{SinkExt as _, StreamExt as _};
 use tokio_serial::{SerialPort as _, SerialPortBuilderExt as _, SerialStream};
 use tokio_util::codec::Framed;
+use tracing::instrument;
 
 use crate::Error;
 use crate::codec::MeshCodec;
@@ -37,6 +38,7 @@ impl SerialTransport {
     /// # Errors
     ///
     /// Returns [`Error::SerialConnect`] if the port cannot be opened.
+    #[instrument(level = "debug", skip(port), fields(port = %port, baud))]
     pub async fn open(port: &str, baud: u32) -> Result<Self, Error> {
         Self::open_with_config(port, baud, &TransportConfig::default()).await
     }
@@ -46,10 +48,7 @@ impl SerialTransport {
     /// # Errors
     ///
     /// Returns [`Error::SerialConnect`] if the port cannot be opened.
-    #[expect(
-        clippy::unused_async,
-        reason = "API symmetry with TcpTransport::connect; future USB enumeration may be async"
-    )]
+    #[instrument(level = "debug", skip(port, config), fields(port = %port, baud))]
     pub async fn open_with_config(
         port: &str,
         baud: u32,

--- a/crates/kerykeion/src/transport/tcp.rs
+++ b/crates/kerykeion/src/transport/tcp.rs
@@ -9,6 +9,7 @@ use futures::{SinkExt as _, StreamExt as _};
 use snafu::ResultExt as _;
 use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
+use tracing::instrument;
 
 use crate::Error;
 use crate::codec::MeshCodec;
@@ -44,6 +45,7 @@ impl TcpTransport {
     ///
     /// Returns [`Error::TcpConnect`] if the connection cannot be established
     /// within the timeout.
+    #[instrument(level = "debug", skip(addr), fields(addr = %addr, port))]
     pub async fn connect(addr: &str, port: u16) -> Result<Self, Error> {
         Self::connect_with_config(addr, port, &TransportConfig::default()).await
     }
@@ -54,6 +56,7 @@ impl TcpTransport {
     ///
     /// Returns [`Error::TcpConnect`] if the connection cannot be established
     /// within [`TransportConfig::tcp_connect_timeout_secs`].
+    #[instrument(level = "debug", skip(addr, config), fields(addr = %addr, port))]
     pub async fn connect_with_config(
         addr: &str,
         port: u16,


### PR DESCRIPTION
## Diagnosis

Issue #124 is still valid on current `main` (`ec68ab9`): `crates/kerykeion/src` had 73 async function signatures and zero literal `#[instrument]` attributes. The most important uninstrumented runtime paths were the transport connect/open functions, handshake, heartbeat, discovery, gateway health monitor, and the `MeshCollector` lifecycle. Production `JoinSet::spawn` calls in `crates/kerykeion/src/collector.rs` also spawned heartbeat, gateway health, discovery, and router flush tasks without span propagation.

This PR ships the first bounded observability slice instead of sweeping every private helper/test async function. It targets the public/runtime entrypoints named in the issue comments and propagates spans through production collector background tasks.

## Changes

- Enable the `tracing` attribute macro at the workspace dependency line.
- Add `#[instrument]` to kerykeion runtime/public async entrypoints in:
  - `crates/kerykeion/src/handshake.rs`
  - `crates/kerykeion/src/heartbeat.rs`
  - `crates/kerykeion/src/discovery.rs`
  - `crates/kerykeion/src/bridge.rs`
  - `crates/kerykeion/src/collector.rs`
  - `crates/kerykeion/src/transport/mod.rs`
  - `crates/kerykeion/src/transport/serial.rs`
  - `crates/kerykeion/src/transport/tcp.rs`
- Wrap production collector `JoinSet::spawn` futures with named `kerykeion.*` spans.
- Remove a stale `clippy::unused_async` expectation in `SerialTransport::open_with_config`; `#[instrument]` changes the generated async body enough that the expectation is no longer fulfilled.

Refs #124.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p kerykeion`
- `cargo clippy -p kerykeion --all-targets -- -D warnings`
- `cargo test -p kerykeion`

Gate-Passed: cargo fmt --all -- --check; cargo check -p kerykeion; cargo clippy -p kerykeion --all-targets -- -D warnings; cargo test -p kerykeion
