### PR TITLE
feat(akroasis): add direct-port radio detection

### DIFF
--- a/crates/akroasis/src/radio/detect.rs
+++ b/crates/akroasis/src/radio/detect.rs
@@ -27,8 +27,18 @@ struct DetectedRadioReport<'a> {
 }
 
 /// Runs the detect subcommand.
-pub(crate) fn run(hw: &dyn Hardware, json: bool, out: &mut dyn Write) -> Result<(), RadioError> {
-    let radios = hw.detect_radios()?;
+pub(crate) fn run(
+    port: Option<&str>,
+    hw: &dyn Hardware,
+    json: bool,
+    out: &mut dyn Write,
+) -> Result<(), RadioError> {
+    let radios = match port {
+        Some(port) => hw
+            .detect_radio_on_port(port)?
+            .map_or_else(Vec::new, |radio| vec![radio]),
+        None => hw.detect_radios()?,
+    };
 
     if json {
         write_json_report(&radios, out)?;
@@ -176,7 +186,7 @@ mod tests {
     fn run_no_radios_writes_message() {
         let mut out = Vec::new();
         // StubHardware returns HardwareNotAvailable, which means no radios.
-        let result = run(&super::super::StubHardware, false, &mut out);
+        let result = run(None, &super::super::StubHardware, false, &mut out);
         assert!(result.is_err());
     }
 
@@ -192,7 +202,7 @@ mod tests {
         };
 
         let mut out = Vec::new();
-        run(&hw, true, &mut out).unwrap();
+        run(None, &hw, true, &mut out).unwrap();
 
         let report: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(report["schema_version"], 1);
@@ -205,5 +215,45 @@ mod tests {
             report["radios"][0]["warnings"][0],
             "low-cost cable detected"
         );
+    }
+
+    #[test]
+    fn run_port_probe_outputs_matching_radio_only() {
+        let hw = FakeHardware {
+            radios: vec![
+                DetectedRadio {
+                    variant: RadioVariant::BfF8hp,
+                    port: "/dev/ttyUSB0".to_string(),
+                    firmware: "BFP3V3".to_string(),
+                    warnings: vec![],
+                },
+                DetectedRadio {
+                    variant: RadioVariant::Uv5r,
+                    port: "/dev/ttyUSB1".to_string(),
+                    firmware: "BFB297".to_string(),
+                    warnings: vec![],
+                },
+            ],
+        };
+
+        let mut out = Vec::new();
+        run(Some("/dev/ttyUSB1"), &hw, false, &mut out).unwrap();
+
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("Baofeng UV-5R"));
+        assert!(s.contains("/dev/ttyUSB1"));
+        assert!(!s.contains("BF-F8HP"));
+        assert!(!s.contains("/dev/ttyUSB0"));
+    }
+
+    #[test]
+    fn run_port_probe_no_match_writes_no_radios() {
+        let hw = FakeHardware { radios: vec![] };
+
+        let mut out = Vec::new();
+        run(Some("/dev/ttyUSB2"), &hw, false, &mut out).unwrap();
+
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("No radios detected"));
     }
 }

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -23,6 +23,10 @@ use self::errors::RadioError;
 pub enum RadioCommand {
     /// Detect connected radios
     Detect {
+        /// Serial port to probe directly (e.g. /dev/ttyUSB0).
+        #[arg(long)]
+        port: Option<String>,
+
         /// Emit a machine-readable JSON report instead of human text.
         #[arg(long)]
         json: bool,
@@ -165,6 +169,14 @@ pub struct DetectedRadio {
 /// Abstraction over radio hardware detection and connection.
 pub trait Hardware {
     fn detect_radios(&self) -> Result<Vec<DetectedRadio>, RadioError>;
+    fn detect_radio_on_port(&self, port: &str) -> Result<Option<DetectedRadio>, RadioError> {
+        let mut radios = self.detect_radios()?;
+        Ok(radios
+            .iter()
+            .position(|radio| radio.port == port)
+            .map(|idx| radios.swap_remove(idx)))
+    }
+
     fn open(&self, port: &str) -> Result<Box<dyn Session>, RadioError>;
 }
 
@@ -207,11 +219,10 @@ impl Hardware for StubHardware {
 /// Resolves the target radio from an explicit port or auto-detection.
 pub fn resolve_target(port: Option<&str>, hw: &dyn Hardware) -> Result<DetectedRadio, RadioError> {
     if let Some(port) = port {
-        let mut radios = hw.detect_radios()?;
-        radios.iter().position(|r| r.port == port).map_or_else(
+        hw.detect_radio_on_port(port)?.map_or_else(
             || {
-                // WHY: Port was given explicitly but detection didn't find it.
-                // Fall back to opening directly — the user knows what they're doing.
+                // WHY: Port was given explicitly but detection didn't identify it.
+                // Fall back to opening directly; the user may know the target.
                 Ok(DetectedRadio {
                     variant: RadioVariant::Uv5r,
                     port: port.to_string(),
@@ -219,7 +230,7 @@ pub fn resolve_target(port: Option<&str>, hw: &dyn Hardware) -> Result<DetectedR
                     warnings: Vec::new(),
                 })
             },
-            |idx| Ok(radios.swap_remove(idx)),
+            Ok,
         )
     } else {
         let radios = hw.detect_radios()?;
@@ -257,7 +268,7 @@ pub fn dispatch_with(
     out: &mut dyn std::io::Write,
 ) -> Result<(), RadioError> {
     match cmd {
-        RadioCommand::Detect { json } => detect::run(hw, *json, out),
+        RadioCommand::Detect { port, json } => detect::run(port.as_deref(), hw, *json, out),
         RadioCommand::Read { port } => read::run(port.as_deref(), hw, out),
         RadioCommand::Program { port, plan } => program::run(port.as_deref(), plan, hw, out),
         RadioCommand::Export {
@@ -295,7 +306,10 @@ mod tests {
     fn parse_detect() {
         let cmd = parse(&["detect"]);
         match cmd {
-            RadioCommand::Detect { json } => assert!(!json),
+            RadioCommand::Detect { port, json } => {
+                assert!(port.is_none());
+                assert!(!json);
+            }
             _ => panic!("expected Detect"),
         }
     }
@@ -304,7 +318,22 @@ mod tests {
     fn parse_detect_json_flag() {
         let cmd = parse(&["detect", "--json"]);
         match cmd {
-            RadioCommand::Detect { json } => assert!(json),
+            RadioCommand::Detect { port, json } => {
+                assert!(port.is_none());
+                assert!(json);
+            }
+            _ => panic!("expected Detect"),
+        }
+    }
+
+    #[test]
+    fn parse_detect_with_port() {
+        let cmd = parse(&["detect", "--port", "/dev/ttyUSB0"]);
+        match cmd {
+            RadioCommand::Detect { port, json } => {
+                assert_eq!(port.as_deref(), Some("/dev/ttyUSB0"));
+                assert!(!json);
+            }
             _ => panic!("expected Detect"),
         }
     }

--- a/crates/akroasis/src/radio/serial_hardware.rs
+++ b/crates/akroasis/src/radio/serial_hardware.rs
@@ -15,6 +15,12 @@ impl Hardware for SerialHardware {
         Ok(detected.into_iter().filter_map(to_cli_radio).collect())
     }
 
+    fn detect_radio_on_port(&self, port: &str) -> Result<Option<DetectedRadio>, RadioError> {
+        let detected = hardware::detect_radio_on_port(port)
+            .map_err(|source| RadioError::HardwareDetect { source })?;
+        Ok(detected.and_then(to_cli_radio))
+    }
+
     fn open(&self, _port: &str) -> Result<Box<dyn Session>, RadioError> {
         Err(RadioError::HardwareNotAvailable)
     }
@@ -62,8 +68,9 @@ fn cable_warnings(cable: &UsbCable) -> Vec<String> {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test assertions use unwrap for clarity")]
 mod tests {
-    use super::*;
     use syntonia::hardware::{RadioIdent, VariantConfig};
+
+    use super::*;
 
     fn cable(chip: CableChip) -> UsbCable {
         UsbCable {


### PR DESCRIPTION
Summary:
- Adds `akroasis radio detect --port <PORT>` for direct serial-port probing.
- Wires the hardware abstraction to support single-port detection, with the `hardware-serial` backend calling syntonia's public `detect_radio_on_port` API.
- Reuses the direct-port probe when resolving explicit ports for read/program/export, while leaving session read/program/export unavailable until syntonia exposes a suitable protocol/session API.

Scope:
This advances #122 without claiming full radio read/program/export support. The Baofeng protocol driver and hardware serial adapter remain private to syntonia, so this PR keeps the slice to public detection APIs only.

Notes:
- `kanon lint . --summary` still reports pre-existing repository violations outside this slice.
- `kanon lint` passes on each changed file.

Gate-Passed: cargo fmt --all -- --check; cargo test -p akroasis; cargo clippy -p akroasis --all-targets -- -D warnings; cargo check -p akroasis --features hardware-serial; cargo test -p akroasis --features hardware-serial; cargo clippy -p akroasis --features hardware-serial --all-targets -- -D warnings; cargo test --workspace; git diff --check; kanon lint crates/akroasis/src/radio/detect.rs --summary; kanon lint crates/akroasis/src/radio/mod.rs --summary; kanon lint crates/akroasis/src/radio/serial_hardware.rs --summary
