### PR TITLE
docs(syntonia): avoid cfg-gated rustdoc link

### DIFF
--- a/crates/syntonia/src/lib.rs
+++ b/crates/syntonia/src/lib.rs
@@ -17,7 +17,7 @@
 //! - [`import`] — CHIRP `.img` and `.csv` import
 //! - [`export`] — CHIRP `.csv` export
 //! - [`baofeng`] — Baofeng UV-5R EEPROM codec
-//! - [`hardware`] — optional serial cable and radio detection APIs
+//! - `hardware` — optional serial cable and radio detection APIs behind `hardware-serial`
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
## Summary
- avoid an unconditional rustdoc link to the feature-gated `hardware` module
- keep the docs accurate for both default and `hardware-serial` builds

## Scope
Tiny rustdoc follow-up for the #122 detect-only hardware-serial slice. This does not wire read/program/export.

## Gates
- Gate-Passed: `git diff --check`
- Gate-Passed: `cargo fmt --all --check`
- Gate-Passed: `RUSTDOCFLAGS='-D warnings' cargo doc -p syntonia --no-deps`
- Gate-Passed: `RUSTDOCFLAGS='-D warnings' cargo doc -p syntonia --features hardware-serial --no-deps`

Refs #122