### PR TITLE
ci(gate-attestation): auto-pass trusted automation actors (kanon#572)

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -16,12 +16,18 @@ jobs:
     name: gate-attestation
     runs-on: ubuntu-latest
     steps:
+      - name: Pass trusted automation PRs
+        if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'release-please[bot]' }}
+        run: echo "Gate attestation waived for trusted automation actor."
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' }}
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Verify Gate-Passed trailer
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'release-please[bot]' }}
         run: |
           commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
           if [ -z "$commits" ]; then


### PR DESCRIPTION
Auto-pass `gate-attestation` for PRs authored by `dependabot[bot]` and `release-please[bot]`.

**WHY:** dependabot and release-please cannot author `Gate-Passed:` commit trailers, so every bot PR was blocked fleet-wide by branch protection. This waiver unblocks the dependency-update flow across the fleet.

**Shape:** one early-pass step echoes a waiver line for the two trusted actors; the existing checkout and trailer-verification steps grow `if:` guards that skip them for the same actors. Human PRs are unaffected — they still must commit a `Gate-Passed:` trailer.

Refs: kanon#572, DIRECTIVE v17 (escalations.md).