### PR TITLE
docs(opsis): clarify backend-first surface planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 | **Navigation** | chorografia | ◻ | ◻ | Future RF propagation modeling, infrastructure graphs, offline OSM navigation, and space weather HF prediction. |
 | **Knowledge** | pinax | ◻ |  -  | Future offline repository for frequency databases, protocol specs, equipment manuals, topo maps, and indexed references. Target instance layout is documented in [docs/reference-store.md](docs/reference-store.md). |
 | **Privacy** | lethe | ◻ | ◻ | Future VPN/proxy management, anonymization, IMSI catcher detection, and OPSEC scoring. The etymological complement to [Aletheia](https://github.com/forkwright/aletheia). |
-| **Interface** | opsis | ◻ |  -  | Future TUI, native app, and web UI for spectrum waterfall, mesh topology, and intelligence dashboard views. |
+| **Interface** | opsis | ◻ |  -  | Future operator surfaces for spectrum waterfall, mesh topology, and intelligence dashboard views. Surface stack and order are pending the backend/programmatic API boundary tracked in #118 and #126. |
 
 **Legend:** ✓ = shipped in `crates/`, ◻ = planned/not shipped,  -  = not applicable.
 
@@ -61,8 +61,8 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
                    │                   │  focal points,    │           │
           ┌────────▼─────────┐         │  threat scoring)  │    ┌──────▼──────┐
           │ koinon           │         └──────────────────┘    │ opsis       │
-          │ (signal model,   │                                  │ (TUI, app,  │
-          │  entity index,   │         ┌──────────────────┐    │  web UI)    │
+          │ (signal model,   │                                  │ (operator   │
+          │  entity index,   │         ┌──────────────────┐    │  surfaces)  │
           │  temporal engine)│         │ chorografia      │    └─────────────┘
           │                  │         │ (geo, nav, RF    │
           │ kryphos          │         │  propagation)    │
@@ -104,7 +104,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | Planned: ratatui, Dioxus, and Axum surfaces will land with `opsis` |
+| Interfaces | Planned: operator surfaces will land with `opsis` after the typed programmatic/API boundary is defined; TUI, native, web, and desktop-first order remain open planning decisions |
 | License | AGPL-3.0-only |
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Run `cargo metadata --format-version 1 | jq '.workspace_members | length'` for c
 ## Layer structure
 
 ```
-Interface:      opsis (TUI/web/native)
+Interface:      opsis (operator surfaces; stack/order pending API boundary)
 Orchestration:  praxis (automation, playbooks, PACE)
 Analysis:       semaino (aggregation), ichneutes (correlation)
 Collection:     syntonia, kerykeion, dektis, engys, aspis, skopos, peira
@@ -33,7 +33,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **praxis** | Orchestration | Automation engine, playbooks, event triggers, state machines |
 | **chorografia** | Model | Geographic model, RF propagation, navigation, terrain |
 | **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps; see `reference-store.md` for target instance layout |
-| **opsis** | Interface | TUI, Dioxus native app, web UI |
+| **opsis** | Interface | Operator surfaces after a typed programmatic/API boundary exists; stack/order pending #118 and #126 |
 | **akroasis** | Binary | CLI entrypoint, subcommand routing |
 
 ## Key decisions

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -66,7 +66,7 @@
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. TUI (ratatui), native app (Dioxus), web UI (Axum over Tailscale). Spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, after-action replay. Three surfaces, one backend. |
+| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. Future operator surfaces for spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, and after-action replay. The surface stack and order wait on a typed backend/programmatic API boundary. |
 
 ---
 


### PR DESCRIPTION
## Diagnosis

Issue #118 asks whether akroasis should keep presenting TUI -> web -> desktop as the future surface order. Current main still named the interface layer as `opsis (TUI/web/native)` in `docs/ARCHITECTURE.md`, described `opsis` as "Future TUI, native app, and web UI" in `README.md`, and the lexicon row still committed to "Three surfaces, one backend."

Issue #126 also remains open: the CLI has no stable `--json`, MCP, JSON-RPC, or request/response boundary yet. PR #148 removed unwired placeholder daemon surfaces, and `CONTRIBUTING.md` now says surfaces ship after dependencies. So this PR does not choose desktop-first, TUI-first, or web-first. It narrows the docs to the current safe statement: future operator surfaces wait on the typed backend/programmatic API boundary.

## Changes

- Replace committed TUI/native/web wording in `README.md` with surface-order-neutral operator surface wording tied to #118/#126.
- Update the architecture diagram and crate registry in `docs/ARCHITECTURE.md` to avoid presenting TUI/web/native as settled.
- Update `docs/lexicon.md` so `opsis` remains the frontend/operator layer without preselecting ratatui, Dioxus, Axum, or desktop-first order.

Refs #118
Refs #126

## Verification

- `git diff --check`
- `cargo fmt --all -- --check`

Gate-Passed: git diff --check; cargo fmt --all -- --check