### PR TITLE
feat(akroasis): wire opt-in radio detect hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 | **Application shell** | akroasis | ✓ | ◻ | Single binary with CLI dispatch for radio, mesh, vault, and future domain stubs. Radio uses `StubHardware`; mesh CLI shows static/no-live-connection status until daemon mode is implemented. |
 | **Foundation** | koinon | ✓ |  -  | Shared IDs, coordinates, frequency and power types, 7-domain `GeoSignal` model, hardware asset registry, temporal baselines, and tamper-evident logging. |
 | **Foundation** | kryphos | ✓ |  -  | Credential vault and installation identity: fjall-backed encrypted storage, Argon2id derivation, ChaCha20-Poly1305 encryption, Ed25519 signing keys, rotation/revocation metadata, and mutation audit logging at `tamper.log` beside the vault store. |
-| **Radio Management** | syntonia | ✓ | ◻ | Frequency plans, CHIRP CSV/IMG import, CHIRP CSV export, validation, USB detection metadata, and Baofeng UV-5R-family codec. Hardware serial backend is optional; the shipped binary does not yet connect live radios. |
+| **Radio Management** | syntonia | ✓ | ◻ | Frequency plans, CHIRP CSV/IMG import, CHIRP CSV export, validation, USB detection metadata, and Baofeng UV-5R-family codec. With `akroasis/hardware-serial`, `radio detect` uses live serial probing; read/program/export still require the future protocol session backend. |
 | **Mesh Networking** | kerykeion | ✓ | ✓ | Clean-room Meshtastic stack: protobuf framing, serial/TCP transports, handshake, encryption, node database, topology, discovery, routing, delivery tracking, store-and-forward, gateway bridge, and signal conversion. |
 | **Signal Processing** | semaino | ✓ |  -  | Signal aggregation, per-kind anomaly baselines, convergence detection, and deduplicated severity-classified alert pipeline. |
 | **SDR / Reception** | dektis | ◻ | ◻ | Future spectrum monitoring, FM/AM/SSB demodulation, protocol decoding (APRS, ADS-B, P25), jamming detection, direction finding, and emitter fingerprinting. |
@@ -99,7 +99,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | Async | tokio |
 | Storage | fjall for vault state; CBOR + BLAKE3 hash chains for tamper logs |
 | Mesh | Shipped: clean-room Meshtastic stack with prost protobuf, serial/TCP transports, AES-CTR channel crypto, routing, topology, and store-and-forward |
-| Radio | Shipped: frequency-plan model, validation, import/export, Baofeng UV-5R-family codec; planned: live binary hardware connection beyond stub dispatch |
+| Radio | Shipped: frequency-plan model, validation, import/export, Baofeng UV-5R-family codec, and opt-in live serial detection through `akroasis/hardware-serial`; planned: live read/program/export protocol sessions beyond stub dispatch |
 | SDR | Planned: FutureSDR, FFT, RTL-SDR, and SoapySDR work will land with `dektis` |
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |

--- a/crates/akroasis/Cargo.toml
+++ b/crates/akroasis/Cargo.toml
@@ -11,6 +11,11 @@ repository.workspace = true
 name = "akroasis"
 path = "src/main.rs"
 
+[features]
+# Opt-in live serial radio detection. Kept off by default so default builds do
+# not require native serial dependencies.
+hardware-serial = ["syntonia/hardware-serial"]
+
 [dependencies]
 clap = { workspace = true }
 comfy-table = "7"

--- a/crates/akroasis/src/radio/errors.rs
+++ b/crates/akroasis/src/radio/errors.rs
@@ -82,6 +82,12 @@ pub enum RadioError {
     #[snafu(display("hardware support not yet available (syntonia protocol layer pending)"))]
     HardwareNotAvailable,
 
+    #[cfg(feature = "hardware-serial")] // kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
+    #[snafu(display("radio hardware detection failed: {source}"))]
+    HardwareDetect {
+        source: syntonia::hardware::DetectError,
+    },
+
     #[snafu(display("I/O error: {source}"))]
     Io { source: std::io::Error },
 }

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -7,6 +7,9 @@ pub mod import;
 pub mod program;
 pub mod progress;
 pub mod read;
+#[cfg(feature = "hardware-serial")]
+// kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
+mod serial_hardware;
 
 use std::path::PathBuf;
 
@@ -80,9 +83,12 @@ pub enum ExportFormat {
 
 /// Known radio variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[expect(
-    dead_code,
-    reason = "radio variants used in test mocks; not all exercised in binary"
+#[cfg_attr(
+    not(feature = "hardware-serial"),
+    expect(
+        dead_code,
+        reason = "radio variants used in test mocks; not all exercised in binary"
+    )
 )]
 pub enum RadioVariant {
     Uv5r,
@@ -156,6 +162,13 @@ pub trait Session {
 // Stub hardware (returns errors until P1-02..P1-06 are implemented)
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(
+    all(feature = "hardware-serial", not(test)),
+    expect(
+        dead_code,
+        reason = "stub backend remains available for tests and no-hardware builds"
+    )
+)]
 pub struct StubHardware;
 
 impl Hardware for StubHardware {
@@ -207,8 +220,15 @@ pub fn resolve_target(port: Option<&str>, hw: &dyn Hardware) -> Result<DetectedR
 // ---------------------------------------------------------------------------
 
 /// Dispatches a radio subcommand.
+#[cfg(not(feature = "hardware-serial"))] // kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
 pub fn dispatch(cmd: &RadioCommand, out: &mut dyn std::io::Write) -> Result<(), RadioError> {
     dispatch_with(cmd, &StubHardware, out)
+}
+
+/// Dispatches a radio subcommand with live serial detection enabled.
+#[cfg(feature = "hardware-serial")] // kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
+pub fn dispatch(cmd: &RadioCommand, out: &mut dyn std::io::Write) -> Result<(), RadioError> {
+    dispatch_with(cmd, &serial_hardware::SerialHardware, out)
 }
 
 /// Dispatches with a specific hardware backend (for testing).

--- a/crates/akroasis/src/radio/serial_hardware.rs
+++ b/crates/akroasis/src/radio/serial_hardware.rs
@@ -1,0 +1,118 @@
+//! Feature-gated live serial radio detection backend.
+
+use koinon::RadioKind;
+use syntonia::hardware::{self, CableChip, DetectedRadio as SyntoniaDetectedRadio, UsbCable};
+
+use super::errors::RadioError;
+use super::{DetectedRadio, Hardware, RadioVariant, Session};
+
+pub(super) struct SerialHardware;
+
+impl Hardware for SerialHardware {
+    fn detect_radios(&self) -> Result<Vec<DetectedRadio>, RadioError> {
+        let detected =
+            hardware::detect_radios().map_err(|source| RadioError::HardwareDetect { source })?;
+        Ok(detected.into_iter().filter_map(to_cli_radio).collect())
+    }
+
+    fn open(&self, _port: &str) -> Result<Box<dyn Session>, RadioError> {
+        Err(RadioError::HardwareNotAvailable)
+    }
+}
+
+fn to_cli_radio(detected: SyntoniaDetectedRadio) -> Option<DetectedRadio> {
+    let warnings = cable_warnings(&detected.cable);
+    Some(DetectedRadio {
+        variant: to_cli_variant(detected.variant.kind)?,
+        port: detected.cable.serial_port,
+        firmware: detected.ident.firmware,
+        warnings,
+    })
+}
+
+const fn to_cli_variant(kind: RadioKind) -> Option<RadioVariant> {
+    match kind {
+        RadioKind::BaofengUv5r => Some(RadioVariant::Uv5r),
+        RadioKind::BaofengBfF8hp => Some(RadioVariant::BfF8hp),
+        RadioKind::BaofengUv5rmPlus => Some(RadioVariant::Uv5rmPlus),
+        _ => None,
+    }
+}
+
+fn cable_warnings(cable: &UsbCable) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if cable.is_clone == Some(true) {
+        warnings.push(format!(
+            "PL2303 clone detected on {}. Works on Linux but may fail on Windows.",
+            cable.serial_port
+        ));
+    }
+
+    if let CableChip::Unknown { vid, pid } = cable.chip {
+        warnings.push(format!(
+            "Unknown USB serial device {vid:04X}:{pid:04X} on {}. It might work; try --port {} to use it directly.",
+            cable.serial_port, cable.serial_port
+        ));
+    }
+
+    warnings
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions use unwrap for clarity")]
+mod tests {
+    use super::*;
+    use syntonia::hardware::{RadioIdent, VariantConfig};
+
+    fn cable(chip: CableChip) -> UsbCable {
+        UsbCable {
+            vid: 0x1234,
+            pid: 0x5678,
+            chip,
+            serial_port: "/dev/ttyUSB0".to_string(),
+            manufacturer: None,
+            product: None,
+            serial_number: None,
+            is_clone: None,
+        }
+    }
+
+    #[test]
+    fn maps_baofeng_detected_radio_to_cli_descriptor() {
+        let detected = SyntoniaDetectedRadio {
+            cable: cable(CableChip::Ch340),
+            variant: VariantConfig {
+                kind: RadioKind::BaofengBfF8hp,
+                baud_rate: 9600,
+                memory_size: 0x1808,
+            },
+            ident: RadioIdent {
+                firmware: "BFF800".to_string(),
+                raw_response: b"BFF800".to_vec(),
+            },
+        };
+
+        let cli = to_cli_radio(detected).unwrap();
+
+        assert_eq!(cli.variant, RadioVariant::BfF8hp);
+        assert_eq!(cli.port, "/dev/ttyUSB0");
+        assert_eq!(cli.firmware, "BFF800");
+        assert!(cli.warnings.is_empty());
+    }
+
+    #[test]
+    fn cable_warnings_include_clone_and_unknown_adapter() {
+        let mut usb = cable(CableChip::Unknown {
+            vid: 0x9999,
+            pid: 0x0001,
+        });
+        usb.is_clone = Some(true);
+
+        let warnings = cable_warnings(&usb);
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().any(|w| w.contains("PL2303 clone")));
+        assert!(warnings.iter().any(|w| w.contains("9999:0001")));
+    }
+}

--- a/crates/syntonia/src/config.rs
+++ b/crates/syntonia/src/config.rs
@@ -134,7 +134,7 @@ mod tests {
         let cfg = BaofengTimingConfig::default();
         assert_eq!(cfg.inter_byte_delay(), Duration::from_millis(10));
         assert_eq!(cfg.post_ack_delay(), Duration::from_millis(50));
-        assert_eq!(cfg.ident_retry_delay(), Duration::from_millis(2_000));
+        assert_eq!(cfg.ident_retry_delay(), Duration::from_secs(2));
         assert_eq!(cfg.read_timeout(), Duration::from_millis(1_500));
         assert_eq!(cfg.max_retries, 3);
     }

--- a/crates/syntonia/src/hardware/cables.rs
+++ b/crates/syntonia/src/hardware/cables.rs
@@ -92,7 +92,7 @@ pub fn lookup_cable(vid: u16, pid: u16) -> Option<&'static KnownCable> {
 }
 
 #[cfg(test)]
-#[expect(
+#[allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,

--- a/crates/syntonia/src/hardware/detect.rs
+++ b/crates/syntonia/src/hardware/detect.rs
@@ -147,7 +147,8 @@ pub trait RadioProber {
 /// Default prober that opens real serial ports.
 struct DefaultProber;
 
-impl RadioProber for DefaultProber { // kanon:ignore ARCHITECTURE/trait-impl-colocation -- RadioProber trait exists for testability; DefaultProber is the production path
+impl RadioProber for DefaultProber {
+    // kanon:ignore ARCHITECTURE/trait-impl-colocation -- RadioProber trait exists for testability; DefaultProber is the production path
     fn probe(&self, port_path: &str) -> Result<Option<(VariantConfig, RadioIdent)>, DetectError> {
         let mut port = serialport::new(port_path, BAUD_RATE)
             .timeout(PROBE_TIMEOUT)
@@ -173,7 +174,7 @@ fn try_magic_sequence(
 
     let mut ack = [0u8; 1];
     port.read_exact(&mut ack).ok()?;
-    if ack.get(0).copied().unwrap_or_default() != ACK {
+    if ack.first().copied().unwrap_or_default() != ACK {
         return None;
     }
 
@@ -295,10 +296,11 @@ fn find_cable_for_port(port_path: &str) -> Result<UsbCable, DetectError> {
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-#[expect(
+#[allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
+    clippy::type_complexity,
     clippy::missing_docs_in_private_items,
     reason = "test code: panics and unwraps acceptable in assertions"
 )]
@@ -391,7 +393,7 @@ mod tests {
         let response = [&[ACK][..], b"BFB297\x00\x00"].concat();
         let mut port = MockSerial::new(response);
 
-        let result = try_magic_sequence(&mut port, &MAGIC_SEQUENCES.get(0).copied().unwrap_or_default());
+        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap());
         assert!(result.is_some());
 
         let (variant, ident) = result.unwrap();
@@ -404,7 +406,7 @@ mod tests {
         let response = [&[ACK][..], b"BFF800\x00\x00"].concat();
         let mut port = MockSerial::new(response);
 
-        let result = try_magic_sequence(&mut port, &MAGIC_SEQUENCES.get(0).copied().unwrap_or_default());
+        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap());
         assert!(result.is_some());
         assert_eq!(result.unwrap().0.kind, RadioKind::BaofengBfF8hp);
     }
@@ -413,20 +415,20 @@ mod tests {
     fn try_magic_returns_none_on_no_ack() {
         let response = vec![0xFF]; // Not an ACK
         let mut port = MockSerial::new(response);
-        assert!(try_magic_sequence(&mut port, &MAGIC_SEQUENCES.get(0).copied().unwrap_or_default()).is_none());
+        assert!(try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).is_none());
     }
 
     #[test]
     fn try_magic_returns_none_on_empty_response() {
         let mut port = MockSerial::new(vec![]);
-        assert!(try_magic_sequence(&mut port, &MAGIC_SEQUENCES.get(0).copied().unwrap_or_default()).is_none());
+        assert!(try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).is_none());
     }
 
     #[test]
     fn try_magic_returns_none_for_unrecognized_ident() {
         let response = [&[ACK][..], b"ZZZ999\x00\x00"].concat();
         let mut port = MockSerial::new(response);
-        assert!(try_magic_sequence(&mut port, &MAGIC_SEQUENCES.get(0).copied().unwrap_or_default()).is_none());
+        assert!(try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).is_none());
     }
 
     #[test]
@@ -453,8 +455,11 @@ mod tests {
 
         let results = detect_radios_impl(cables, &prober);
         assert_eq!(results.len(), 1);
-        assert_eq!(results.get(0).copied().unwrap_or_default().variant.kind, RadioKind::BaofengUv5r);
-        assert_eq!(results.get(0).copied().unwrap_or_default().cable.serial_port, "/dev/ttyUSB0");
+        assert_eq!(
+            results.first().unwrap().variant.kind,
+            RadioKind::BaofengUv5r
+        );
+        assert_eq!(results.first().unwrap().cable.serial_port, "/dev/ttyUSB0");
     }
 
     #[test]
@@ -495,8 +500,11 @@ mod tests {
 
         let results = detect_radios_impl(cables, &prober);
         assert_eq!(results.len(), 1);
-        assert_eq!(results.get(0).copied().unwrap_or_default().cable.serial_port, "/dev/ttyUSB1");
-        assert_eq!(results.get(0).copied().unwrap_or_default().variant.kind, RadioKind::BaofengBfF8hp);
+        assert_eq!(results.first().unwrap().cable.serial_port, "/dev/ttyUSB1");
+        assert_eq!(
+            results.first().unwrap().variant.kind,
+            RadioKind::BaofengBfF8hp
+        );
     }
 
     #[test]

--- a/crates/syntonia/src/hardware/usb.rs
+++ b/crates/syntonia/src/hardware/usb.rs
@@ -110,7 +110,7 @@ fn is_pl2303_clone(devices: &rusb::DeviceList<rusb::GlobalContext>, vid: u16, pi
 }
 
 #[cfg(test)]
-#[expect(
+#[allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,

--- a/crates/syntonia/src/hardware/warnings.rs
+++ b/crates/syntonia/src/hardware/warnings.rs
@@ -63,6 +63,13 @@ impl fmt::Display for HardwareWarning {
 
 /// Collect warnings from a cable scan result.
 #[must_use]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "crate-local warning helpers are staged for the akroasis hardware backend"
+    )
+)]
 pub(crate) fn collect_scan_warnings(cables: &[UsbCable]) -> Vec<HardwareWarning> {
     let mut warnings = Vec::new();
     for cable in cables {
@@ -84,6 +91,13 @@ pub(crate) fn collect_scan_warnings(cables: &[UsbCable]) -> Vec<HardwareWarning>
 
 /// Collect warnings from radio detection results.
 #[must_use]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "crate-local warning helpers are staged for the akroasis hardware backend"
+    )
+)]
 pub(crate) fn collect_detection_warnings(detected: &[DetectedRadio]) -> Vec<HardwareWarning> {
     let mut warnings = Vec::new();
     if detected.len() > 1 {
@@ -96,6 +110,13 @@ pub(crate) fn collect_detection_warnings(detected: &[DetectedRadio]) -> Vec<Hard
 
 /// Create a port-access-denied warning.
 #[must_use]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "crate-local warning helpers are staged for the akroasis hardware backend"
+    )
+)]
 pub(crate) fn port_access_denied(port: &str) -> HardwareWarning {
     HardwareWarning::PortAccessDenied {
         port: port.to_string(),
@@ -103,7 +124,7 @@ pub(crate) fn port_access_denied(port: &str) -> HardwareWarning {
 }
 
 #[cfg(test)]
-#[expect(
+#[allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
@@ -139,7 +160,7 @@ mod tests {
         let warnings = collect_scan_warnings(&cables);
         assert_eq!(warnings.len(), 1);
         assert!(matches!(
-            &warnings.get(0).copied().unwrap_or_default(),
+            warnings.first().unwrap(),
             HardwareWarning::Pl2303Clone { port } if port == "/dev/ttyUSB0"
         ));
     }
@@ -164,7 +185,7 @@ mod tests {
         let warnings = collect_scan_warnings(&cables);
         assert_eq!(warnings.len(), 1);
         assert!(matches!(
-            &warnings.get(0).copied().unwrap_or_default(),
+            warnings.first().unwrap(),
             HardwareWarning::UnknownCable {
                 vid: 0xDEAD,
                 pid: 0xBEEF,
@@ -216,7 +237,7 @@ mod tests {
         let warnings = collect_detection_warnings(&detected);
         assert_eq!(warnings.len(), 1);
         assert!(matches!(
-            &warnings.get(0).copied().unwrap_or_default(),
+            warnings.first().unwrap(),
             HardwareWarning::MultipleRadiosDetected { count: 2 }
         ));
     }

--- a/crates/syntonia/src/lib.rs
+++ b/crates/syntonia/src/lib.rs
@@ -17,6 +17,7 @@
 //! - [`import`] — CHIRP `.img` and `.csv` import
 //! - [`export`] — CHIRP `.csv` export
 //! - [`baofeng`] — Baofeng UV-5R EEPROM codec
+//! - [`hardware`] — optional serial cable and radio detection APIs
 
 #![deny(missing_docs)]
 
@@ -25,6 +26,9 @@ pub mod channel;
 pub mod config;
 pub mod error;
 pub mod export;
+#[cfg(feature = "hardware-serial")]
+// kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
+pub mod hardware;
 pub mod import;
 pub mod plan;
 pub(crate) mod serial;

--- a/crates/syntonia/src/serial.rs
+++ b/crates/syntonia/src/serial.rs
@@ -47,10 +47,6 @@ pub trait SerialPort: Send {
 /// Only available with the `hardware-serial` feature (requires `libudev-dev`
 /// on Linux).
 #[cfg(feature = "hardware-serial")] // kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
-#[expect(
-    dead_code,
-    reason = "public hardware adapter; consumers live outside this crate (baofeng::protocol module not yet re-wired, see #80-follow-up)"
-)]
 pub(crate) struct HardwareSerialPort {
     inner: Box<dyn serialport::SerialPort>,
 }


### PR DESCRIPTION
## Summary
- expose `syntonia::hardware` behind the existing `hardware-serial` feature
- add `akroasis/hardware-serial` and route `radio detect` through live syntonia serial probing when enabled
- keep read/program/export on the existing typed `HardwareNotAvailable` path until the protocol session backend is public

Refs #122.

## Gates
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets --jobs 8`
- `cargo clippy --workspace --all-targets --jobs 8 -- -D warnings`
- `cargo test --workspace`
- `cargo check -p akroasis --features hardware-serial --all-targets`
- `cargo clippy -p akroasis --features hardware-serial --all-targets -- -D warnings`
- `cargo test -p akroasis --features hardware-serial`
- `cargo clippy -p syntonia --features hardware-serial --all-targets -- -D warnings`
- `cargo test -p syntonia --features hardware-serial`