### PR TITLE
docs(signal): clarify live domain coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Every tool for radio, mesh networking, spectrum monitoring, network security, or
 
 Akroasis is the attempt to fix that.
 
-One system. One signal model. Every domain produces typed signals into the same pipeline. Radio anomalies correlate with network threats correlate with proximity intelligence correlate with OSINT. The convergence is where the intelligence lives - not in any single domain but in the relationships between them.
+One system. One signal model. The shared pipeline is designed for every domain to produce typed signals; today the live production `GeoSignal` producer is kerykeion mesh, while the remaining domains are planned or covered with synthetic pipeline tests. Radio anomalies correlate with network threats correlate with proximity intelligence correlate with OSINT. The convergence is where the intelligence lives - not in any single domain but in the relationships between them.
 
 Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, offensive security, signal intelligence, and geospatial modeling. Rust from the ground up. See the domain table below for shipped crates (✓) vs planned crates (◻).
 
@@ -75,7 +75,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
           └──────────────────┘
 ```
 
-Every collection crate produces typed `GeoSignal` objects into koinon. Semaino aggregates domain-agnostically. Ichneutes analyzes domain-agnostically. Praxis acts. Opsis displays. Add a domain, add a crate - signals flow automatically.
+Every collection crate is expected to produce typed `GeoSignal` objects into koinon; the current live producer is kerykeion mesh. Semaino aggregates domain-agnostically, and its tests cover the full seven-domain signal model synthetically. Ichneutes analyzes domain-agnostically. Praxis acts. Opsis displays. Add a domain, add a crate - signals flow automatically once the collector exists.
 
 ---
 
@@ -116,7 +116,7 @@ Every collection crate produces typed `GeoSignal` objects into koinon. Semaino a
 
 ## Status
 
-**Phase 02 complete** (project state 2026-04-22). Kerykeion mesh networking fully landed.
+**Phase 02 complete** (project state 2026-04-22). Kerykeion mesh networking fully landed and is the current live `GeoSignal` collector.
 For current planning and phase status, see
 [CLAUDE.md](CLAUDE.md) and the kanon planning substrate at `kanon:projects/akroasis/STATE.md`.
 

--- a/crates/semaino/src/convergence.rs
+++ b/crates/semaino/src/convergence.rs
@@ -244,7 +244,8 @@ mod tests {
     use koinon::{
         Frequency, Power, Timestamp,
         signal::{
-            EnvironmentalDetail, GpsDetail, MeshDetail, NetworkDetail, ProximityDetail, RfDetail,
+            EnvironmentalDetail, GpsDetail, MeshDetail, NetworkDetail, OsintDetail,
+            ProximityDetail, RfDetail,
         },
     };
 
@@ -304,6 +305,13 @@ mod tests {
 
     fn env_kind() -> SignalKind {
         SignalKind::Environmental(EnvironmentalDetail::Temperature { celsius: 22.5 })
+    }
+
+    fn osint_kind() -> SignalKind {
+        SignalKind::Osint(OsintDetail::FeedItem {
+            source: "test-feed".into(),
+            title: "synthetic indicator".into(),
+        })
     }
 
     // ── quantize ─────────────────────────────────────────────────────────────
@@ -434,7 +442,7 @@ mod tests {
     // ── full domain set ───────────────────────────────────────────────────────
 
     #[test]
-    fn six_distinct_domains_all_detected() {
+    fn seven_distinct_domains_all_detected() {
         let mut grid = ConvergenceGrid::new(10_000);
         let loc = coords(40.0, -74.0);
         for kind in [
@@ -444,12 +452,13 @@ mod tests {
             proximity_kind(),
             gps_kind(),
             env_kind(),
+            osint_kind(),
         ] {
             grid.ingest(&signal_at(kind, loc));
         }
         let now = Timestamp::now();
-        let found = grid.detect(6, std::time::Duration::from_secs(30), now);
+        let found = grid.detect(7, std::time::Duration::from_secs(30), now);
         assert_eq!(found.len(), 1);
-        assert_eq!(found.first().expect("checked len above").domain_count, 6);
+        assert_eq!(found.first().expect("checked len above").domain_count, 7);
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture: Akroasis
 
-Single Rust binary. Five layers. All domains produce typed `GeoSignal` into a shared pipeline.
+Single Rust binary. Five layers. The shared model supports all domains producing typed `GeoSignal` values into one pipeline; current live collection is kerykeion mesh, with the other domain collectors planned.
 
 Run `cargo metadata --format-version 1 | jq '.workspace_members | length'` for current crate count.
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -4,7 +4,7 @@ Communications sovereignty, RF intelligence, and operational awareness platform.
 
 ## Current state
 
-See the status markers in [../README.md](../README.md) for shipped vs planned crates. Phase and wave status lives in the kanon repo roadmap  -  single source of truth.
+See the status markers in [../README.md](../README.md) for shipped vs planned crates. Current live signal collection is kerykeion mesh; the shared model and semaino tests cover the planned domains synthetically. Phase and wave status lives in the kanon repo roadmap  -  single source of truth.
 
 ## Architecture
 


### PR DESCRIPTION
## Diagnosis

Issue #127 still matches current main: `crates/koinon/src/signal.rs` defines seven `SignalKind` domains, while production live signal construction is currently kerykeion mesh. `crates/kerykeion/src/signals.rs` constructs `SignalKind::Mesh(...)` for mesh events; I found no production collector constructing `Rf`, `Network`, `Proximity`, `Gps`, `Environmental`, or `Osint` from live subsystems.

The docs also stated target-state wording as present-state behavior: README and architecture copy said every/all domains produce typed `GeoSignal`s. Semaino had synthetic convergence coverage for six distinct domains, but the full-domain regression omitted OSINT.

## Changes

- Update README, `docs/ARCHITECTURE.md`, and `docs/PROJECT.md` to state the current live producer clearly: kerykeion mesh.
- Preserve the target architecture by saying the shared model supports seven domains and the other live collectors are planned.
- Extend `crates/semaino/src/convergence.rs` from the six-domain synthetic test to all seven `SignalKind` domains by adding OSINT coverage.

Refs #127.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p semaino --all-targets -- -D warnings`
- `cargo test -p semaino`

Gate-Passed: cargo fmt --all -- --check; cargo clippy -p semaino --all-targets -- -D warnings; cargo test -p semaino
