### PR TITLE
feat(akroasis): add radio detect json report

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | Current: `akroasis radio import --json` emits a schema-versioned JSON report for parsed frequency plans. Planned: broader JSON CLI/MCP/API coverage before `opsis`; TUI, native, web, and desktop-first order remain open planning decisions |
+| Interfaces | Current: `akroasis radio import --json` and `akroasis radio detect --json` emit schema-versioned JSON reports. Planned: broader JSON CLI/MCP/API coverage before `opsis`; TUI, native, web, and desktop-first order remain open planning decisions |
 | License | AGPL-3.0-only |
 
 ---

--- a/crates/akroasis/src/radio/detect.rs
+++ b/crates/akroasis/src/radio/detect.rs
@@ -2,14 +2,38 @@
 
 use std::io::Write;
 
+use serde::Serialize;
 use snafu::ResultExt;
 
-use super::errors::{IoSnafu, RadioError};
+use super::errors::{IoSnafu, JsonReportSnafu, RadioError};
 use super::{DetectedRadio, Hardware};
 
+const RADIO_DETECT_JSON_SCHEMA: u8 = 1;
+
+#[derive(Serialize)]
+struct DetectReport<'a> {
+    schema_version: u8,
+    command: &'static str,
+    radio_count: usize,
+    radios: Vec<DetectedRadioReport<'a>>,
+}
+
+#[derive(Serialize)]
+struct DetectedRadioReport<'a> {
+    variant: &'static str,
+    port: &'a str,
+    firmware: &'a str,
+    warnings: &'a [String],
+}
+
 /// Runs the detect subcommand.
-pub(crate) fn run(hw: &dyn Hardware, out: &mut dyn Write) -> Result<(), RadioError> {
+pub(crate) fn run(hw: &dyn Hardware, json: bool, out: &mut dyn Write) -> Result<(), RadioError> {
     let radios = hw.detect_radios()?;
+
+    if json {
+        write_json_report(&radios, out)?;
+        return Ok(());
+    }
 
     if radios.is_empty() {
         writeln!(
@@ -22,6 +46,27 @@ pub(crate) fn run(hw: &dyn Hardware, out: &mut dyn Write) -> Result<(), RadioErr
     }
 
     print_detected(&radios, out)?;
+    Ok(())
+}
+
+fn write_json_report(radios: &[DetectedRadio], out: &mut dyn Write) -> Result<(), RadioError> {
+    let report = DetectReport {
+        schema_version: RADIO_DETECT_JSON_SCHEMA,
+        command: "radio detect",
+        radio_count: radios.len(),
+        radios: radios
+            .iter()
+            .map(|radio| DetectedRadioReport {
+                variant: radio.variant.display_name(),
+                port: &radio.port,
+                firmware: &radio.firmware,
+                warnings: &radio.warnings,
+            })
+            .collect(),
+    };
+
+    serde_json::to_writer_pretty(&mut *out, &report).context(JsonReportSnafu)?;
+    writeln!(out).context(IoSnafu)?;
     Ok(())
 }
 
@@ -59,10 +104,28 @@ pub(crate) fn print_detected(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test assertions use unwrap for clarity")]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test assertions use unwrap and indexing for clarity"
+)]
 mod tests {
     use super::*;
     use crate::radio::RadioVariant;
+
+    struct FakeHardware {
+        radios: Vec<DetectedRadio>,
+    }
+
+    impl Hardware for FakeHardware {
+        fn detect_radios(&self) -> Result<Vec<DetectedRadio>, RadioError> {
+            Ok(self.radios.clone())
+        }
+
+        fn open(&self, _port: &str) -> Result<Box<dyn crate::radio::Session>, RadioError> {
+            Err(RadioError::HardwareNotAvailable)
+        }
+    }
 
     #[test]
     fn format_single_detected_radio() {
@@ -113,7 +176,34 @@ mod tests {
     fn run_no_radios_writes_message() {
         let mut out = Vec::new();
         // StubHardware returns HardwareNotAvailable, which means no radios.
-        let result = run(&super::super::StubHardware, &mut out);
+        let result = run(&super::super::StubHardware, false, &mut out);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_json_outputs_machine_readable_report() {
+        let hw = FakeHardware {
+            radios: vec![DetectedRadio {
+                variant: RadioVariant::BfF8hp,
+                port: "/dev/ttyUSB0".to_string(),
+                firmware: "BFP3V3".to_string(),
+                warnings: vec!["low-cost cable detected".to_string()],
+            }],
+        };
+
+        let mut out = Vec::new();
+        run(&hw, true, &mut out).unwrap();
+
+        let report: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(report["schema_version"], 1);
+        assert_eq!(report["command"], "radio detect");
+        assert_eq!(report["radio_count"], 1);
+        assert_eq!(report["radios"][0]["variant"], "Baofeng BF-F8HP");
+        assert_eq!(report["radios"][0]["port"], "/dev/ttyUSB0");
+        assert_eq!(report["radios"][0]["firmware"], "BFP3V3");
+        assert_eq!(
+            report["radios"][0]["warnings"][0],
+            "low-cost cable detected"
+        );
     }
 }

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -22,7 +22,11 @@ use self::errors::RadioError;
 #[derive(Subcommand)]
 pub enum RadioCommand {
     /// Detect connected radios
-    Detect,
+    Detect {
+        /// Emit a machine-readable JSON report instead of human text.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Read channels from radio
     Read {
@@ -238,7 +242,7 @@ pub fn dispatch_with(
     out: &mut dyn std::io::Write,
 ) -> Result<(), RadioError> {
     match cmd {
-        RadioCommand::Detect => detect::run(hw, out),
+        RadioCommand::Detect { json } => detect::run(hw, *json, out),
         RadioCommand::Read { port } => read::run(port.as_deref(), hw, out),
         RadioCommand::Program { port, plan } => program::run(port.as_deref(), plan, hw, out),
         RadioCommand::Export {
@@ -274,7 +278,19 @@ mod tests {
     #[test]
     fn parse_detect() {
         let cmd = parse(&["detect"]);
-        assert!(matches!(cmd, RadioCommand::Detect));
+        match cmd {
+            RadioCommand::Detect { json } => assert!(!json),
+            _ => panic!("expected Detect"),
+        }
+    }
+
+    #[test]
+    fn parse_detect_json_flag() {
+        let cmd = parse(&["detect", "--json"]);
+        match cmd {
+            RadioCommand::Detect { json } => assert!(json),
+            _ => panic!("expected Detect"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `akroasis radio detect --json` as a schema-versioned command report
- include detected radio count, variant, port, firmware, and warnings in the JSON envelope
- document the expanded current JSON CLI surface while leaving broader #126 coverage open

## Scope
Advances #126 with one command-local report surface. This does not close the full MCP/global JSON/API gap.

## Verification
- `cargo fmt --all --check`
- `cargo test -p akroasis`
- `cargo clippy -p akroasis --all-targets -- -D warnings`
- `cargo check -p akroasis --features hardware-serial --all-targets`
- `cargo test -p akroasis --features hardware-serial`
- `cargo clippy -p akroasis --features hardware-serial --all-targets -- -D warnings`
- `cargo test --workspace`