### PR TITLE
docs(kryphos): align PQ content-key wrapping to operator decision (#131)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,4 +61,4 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 - Naming: `../standards/GNOMON.md`, `lexicon.md`
 - Reference store layout: `reference-store.md`
 - Fjall column encryption boundary: `fjall-column-encryption.md`
-- Hybrid PQ content-key wrapping boundary: `hybrid-pq-content-key-wrapping.md`
+- PQ content-key wrapping boundary: `pq-content-key-wrapping.md`

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -27,7 +27,7 @@ Phase index lives in the kanon repo roadmap. Wave status is reflected in merged 
 |----------|---------|
 | `ARCHITECTURE.md` | Crate map, layer structure, key decisions |
 | `fjall-column-encryption.md` | Future declarative encrypted-field boundary for fjall-backed stores |
-| `hybrid-pq-content-key-wrapping.md` | Future hybrid PQ content-key wrapping boundary and implementation gates |
+| `pq-content-key-wrapping.md` | Future PQ content-key wrapping boundary and implementation gates |
 | `reference-store.md` | Target `/instance/reference/` layout for the planned pinax knowledge store |
 | `../standards/GNOMON.md` | Greek naming methodology |
 | `lexicon.md` | Domain terms and name registry |

--- a/docs/pq-content-key-wrapping.md
+++ b/docs/pq-content-key-wrapping.md
@@ -1,26 +1,35 @@
-# Hybrid PQ Content-Key Wrapping Boundary
+# PQ Content-Key Wrapping Boundary
 
 Issue #131 is design input for future multi-device content-key distribution.
-Current main does not implement content-key wrapping, ML-KEM, P-256, AES-KW, or
-a versioned wrapped-key envelope. The shipped vault path derives a symmetric
-key from the operator passphrase and encrypts credential entries directly.
+Current main does not implement content-key wrapping, ML-KEM, or a versioned
+wrapped-key envelope. The shipped vault path derives a symmetric key from the
+operator passphrase and encrypts credential entries directly.
 
 This note records the minimum design boundary before akroasis adds new
 cryptographic dependencies. It is not an implementation of #131.
+
+## Operator Decision
+
+akroasis crypto direction is **PQ-only ML-KEM**. The hybrid P-256/ECDH + ML-KEM
+approach described in the original issue is **not** the target. Do not add
+P-256, ECDH classical half, or a hybrid HKDF combiner to the workspace.
+
+Rationale: the project does not need Web Crypto compatibility for this boundary,
+and keeping the primitive set small reduces audit surface. ML-KEM-768 alone
+provides the required post-quantum protection for offline content-key
+distribution.
 
 ## Current State
 
 - `kryphos` encrypts vault secrets with ChaCha20-Poly1305 using an Argon2id
   passphrase-derived `VaultKey`.
-- Workspace dependencies include the current classical primitives used by the
-  vault and mesh stack, including `chacha20poly1305`, `ed25519-dalek`, and
+- Workspace dependencies include `chacha20poly1305`, `ed25519-dalek`, and
   `x25519-dalek`.
-- There is no `ml-kem`, `p256`, `hkdf`, AES-KW, or `WrappedContentKey` model in
-  the workspace.
+- There is no `ml-kem`, `hkdf`, or `WrappedContentKey` model in the workspace.
 - The offline reference store is still a planned `pinax` instance layout, not a
   checked-in runtime store or sharing workflow.
 
-Adding a hybrid wrapper now would force protocol choices before the shared
+Adding a content-key wrapper now would force protocol choices before the shared
 content model exists.
 
 ## Target Envelope
@@ -31,9 +40,8 @@ The future wrapper should be versioned and per-recipient:
 WrappedContentKey {
     version,
     recipient_id,
-    classical_public,
     kem_ciphertext,
-    nonce_or_kw_metadata,
+    nonce_or_aead_metadata,
     encrypted_content_key,
 }
 ```
@@ -44,22 +52,20 @@ only for the remaining recipients, depending on the store's forward-secrecy
 requirement.
 
 The domain tag for version 1 should be fixed before implementation, for example
-`akroasis-hybrid-ck-wrap-v1`. Later protocol changes get new versions instead
-of silent reinterpretation.
+`akroasis-pq-ck-wrap-v1`. Later protocol changes get new versions instead of
+silent reinterpretation.
 
 ## Required Decisions
 
-1. Classical half: use P-256 as described in the issue, or use the existing
-   X25519 dependency to reduce the number of primitives in the workspace.
-2. PQ half: select an ML-KEM-768 crate and require upstream/FIPS test vectors in
+1. PQ KEM: select an ML-KEM-768 crate and require upstream/FIPS test vectors in
    the implementation PR.
-3. Combiner: define HKDF extract/expand inputs, salt policy, and domain
-   separation tags.
-4. Envelope encryption: choose AES-KW, AES-GCM, or the existing
-   ChaCha20-Poly1305 stack for the wrapped content key.
-5. Feature gate: decide whether the first implementation is behind a preview
+2. Key derivation: define HKDF extract/expand inputs, salt policy, and domain
+   separation tags for the ML-KEM shared secret.
+3. Envelope encryption: reuse the existing ChaCha20-Poly1305 stack or select a
+   different AEAD for the wrapped content key.
+4. Feature gate: decide whether the first implementation is behind a preview
    feature until cryptographic review is complete.
-6. Store integration: decide whether this belongs in `kryphos` alone or in the
+5. Store integration: decide whether this belongs in `kryphos` alone or in the
    first multi-device `pinax`/reference-store workflow.
 
 ## Implementation Gates


### PR DESCRIPTION
Refs #131.

Operator decision: akroasis crypto direction is PQ-only ML-KEM. The hybrid P-256/ECDH + ML-KEM approach from the original issue is not the target. This change updates the design boundary document to reflect that decision and records the remaining implementation gates. It does not implement content-key wrapping.

Changes:
- Renames `docs/hybrid-pq-content-key-wrapping.md` -> `docs/pq-content-key-wrapping.md`
- Removes P-256, ECDH classical half, and hybrid combiner as target primitives
- Adds explicit operator decision section with rationale
- Updates ARCHITECTURE.md and PROJECT.md cross-references

Gate-Passed:
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`