### PR TITLE
docs: record desktop-primary operator surface decision (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 | **Navigation** | chorografia | ◻ | ◻ | Future RF propagation modeling, infrastructure graphs, offline OSM navigation, and space weather HF prediction. |
 | **Knowledge** | pinax | ◻ |  -  | Future offline repository for frequency databases, protocol specs, equipment manuals, topo maps, and indexed references. Target instance layout is documented in [docs/reference-store.md](docs/reference-store.md). |
 | **Privacy** | lethe | ◻ | ◻ | Future VPN/proxy management, anonymization, IMSI catcher detection, and OPSEC scoring. The etymological complement to [Aletheia](https://github.com/forkwright/aletheia). |
-| **Interface** | opsis | ◻ |  -  | Future operator surfaces for spectrum waterfall, mesh topology, and intelligence dashboard views. Surface stack and order are pending the backend/programmatic API boundary tracked in #118 and #126. |
+| **Interface** | opsis | ◻ |  -  | Future operator surfaces for spectrum waterfall, mesh topology, and intelligence dashboard views. Desktop via theatron is the primary planned surface; backend/programmatic API boundary is prerequisite. TUI and web remain possible alternatives. Tracked in #118 and #126. |
 
 **Legend:** ✓ = shipped in `crates/`, ◻ = planned/not shipped,  -  = not applicable.
 
@@ -104,7 +104,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | Current: `akroasis radio import --json`, `akroasis radio detect --json`, `akroasis radio export --json`, and `akroasis mesh {status,nodes,topology} --json` emit schema-versioned JSON reports. Planned: broader JSON CLI/MCP/API coverage before `opsis`; TUI, native, web, and desktop-first order remain open planning decisions |
+| Interfaces | Current: `akroasis radio import --json`, `akroasis radio detect --json`, `akroasis radio export --json`, and `akroasis mesh {status,nodes,topology} --json` emit schema-versioned JSON reports. Planned: broader JSON CLI/MCP/API coverage before `opsis`; desktop via theatron is the primary planned surface, with backend/programmatic API boundary as prerequisite. TUI and web remain possible alternatives. |
 | License | AGPL-3.0-only |
 
 ---

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -8,7 +8,7 @@ source_docs = [
 ]
 
 [apis]
-summary = "Akroasis exposes a single CLI shell today; future TUI, desktop, and web surfaces are planned under opsis."
+summary = "Akroasis exposes a single CLI shell today; future operator surfaces are planned under opsis, with desktop via theatron as the primary surface after a backend/programmatic API boundary exists."
 
 [[cli_commands]]
 name = "akroasis"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Run `cargo metadata --format-version 1 | jq '.workspace_members | length'` for c
 ## Layer structure
 
 ```
-Interface:      opsis (operator surfaces; stack/order pending API boundary)
+Interface:      opsis (operator surfaces; desktop via theatron primary, API boundary prerequisite)
 Orchestration:  praxis (automation, playbooks, PACE)
 Analysis:       semaino (aggregation), ichneutes (correlation)
 Collection:     syntonia, kerykeion, dektis, engys, aspis, skopos, peira
@@ -33,7 +33,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **praxis** | Orchestration | Automation engine, playbooks, event triggers, state machines |
 | **chorografia** | Model | Geographic model, RF propagation, navigation, terrain |
 | **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps; see `reference-store.md` for target instance layout |
-| **opsis** | Interface | Operator surfaces after a typed programmatic/API boundary exists; stack/order pending #118 and #126 |
+| **opsis** | Interface | Operator surfaces after a typed programmatic/API boundary exists; desktop via theatron is the primary planned surface, TUI and web are alternatives. Tracked in #118 and #126 |
 | **akroasis** | Binary | CLI entrypoint, subcommand routing |
 
 ## Key decisions

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -66,7 +66,7 @@
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. Future operator surfaces for spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, and after-action replay. The surface stack and order wait on a typed backend/programmatic API boundary. |
+| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. Future operator surfaces for spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, and after-action replay. The surface stack waits on a typed backend/programmatic API boundary; desktop via theatron is the primary planned surface, with TUI and web as possible alternatives. |
 
 ---
 


### PR DESCRIPTION
Closes #118

Replaces stale "open planning decisions" and "pending" wording across docs with the operator decision captured in the issue discussion:

- Desktop via theatron is the primary planned operator surface for opsis, not tertiary.
- The backend/programmatic API boundary remains prerequisite.
- TUI and web remain possible alternative surfaces, not committed to primary order.

Files updated:
- README.md — opsis crate description and Technical table Interfaces row
- docs/ARCHITECTURE.md — layer structure and crate registry
- docs/lexicon.md — opsis definition
- _llm/apis.toml — API summary

No code scaffolded; docs-only change.

Gate-Passed: cargo fmt --check, cargo clippy --workspace --all-targets -- -D warnings