### PR TITLE
feat(semaino): instrument runtime async entrypoints

### DIFF
--- a/crates/semaino/src/aggregator.rs
+++ b/crates/semaino/src/aggregator.rs
@@ -146,6 +146,11 @@ impl SignalAggregator {
     ///
     /// `recv()` on a broadcast receiver is cancel-safe; no signal is lost on
     /// cancellation at the `select!` boundary.
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, rx, tx),
+        fields(baselines = self.baselines.len())
+    )]
     pub async fn run(
         &mut self,
         mut rx: broadcast::Receiver<GeoSignal>,

--- a/crates/semaino/src/pipeline.rs
+++ b/crates/semaino/src/pipeline.rs
@@ -92,6 +92,14 @@ impl SemainoPipeline {
     /// 2. The main task fans out each incoming [`GeoSignal`] to the convergence
     ///    grid and consumes [`AggregatedSignal`]s from the mpsc channel to run
     ///    the alert pipeline.
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, rx),
+        fields(
+            time_window_secs = self.time_window.as_secs(),
+            min_convergence_domains = self.min_convergence_domains
+        )
+    )]
     pub async fn run(&mut self, rx: broadcast::Receiver<GeoSignal>) {
         // WHY: We need two consumers of the broadcast:
         //   (a) the aggregator, for baseline scoring, and


### PR DESCRIPTION
## Diagnosis

Issue #124 was partially handled by PR #150, which instrumented the kerykeion runtime async entrypoints and propagated spans through kerykeion collector tasks. A current-main sweep at f6d9a21 still found public semaino runtime loops without function-level spans: `crates/semaino/src/aggregator.rs:149` (`SignalAggregator::run`) and `crates/semaino/src/pipeline.rs:95` (`SemainoPipeline::run`).

Semaino already propagates spans into its spawned aggregator/fan tasks, so this PR keeps the follow-up narrow: add `#[tracing::instrument]` to the public async entrypoints and skip channel/self values that are not useful span fields.

## Changes

- Add a debug span to `SignalAggregator::run`, recording the current baseline-map size.
- Add a debug span to `SemainoPipeline::run`, recording the convergence time window and minimum domain threshold.

Refs #124.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p semaino`
- `cargo clippy -p semaino --all-targets -- -D warnings`
- `cargo test -p semaino`

Gate-Passed: cargo fmt --all -- --check; cargo check -p semaino; cargo clippy -p semaino --all-targets -- -D warnings; cargo test -p semaino