### PR TITLE
docs(pinax): define reference store layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 | **Signal Intelligence** | ichneutes | ◻ |  -  | Future entity correlation, focal point synthesis, threat scoring, and forensic timeline reconstruction across all domains. |
 | **Automation** | praxis | ◻ |  -  | Future event-driven triggers, named playbooks, PACE communications, and operational state machines. |
 | **Navigation** | chorografia | ◻ | ◻ | Future RF propagation modeling, infrastructure graphs, offline OSM navigation, and space weather HF prediction. |
-| **Knowledge** | pinax | ◻ |  -  | Future offline repository for frequency databases, protocol specs, equipment manuals, topo maps, and indexed references. |
+| **Knowledge** | pinax | ◻ |  -  | Future offline repository for frequency databases, protocol specs, equipment manuals, topo maps, and indexed references. Target instance layout is documented in [docs/reference-store.md](docs/reference-store.md). |
 | **Privacy** | lethe | ◻ | ◻ | Future VPN/proxy management, anonymization, IMSI catcher detection, and OPSEC scoring. The etymological complement to [Aletheia](https://github.com/forkwright/aletheia). |
 | **Interface** | opsis | ◻ |  -  | Future TUI, native app, and web UI for spectrum waterfall, mesh topology, and intelligence dashboard views. |
 
@@ -113,6 +113,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 
 - [standards/](standards/): Pointer to canonical kanon standards (STANDARDS.md, GNOMON.md, etc.)
 - [docs/lexicon.md](docs/lexicon.md): Project name registry
+- [docs/reference-store.md](docs/reference-store.md): Target `/instance/reference/` layout for the planned pinax knowledge store
 
 ## Status
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **ichneutes** | Analysis | Entity correlation, focal points, threat scoring, intelligence synthesis |
 | **praxis** | Orchestration | Automation engine, playbooks, event triggers, state machines |
 | **chorografia** | Model | Geographic model, RF propagation, navigation, terrain |
-| **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps |
+| **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps; see `reference-store.md` for target instance layout |
 | **opsis** | Interface | TUI, Dioxus native app, web UI |
 | **akroasis** | Binary | CLI entrypoint, subcommand routing |
 
@@ -59,3 +59,4 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 
 - Planning docs (scope, roadmap, vision, research): live in the kanon repo
 - Naming: `../standards/GNOMON.md`, `lexicon.md`
+- Reference store layout: `reference-store.md`

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -26,6 +26,7 @@ Phase index lives in the kanon repo roadmap. Wave status is reflected in merged 
 | Document | Purpose |
 |----------|---------|
 | `ARCHITECTURE.md` | Crate map, layer structure, key decisions |
+| `reference-store.md` | Target `/instance/reference/` layout for the planned pinax knowledge store |
 | `../standards/GNOMON.md` | Greek naming methodology |
 | `lexicon.md` | Domain terms and name registry |
 | `../standards/STANDARDS.md` | Universal coding standards |

--- a/docs/reference-store.md
+++ b/docs/reference-store.md
@@ -1,0 +1,126 @@
+# Reference Store Layout
+
+Akroasis owns the long-term offline reference store through `pinax`, the planned
+knowledge layer. The repository does not ship an `instance/` tree today; this
+document defines the target layout and migration policy so the existing
+`theke/_reference` staging area can move only after the source inventory is
+visible and checksummed.
+
+## Canonical path
+
+The canonical runtime path is:
+
+```text
+${AKROASIS_INSTANCE:-~/akroasis/instance}/reference/
+```
+
+The store is instance data, not source code. It should not be committed to this
+repository. Repo docs and manifests may describe captures, checksums, and index
+state, but the payloads live under the operator instance root.
+
+Expected top-level layout:
+
+```text
+reference/
+  captures/
+    frozen/
+    refreshable/
+  indexes/
+    rg/
+    tantivy/
+    embeddings/
+  manifests/
+  adapters/
+  staging/
+```
+
+`captures/frozen/` holds material captured for grid-down use where upstream
+availability is the risk. `captures/refreshable/` holds mirrors that can be
+re-pulled from upstream while the network is available. `indexes/` is generated
+and disposable; it can be rebuilt from captures and manifests. `staging/` is for
+imports before checksums, content class, license notes, and refresh policy are
+assigned.
+
+## Content classes
+
+Initial supported content classes:
+
+| Class | Destination | Notes |
+|-------|-------------|-------|
+| Dash docsets | `captures/frozen/docsets/` or `captures/refreshable/docsets/` | Preserve upstream docset structure and record feed URL when available. |
+| Curated PDFs | `captures/frozen/pdfs/` | Keep original filename plus manifest title, source URL, capture date, and checksum. |
+| Preserved wikis | `captures/frozen/wikis/` | Store static export plus source revision or dump metadata. |
+| Stack Exchange snapshots | `captures/frozen/stack-exchange/` | Store dump metadata and license/provenance in manifest. |
+| Model-agnostic corpora | `captures/frozen/corpora/` | Plain text, markdown, or other durable formats preferred. |
+| Frequency/protocol references | `captures/refreshable/radio/` or `captures/frozen/radio/` | Use refreshable for public frequency databases; frozen for field manuals and protocol captures. |
+
+Per-crate docs stay in the crate or `docs/`. Operational reference payloads,
+large manuals, docsets, and preserved external corpora live in the instance
+reference store. Theke may link to this store, but it should not own akroasis
+reference data after migration.
+
+## Manifests
+
+Each capture set has a manifest under `manifests/` with:
+
+- stable capture id
+- content class
+- relative payload path
+- title and source
+- upstream URL or local provenance
+- capture timestamp
+- refresh policy: `frozen` or `refreshable`
+- checksum set
+- license or redistribution notes
+- index adapters enabled for the payload
+
+Manifests are the contract between raw filesystem access, index builders, and
+future query APIs.
+
+## Agent access tiers
+
+Access starts with the filesystem and grows toward services:
+
+1. Raw tree: agents and humans can use `rg`, `fd`, and direct file reads under
+   `reference/captures/`.
+2. Text index: generated full-text indexes under `reference/indexes/` for fast
+   local search.
+3. Embedded index: optional vector indexes for semantic lookup. These are
+   generated artifacts and must be rebuildable from captures.
+4. Query API: future MCP or HTTP tools read manifests and indexes instead of
+   scraping arbitrary paths. This is the programmatic surface; it should not
+   become the only way to access the corpus.
+
+## Drive and symlink policy
+
+Docsets alone were reported as 6.1 GB in the staging issue, and the expected
+store is 50-100 GB. The instance root may therefore live on a larger mount such
+as `/storage` or another operator-selected drive. The canonical path remains
+`~/akroasis/instance/reference`; if payloads live elsewhere, use a single
+symlink at `~/akroasis/instance/reference` and keep all internal paths relative
+to that canonical root.
+
+Do not scatter per-content symlinks across `/`, `/data`, `/storage`, and
+removable menos drives. Mount or link the store root once, then let manifests
+describe the content inside it.
+
+## Migration gates
+
+Before moving data out of the current staging area:
+
+1. Verify the source path exists on the migration host.
+2. Generate checksums for every payload.
+3. Classify each content set as frozen or refreshable.
+4. Write manifests for each content set.
+5. Create the target `reference/` tree on the chosen drive.
+6. Copy payloads into `staging/`, verify checksums, then promote them into
+   `captures/`.
+7. Build the raw/text indexes.
+8. Update fleet pointers that currently name the staging path.
+9. Remove the staging copy only after checksum verification and operator signoff.
+
+## Current repo state
+
+As of this design note, akroasis only documents the planned `pinax` knowledge
+layer. There is no checked-in `instance/` directory, no `crates/pinax`, and no
+verified local copy of the source `theke/_reference` tree in this worktree.


### PR DESCRIPTION
## Diagnosis

Issue #120 asks for a concrete `/instance/reference/` design before moving the 6.1 GB staged offline reference library out of `~/aletheia/instance/theke/_reference/`. Current main had only planned `pinax` references: `README.md` described pinax as a future offline repository, `docs/ARCHITECTURE.md` listed it as knowledge storage, and no checked-in `instance/` tree or `crates/pinax` existed.

## Changes

- Add `docs/reference-store.md` with the target `${AKROASIS_INSTANCE:-~/akroasis/instance}/reference/` layout.
- Define frozen vs refreshable captures, generated indexes, manifests, staging, access tiers, drive/symlink policy, and migration gates.
- Link the design from `README.md`, `docs/ARCHITECTURE.md`, and `docs/PROJECT.md` without claiming that the instance data exists in the repo.

## Verification

- `git diff --check`
- `cargo fmt --all -- --check`

Refs #120
