### PR TITLE
feat(kryphos): audit vault mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 |--------|-------|:-------------:|:----------------:|------|
 | **Application shell** | akroasis | ✓ | ◻ | Single binary with CLI dispatch for radio, mesh, vault, and future domain stubs. Radio uses `StubHardware`; mesh CLI shows static/no-live-connection status until daemon mode is implemented. |
 | **Foundation** | koinon | ✓ |  -  | Shared IDs, coordinates, frequency and power types, 7-domain `GeoSignal` model, hardware asset registry, temporal baselines, and tamper-evident logging. |
-| **Foundation** | kryphos | ✓ |  -  | Credential vault and installation identity: fjall-backed encrypted storage, Argon2id derivation, ChaCha20-Poly1305 encryption, Ed25519 signing keys, rotation/revocation metadata. |
+| **Foundation** | kryphos | ✓ |  -  | Credential vault and installation identity: fjall-backed encrypted storage, Argon2id derivation, ChaCha20-Poly1305 encryption, Ed25519 signing keys, rotation/revocation metadata, and mutation audit logging at `tamper.log` beside the vault store. |
 | **Radio Management** | syntonia | ✓ | ◻ | Frequency plans, CHIRP CSV/IMG import, CHIRP CSV export, validation, USB detection metadata, and Baofeng UV-5R-family codec. Hardware serial backend is optional; the shipped binary does not yet connect live radios. |
 | **Mesh Networking** | kerykeion | ✓ | ✓ | Clean-room Meshtastic stack: protobuf framing, serial/TCP transports, handshake, encryption, node database, topology, discovery, routing, delivery tracking, store-and-forward, gateway bridge, and signal conversion. |
 | **Signal Processing** | semaino | ✓ |  -  | Signal aggregation, per-kind anomaly baselines, convergence detection, and deduplicated severity-classified alert pipeline. |
@@ -84,7 +84,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 - **Standalone.** Runs without internet, without an LLM, without anything but the hardware in front of you. Grid-down capable.
 - **Sovereignty.** Every protocol owned. No cloud dependencies, no subscriptions, no external trust.
 - **Security default.** Encrypted by default. Unencrypted is the opt-in.
-- **Auditable.** Tamper-evident logging with hash chains. Every action recorded. Evidence packaging with chain of custody.
+- **Auditable.** Credential vault mutations are recorded in a tamper-evident BLAKE3 hash-chain log beside the vault store. Broader action logging and evidence packaging are planned follow-ons.
 - **Reproducible deployment (planned).** NixOS flake + systemd unit hardening + declarative deployment is the intended target shape; no deployment artifacts ship today. Tracked in #125.
 
 ---

--- a/crates/koinon/src/tamper_log.rs
+++ b/crates/koinon/src/tamper_log.rs
@@ -154,6 +154,13 @@ pub enum LogEntryKind {
         /// Target of the action, if applicable.
         target: Option<CompactString>,
     },
+    /// A credential vault entry lifecycle mutation was committed.
+    VaultMutation {
+        /// Human-readable credential name affected by the mutation.
+        credential_name: CompactString,
+        /// Mutation operation, e.g. `"add"`, `"rotate"`, `"revoke"`, or `"remove"`.
+        operation: CompactString,
+    },
 }
 
 /// A single record in the tamper-evident log.

--- a/crates/kryphos/Cargo.toml
+++ b/crates/kryphos/Cargo.toml
@@ -23,10 +23,10 @@ compact_str.workspace = true
 figment.workspace = true
 fjall.workspace = true
 fs2.workspace = true
+koinon = { path = "../koinon" }
 
 [dev-dependencies]
 serde_json.workspace = true
-koinon = { path = "../koinon" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/kryphos/src/error.rs
+++ b/crates/kryphos/src/error.rs
@@ -89,6 +89,13 @@ pub enum VaultError {
         /// Name of the revoked entry.
         name: String,
     },
+
+    /// Writing the tamper-evident vault audit log failed.
+    #[snafu(display("tamper log error: {source}"))]
+    TamperLog {
+        /// Underlying tamper-log failure.
+        source: koinon::TamperLogError,
+    },
 }
 
 /// Errors from key generation, derivation, or loading.

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -6,13 +6,14 @@ use std::path::{Path, PathBuf};
 use compact_str::CompactString;
 use fs2::FileExt;
 use jiff::Timestamp;
+use koinon::{LogEntryKind, TamperLog};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use crate::crypto::{self, decrypt, encrypt};
 use crate::error::{
     AlreadyExistsSnafu, EntryCryptoSnafu, EntryNotDeletableSnafu, EntryRevokedSnafu, IoSnafu,
-    SerializationSnafu, VaultError, WrongPassphraseSnafu,
+    SerializationSnafu, TamperLogSnafu, VaultError, WrongPassphraseSnafu,
 };
 use crate::key::VaultKey;
 use crate::vault::{
@@ -31,6 +32,9 @@ const LOCK_FILE: &str = "vault.lock";
 
 /// Subdirectory for the fjall keyspace.
 const DATA_DIR: &str = "data";
+
+/// Name of the tamper-evident vault audit log within the vault directory.
+const TAMPER_LOG_FILE: &str = "tamper.log";
 
 /// On-disk vault header stored as JSON.
 #[derive(Debug, Serialize, Deserialize)]
@@ -242,6 +246,7 @@ impl Vault {
         self.db
             .persist(fjall::PersistMode::SyncAll)
             .map_err(fjall_err)?;
+        self.append_vault_audit(name, "add")?;
 
         Ok(())
     }
@@ -329,6 +334,7 @@ impl Vault {
         self.db
             .persist(fjall::PersistMode::SyncAll)
             .map_err(fjall_err)?;
+        self.append_vault_audit(name, "remove")?;
 
         Ok(())
     }
@@ -371,6 +377,7 @@ impl Vault {
         self.db
             .persist(fjall::PersistMode::SyncAll)
             .map_err(fjall_err)?;
+        self.append_vault_audit(name, "rotate")?;
 
         Ok(())
     }
@@ -410,6 +417,7 @@ impl Vault {
         self.db
             .persist(fjall::PersistMode::SyncAll)
             .map_err(fjall_err)?;
+        self.append_vault_audit(name, "revoke")?;
 
         Ok(())
     }
@@ -443,6 +451,22 @@ impl Vault {
     #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Returns the filesystem path of the vault mutation audit log.
+    #[must_use]
+    pub fn tamper_log_path(&self) -> PathBuf {
+        self.path.join(TAMPER_LOG_FILE)
+    }
+
+    fn append_vault_audit(&self, name: &str, operation: &str) -> Result<(), VaultError> {
+        let mut log = TamperLog::open(self.tamper_log_path()).context(TamperLogSnafu)?;
+        log.append(LogEntryKind::VaultMutation {
+            credential_name: CompactString::from(name),
+            operation: CompactString::from(operation),
+        })
+        .context(TamperLogSnafu)?;
+        Ok(())
     }
 }
 

--- a/crates/kryphos/tests/vault_tamper_audit.rs
+++ b/crates/kryphos/tests/vault_tamper_audit.rs
@@ -1,0 +1,27 @@
+//! Integration test: vault mutations append to the tamper-evident audit log.
+
+#![allow(clippy::unwrap_used)]
+
+use koinon::{ChainStatus, verify_chain};
+use kryphos::{CredentialType, Vault};
+
+const TEST_PASSPHRASE: &[u8] = b"correct horse battery staple";
+
+#[test]
+fn vault_mutations_append_intact_tamper_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("audited-vault");
+
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+    let log_path = vault.tamper_log_path();
+
+    vault
+        .add("incident-radio-key", CredentialType::RadioKey, b"secret-v1")
+        .unwrap();
+    vault.rotate("incident-radio-key", b"secret-v2").unwrap();
+    vault.revoke("incident-radio-key").unwrap();
+
+    let result = verify_chain(&log_path).unwrap();
+    assert_eq!(result.status, ChainStatus::Intact);
+    assert_eq!(result.entries_verified, 3);
+}


### PR DESCRIPTION
## Diagnosis

Issue #128 is valid on current main: `koinon::TamperLog` is implemented, exported, and tested, but production runtime paths did not append to it. The only cross-crate kryphos use was test/signing coverage, while `Vault::add`, `Vault::rotate`, `Vault::revoke`, and `Vault::remove` mutated fjall state without a tamper-evident log record.

This PR ships the narrow low-volume audit producer first: kryphos credential vault lifecycle mutations. It does not claim broad mesh/alert/action audit coverage.

## Changes

- Add `LogEntryKind::VaultMutation { credential_name, operation }` in `crates/koinon/src/tamper_log.rs`.
- Move `koinon` into kryphos runtime dependencies so production vault code can use `TamperLog`.
- Append a vault mutation record after successful `add`, `remove`, `rotate`, and `revoke` persists in `crates/kryphos/src/storage.rs`.
- Store the audit chain at `tamper.log` beside the vault directory and expose `Vault::tamper_log_path()` for verification tooling/tests.
- Add `crates/kryphos/tests/vault_tamper_audit.rs` to verify add -> rotate -> revoke yields an intact three-entry hash chain.
- Narrow README audit wording from “every action recorded” to the concrete shipped scope: credential vault mutations.

Refs #128.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p kryphos`
- `cargo test -p kryphos`
- `cargo clippy -p koinon -p kryphos --all-targets -- -D warnings`
- `cargo test -p koinon`

Gate-Passed: cargo fmt --all -- --check; cargo check -p kryphos; cargo test -p kryphos; cargo clippy -p koinon -p kryphos --all-targets -- -D warnings; cargo test -p koinon
