### PR TITLE
docs(kryphos): define future encryption boundaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,3 +60,5 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 - Planning docs (scope, roadmap, vision, research): live in the kanon repo
 - Naming: `../standards/GNOMON.md`, `lexicon.md`
 - Reference store layout: `reference-store.md`
+- Fjall column encryption boundary: `fjall-column-encryption.md`
+- Hybrid PQ content-key wrapping boundary: `hybrid-pq-content-key-wrapping.md`

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -26,6 +26,8 @@ Phase index lives in the kanon repo roadmap. Wave status is reflected in merged 
 | Document | Purpose |
 |----------|---------|
 | `ARCHITECTURE.md` | Crate map, layer structure, key decisions |
+| `fjall-column-encryption.md` | Future declarative encrypted-field boundary for fjall-backed stores |
+| `hybrid-pq-content-key-wrapping.md` | Future hybrid PQ content-key wrapping boundary and implementation gates |
 | `reference-store.md` | Target `/instance/reference/` layout for the planned pinax knowledge store |
 | `../standards/GNOMON.md` | Greek naming methodology |
 | `lexicon.md` | Domain terms and name registry |

--- a/docs/fjall-column-encryption.md
+++ b/docs/fjall-column-encryption.md
@@ -1,0 +1,66 @@
+# Fjall Column Encryption Boundary
+
+Issue #132 tracks a future declarative encryption layer for fjall-backed
+stores. Current main does not have a generic table/column store abstraction:
+the only fjall-backed runtime store is `kryphos::Vault`, and it already
+encrypts credential secrets through a typed field before serializing the row.
+
+This note defines the boundary to use when akroasis adds its first mixed
+plaintext/ciphertext fjall schema for signals, references, or other indexed
+runtime data. It is not an implementation of #132.
+
+## Current State
+
+- `crates/kryphos/src/storage.rs` owns one fjall keyspace named `entries`.
+- `StoredEntry` keeps `encrypted_secret` as the only encrypted field; metadata,
+  status, and history remain structured so vault listing and lifecycle logic can
+  run without decrypting secret material.
+- `Vault::add`, `Vault::get`, and `Vault::rotate` call the existing
+  ChaCha20-Poly1305 helpers directly for that one field.
+- There is no fjall-backed signal store in current main. Mesh signals are
+  produced in memory and forwarded through the collector/processor path.
+
+Because of that shape, wrapping the vault in a generic column codec now would
+mostly add indirection around an already-specific and working encryption path.
+
+## Target Shape
+
+The first store that needs mixed encrypted and plaintext fields should own a
+small codec boundary with these parts:
+
+1. A stable field identity type for the store, such as `(StoreId, FieldId)` or a
+   store-local enum. Do not use ad hoc string literals at call sites.
+2. A single canonical encrypted-field registry in the owning crate, for example
+   `ENCRYPTED_FIELDS`.
+3. A `ColumnCodec` trait or equivalent helper that receives plaintext bytes,
+   field identity, and domain context, then returns authenticated ciphertext.
+4. A read path that decrypts mapped fields before returning typed domain values.
+5. A migration rule for legacy plaintext rows. The preferred first rule is
+   re-encrypt-on-write; a one-shot migration tool is only needed after a durable
+   store with existing plaintext rows ships.
+
+The registry should be declarative, but the owning store still decides which
+fields may remain plaintext for indexing, filtering, or redacted display.
+
+## Non-Goals
+
+- Do not retrofit `kryphos::Vault` only to satisfy the shape. Its existing typed
+  `encrypted_secret` model is clearer than a generic map until another store
+  proves the abstraction.
+- Do not encrypt fields that are required for safe listing or lifecycle checks
+  unless the caller has an explicit decrypted view.
+- Do not add new cryptographic primitives for this issue. Reuse the existing
+  vault AEAD unless a later key-management design selects a different content
+  key envelope.
+
+## Open Decisions
+
+- Whether the first codec lives in `kryphos` as a shared storage utility or in
+  the first crate that owns a mixed fjall schema.
+- Whether encrypted fields should use the vault passphrase key, a per-store
+  content key, or a future wrapped content-key design.
+- Which fields in future signal/reference stores are safe to leave plaintext for
+  search and indexing.
+
+Implementation of #132 should wait for the first durable multi-field store that
+needs this boundary.

--- a/docs/hybrid-pq-content-key-wrapping.md
+++ b/docs/hybrid-pq-content-key-wrapping.md
@@ -1,0 +1,75 @@
+# Hybrid PQ Content-Key Wrapping Boundary
+
+Issue #131 is design input for future multi-device content-key distribution.
+Current main does not implement content-key wrapping, ML-KEM, P-256, AES-KW, or
+a versioned wrapped-key envelope. The shipped vault path derives a symmetric
+key from the operator passphrase and encrypts credential entries directly.
+
+This note records the minimum design boundary before akroasis adds new
+cryptographic dependencies. It is not an implementation of #131.
+
+## Current State
+
+- `kryphos` encrypts vault secrets with ChaCha20-Poly1305 using an Argon2id
+  passphrase-derived `VaultKey`.
+- Workspace dependencies include the current classical primitives used by the
+  vault and mesh stack, including `chacha20poly1305`, `ed25519-dalek`, and
+  `x25519-dalek`.
+- There is no `ml-kem`, `p256`, `hkdf`, AES-KW, or `WrappedContentKey` model in
+  the workspace.
+- The offline reference store is still a planned `pinax` instance layout, not a
+  checked-in runtime store or sharing workflow.
+
+Adding a hybrid wrapper now would force protocol choices before the shared
+content model exists.
+
+## Target Envelope
+
+The future wrapper should be versioned and per-recipient:
+
+```text
+WrappedContentKey {
+    version,
+    recipient_id,
+    classical_public,
+    kem_ciphertext,
+    nonce_or_kw_metadata,
+    encrypted_content_key,
+}
+```
+
+Each recipient gets a separate wrapped copy of the same content key. Revoking a
+device means generating a new content key or re-wrapping the current content key
+only for the remaining recipients, depending on the store's forward-secrecy
+requirement.
+
+The domain tag for version 1 should be fixed before implementation, for example
+`akroasis-hybrid-ck-wrap-v1`. Later protocol changes get new versions instead
+of silent reinterpretation.
+
+## Required Decisions
+
+1. Classical half: use P-256 as described in the issue, or use the existing
+   X25519 dependency to reduce the number of primitives in the workspace.
+2. PQ half: select an ML-KEM-768 crate and require upstream/FIPS test vectors in
+   the implementation PR.
+3. Combiner: define HKDF extract/expand inputs, salt policy, and domain
+   separation tags.
+4. Envelope encryption: choose AES-KW, AES-GCM, or the existing
+   ChaCha20-Poly1305 stack for the wrapped content key.
+5. Feature gate: decide whether the first implementation is behind a preview
+   feature until cryptographic review is complete.
+6. Store integration: decide whether this belongs in `kryphos` alone or in the
+   first multi-device `pinax`/reference-store workflow.
+
+## Implementation Gates
+
+- No new cryptographic dependencies without an explicit design review.
+- No unaudited preview code in the default binary path.
+- Include ML-KEM test vectors and envelope round-trip vectors.
+- Include negative tests for wrong recipient, wrong domain tag, corrupted KEM
+  ciphertext, corrupted encrypted content key, and unsupported version.
+- Document revocation semantics in the store that consumes the wrapper.
+
+Until those decisions are made, #131 should remain design-input rather than a
+code task.


### PR DESCRIPTION
## Diagnosis

Issue #131 is still design-input on current main: the workspace ships passphrase-derived vault encryption and classical mesh/vault primitives, but no `ml-kem`, `p256`, `hkdf`, AES-KW, content-key envelope, or multi-device reference-store sharing workflow. Implementing crypto now would force unresolved primitive and envelope decisions.

Issue #132 is also not implementation-ready as a generic codec. Current main has fjall-backed `kryphos::Vault`, where `StoredEntry.encrypted_secret` is already encrypted through a typed path before the row is serialized, but there is no generic table/field store abstraction and no fjall-backed signal metadata store to protect yet.

## Changes

- Add `docs/hybrid-pq-content-key-wrapping.md` with the future `WrappedContentKey` boundary, version/domain-tag requirements, required primitive decisions, and implementation gates.
- Add `docs/fjall-column-encryption.md` with the future `ColumnCodec` / `ENCRYPTED_FIELDS` boundary for the first mixed plaintext/ciphertext fjall schema.
- Cross-link both notes from `docs/ARCHITECTURE.md` and `docs/PROJECT.md`.

Refs #131
Refs #132

## Verification

- `git diff --check`
- `cargo fmt --all -- --check`
- `rg -n "fjall-column-encryption|hybrid-pq-content-key-wrapping|ColumnCodec|ENCRYPTED_FIELDS|akroasis-hybrid-ck-wrap-v1|WrappedContentKey|ML-KEM" docs crates Cargo.toml`

Gate-Passed: git diff --check; cargo fmt --all -- --check; rg -n "fjall-column-encryption|hybrid-pq-content-key-wrapping|ColumnCodec|ENCRYPTED_FIELDS|akroasis-hybrid-ck-wrap-v1|WrappedContentKey|ML-KEM" docs crates Cargo.toml
