### PR TITLE
feat(akroasis): add radio import json report

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | Planned: operator surfaces will land with `opsis` after the typed programmatic/API boundary is defined; TUI, native, web, and desktop-first order remain open planning decisions |
+| Interfaces | Current: `akroasis radio import --json` emits a schema-versioned JSON report for parsed frequency plans. Planned: broader JSON CLI/MCP/API coverage before `opsis`; TUI, native, web, and desktop-first order remain open planning decisions |
 | License | AGPL-3.0-only |
 
 ---

--- a/crates/akroasis/src/radio/errors.rs
+++ b/crates/akroasis/src/radio/errors.rs
@@ -67,6 +67,9 @@ pub enum RadioError {
     #[snafu(display("{source}"))]
     Syntonia { source: syntonia::Error },
 
+    #[snafu(display("failed to write JSON report: {source}"))]
+    JsonReport { source: serde_json::Error },
+
     #[snafu(display("write aborted by user"))]
     WriteAborted,
 

--- a/crates/akroasis/src/radio/import.rs
+++ b/crates/akroasis/src/radio/import.rs
@@ -4,11 +4,25 @@ use std::io::Write;
 use std::path::Path;
 
 use koinon::Frequency;
+use serde::Serialize;
 use snafu::ResultExt;
 use syntonia::{Bandwidth, Channel, FrequencyPlan, PowerLevel, ScanMode, ToneMode};
 
-use super::errors::{IoSnafu, RadioError, ReadFileSnafu, SyntoniaSnafu};
+use super::errors::{IoSnafu, JsonReportSnafu, RadioError, ReadFileSnafu, SyntoniaSnafu};
 use super::read;
+
+const RADIO_IMPORT_JSON_SCHEMA: u8 = 1;
+
+#[derive(Serialize)]
+struct ImportReport<'a> {
+    schema_version: u8,
+    command: &'static str,
+    source: String,
+    format: &'static str,
+    channel_count: usize,
+    empty_channel_slots: usize,
+    plan: &'a FrequencyPlan,
+}
 
 /// Supported file formats for import.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,9 +49,14 @@ pub(crate) fn detect_format(path: &Path) -> Result<FileFormat, RadioError> {
 }
 
 /// Runs the import subcommand.
-pub(crate) fn run(file: &Path, out: &mut dyn Write) -> Result<(), RadioError> {
+pub(crate) fn run(file: &Path, json: bool, out: &mut dyn Write) -> Result<(), RadioError> {
     let format = detect_format(file)?;
     let plan = import_plan(file, format)?;
+
+    if json {
+        write_json_report(file, format, &plan, out)?;
+        return Ok(());
+    }
 
     read::print_channel_table_owned(&plan.channels, out)?;
 
@@ -59,6 +78,45 @@ pub(crate) fn run(file: &Path, out: &mut dyn Write) -> Result<(), RadioError> {
     .context(IoSnafu)?;
 
     Ok(())
+}
+
+fn write_json_report(
+    file: &Path,
+    format: FileFormat,
+    plan: &FrequencyPlan,
+    out: &mut dyn Write,
+) -> Result<(), RadioError> {
+    let report = ImportReport {
+        schema_version: RADIO_IMPORT_JSON_SCHEMA,
+        command: "radio import",
+        source: file.display().to_string(),
+        format: format.as_str(),
+        channel_count: plan.channel_count(),
+        empty_channel_slots: empty_channel_slots(plan),
+        plan,
+    };
+
+    serde_json::to_writer_pretty(&mut *out, &report).context(JsonReportSnafu)?;
+    writeln!(out).context(IoSnafu)?;
+    Ok(())
+}
+
+fn empty_channel_slots(plan: &FrequencyPlan) -> usize {
+    plan.channels
+        .iter()
+        .filter(|ch| ch.rx_freq.as_hz() == 0)
+        .count()
+}
+
+impl FileFormat {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Toml => "toml",
+            Self::Json => "json",
+            Self::ChirpCsv => "chirp-csv",
+            Self::BinaryImage => "binary-image",
+        }
+    }
 }
 
 /// Imports a plan FROM a file in the detected format.
@@ -409,9 +467,43 @@ busy_lock = false
         std::fs::write(&path, toml).unwrap();
 
         let mut out = Vec::new();
-        run(&path, &mut out).unwrap();
+        run(&path, false, &mut out).unwrap();
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("CALL"));
         assert!(s.contains("Imported 1 channels FROM"));
+    }
+
+    #[test]
+    fn import_run_json_outputs_machine_readable_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan.toml");
+        let toml = r#"
+name = "Test Plan"
+radio_model = "Baofeng UV-5R"
+
+[[channels]]
+index = 0
+name = "CALL"
+rx_freq = 146520000
+offset = "None"
+tone = "None"
+power = "High"
+bandwidth = "Wide"
+scan = "Include"
+busy_lock = false
+"#;
+        std::fs::write(&path, toml).unwrap();
+
+        let mut out = Vec::new();
+        run(&path, true, &mut out).unwrap();
+
+        let report: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(report["schema_version"], 1);
+        assert_eq!(report["command"], "radio import");
+        assert_eq!(report["format"], "toml");
+        assert_eq!(report["channel_count"], 1);
+        assert_eq!(report["empty_channel_slots"], 0);
+        assert_eq!(report["plan"]["name"], "Test Plan");
+        assert_eq!(report["plan"]["channels"][0]["name"], "CALL");
     }
 }

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -56,6 +56,10 @@ pub enum RadioCommand {
 
     /// Import and display a frequency plan from file
     Import {
+        /// Emit a machine-readable JSON report instead of the human channel table.
+        #[arg(long)]
+        json: bool,
+
         /// Input file (.toml, .json, .csv, or .img)
         file: PathBuf,
     },
@@ -222,7 +226,7 @@ pub fn dispatch_with(
             format,
             output,
         } => export::run(port.as_deref(), format, output.as_deref(), hw, out),
-        RadioCommand::Import { file } => import::run(file, out),
+        RadioCommand::Import { json, file } => import::run(file, *json, out),
     }
 }
 
@@ -303,7 +307,20 @@ mod tests {
     fn parse_import_file() {
         let cmd = parse(&["import", "channels.csv"]);
         match cmd {
-            RadioCommand::Import { file } => {
+            RadioCommand::Import { json, file } => {
+                assert!(!json);
+                assert_eq!(file, PathBuf::from("channels.csv"));
+            }
+            _ => panic!("expected Import"),
+        }
+    }
+
+    #[test]
+    fn parse_import_json_flag() {
+        let cmd = parse(&["import", "--json", "channels.csv"]);
+        match cmd {
+            RadioCommand::Import { json, file } => {
+                assert!(json);
                 assert_eq!(file, PathBuf::from("channels.csv"));
             }
             _ => panic!("expected Import"),


### PR DESCRIPTION
## Summary
- add `akroasis radio import --json` for a schema-versioned machine-readable report
- include source path, detected format, channel counts, empty-slot count, and the parsed `FrequencyPlan`
- document this as the first JSON CLI surface while broader JSON CLI/MCP/API coverage remains future work

Advances #126.

## Gates
- `cargo fmt --all --check`
- `cargo clippy -p akroasis --all-targets -- -D warnings`
- `cargo test -p akroasis`
- `cargo test --workspace`