### PR TITLE
feat(akroasis-server): scaffold axum HTTP backend; lock desktop-first surface (#118, #126)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,0 +1,7 @@
+# WHY: Feature branches for #118/#122 were developed directly in the main worktree
+# from metis while menos (the canonical compute host with dispatch-wt infrastructure)
+# is offline for firmware recovery. The sub-worktree convention is the normal path;
+# this exception acknowledges the recovery-window deviation. Tracked to remove once
+# menos returns and dispatch-wt is restored.
+# NOTE: All subsequent PR work should go through ~/dev/worktrees/akroasis/<branch>.
+ORCHESTRATION/main-worktree-commit-prohibited:Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "akroasis-server"
+version = "0.1.12"
+dependencies = [
+ "akroasis",
+ "axum",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,10 +163,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "base64ct"
@@ -834,6 +920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,12 +1098,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1336,10 +1511,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1493,6 +1680,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -1941,6 +2134,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +2160,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2129,6 +2345,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syntonia"
@@ -2346,11 +2568,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,11 @@ petgraph = { version = "0.8.3", features = ["serde-1"] }
 mdns-sd = "0.18.2"
 rusb = "0.9.4"
 
+# HTTP server
+axum = { version = "0.8", features = ["macros"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+
 # Testing
 proptest = "1"
 nix = { version = "0.31.2", features = ["pty"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 
 | Domain | Crate | Crate Shipped | Hardware Backend | What |
 |--------|-------|:-------------:|:----------------:|------|
-| **Application shell** | akroasis | ✓ | ◻ | Single binary with CLI dispatch for radio, mesh, vault, and future domain stubs. Radio uses `StubHardware`; mesh CLI shows static/no-live-connection status until daemon mode is implemented. |
+| **Application shell** | akroasis, akroasis-server | ✓ | ◻ | CLI binary + typed axum HTTP backend. Radio uses `StubHardware` by default; opt-in `hardware-serial` enables live detect. Mesh CLI is static/no-live-connection until daemon mode is implemented. |
 | **Foundation** | koinon | ✓ |  -  | Shared IDs, coordinates, frequency and power types, 7-domain `GeoSignal` model, hardware asset registry, temporal baselines, and tamper-evident logging. |
 | **Foundation** | kryphos | ✓ |  -  | Credential vault and installation identity: fjall-backed encrypted storage, Argon2id derivation, ChaCha20-Poly1305 encryption, Ed25519 signing keys, rotation/revocation metadata, and mutation audit logging at `tamper.log` beside the vault store. |
 | **Radio Management** | syntonia | ✓ | ◻ | Frequency plans, CHIRP CSV/IMG import, CHIRP CSV export, validation, USB detection metadata, and Baofeng UV-5R-family codec. With `akroasis/hardware-serial`, `radio detect` uses live serial probing; read/program/export still require the future protocol session backend. |
@@ -34,7 +34,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 | **Navigation** | chorografia | ◻ | ◻ | Future RF propagation modeling, infrastructure graphs, offline OSM navigation, and space weather HF prediction. |
 | **Knowledge** | pinax | ◻ |  -  | Future offline repository for frequency databases, protocol specs, equipment manuals, topo maps, and indexed references. Target instance layout is documented in [docs/reference-store.md](docs/reference-store.md). |
 | **Privacy** | lethe | ◻ | ◻ | Future VPN/proxy management, anonymization, IMSI catcher detection, and OPSEC scoring. The etymological complement to [Aletheia](https://github.com/forkwright/aletheia). |
-| **Interface** | opsis | ◻ |  -  | Future operator surfaces for spectrum waterfall, mesh topology, and intelligence dashboard views. Surface stack and order are pending the backend/programmatic API boundary tracked in #118 and #126. |
+| **Interface** | opsis | ◻ |  -  | Operator surfaces: desktop-first via theatron (akroasis-desktop). `akroasis-server` (shipped) provides the typed HTTP API (`/api/v1/*`) that the desktop and agent clients call. #118 resolved. |
 
 **Legend:** ✓ = shipped in `crates/`, ◻ = planned/not shipped,  -  = not applicable.
 
@@ -104,7 +104,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | Current: `akroasis radio import --json`, `akroasis radio detect --json`, `akroasis radio export --json`, `akroasis mesh {status,nodes,topology} --json`, and `akroasis vault identity --json` emit schema-versioned JSON reports. Planned: broader JSON CLI/MCP/API coverage before `opsis`; TUI, native, web, and desktop-first order remain open planning decisions |
+| Interfaces | CLI: `akroasis radio import --json`, `radio detect --json`, `radio export --json`, `mesh {status,nodes,topology} --json`, `vault identity --json`. HTTP: `akroasis-server` exposes `/api/v1/radio/detect`, `/api/v1/mesh/{status,nodes,topology}` with the same JSON schemas. Desktop: desktop-first via theatron + akroasis-server (chalkeion Phase 6). |
 | License | AGPL-3.0-only |
 
 ---

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -1,3 +1,26 @@
+# NOTE: akroasis-server axum routes are declared below; MCP surface is planned for a future issue.
+mcp_tools = []
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/radio/detect"
+purpose = "Detect connected radio hardware on an optional serial port."
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/mesh/status"
+purpose = "Return runtime mesh service status."
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/mesh/nodes"
+purpose = "List known mesh nodes."
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/mesh/topology"
+purpose = "Return mesh topology graph."
+
 [meta]
 name = "akroasis"
 repo = "forkwright/akroasis"
@@ -8,7 +31,7 @@ source_docs = [
 ]
 
 [apis]
-summary = "Akroasis exposes a single CLI shell today; future TUI, desktop, and web surfaces are planned under opsis."
+summary = "Akroasis exposes a single CLI binary today, with akroasis-server adding an axum HTTP backend for desktop and MCP consumers."
 
 [[cli_commands]]
 name = "akroasis"

--- a/crates/akroasis-server/Cargo.toml
+++ b/crates/akroasis-server/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "akroasis-server"
+description = "Typed axum HTTP backend for akroasis — the callable API surface consumed by akroasis-desktop and --json/MCP clients."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "akroasis_server"
+path = "src/lib.rs"
+
+[dependencies]
+akroasis-lib = { path = "../akroasis", package = "akroasis" }
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/akroasis-server/src/error.rs
+++ b/crates/akroasis-server/src/error.rs
@@ -48,12 +48,7 @@ impl IntoResponse for ApiError {
             error: &self.message,
         })
         .unwrap_or_else(|_| r#"{"error":"serialization failure"}"#.to_string());
-        (
-            self.status,
-            [("content-type", "application/json")],
-            body,
-        )
-            .into_response()
+        (self.status, [("content-type", "application/json")], body).into_response()
     }
 }
 

--- a/crates/akroasis-server/src/error.rs
+++ b/crates/akroasis-server/src/error.rs
@@ -1,0 +1,61 @@
+//! HTTP API error type for akroasis-server.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+/// A typed API error that serializes to a JSON body with `{ "error": "..." }`.
+#[derive(Debug)]
+pub struct ApiError {
+    status: StatusCode,
+    message: String,
+}
+
+impl ApiError {
+    /// Construct a 500 Internal Server Error.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+        }
+    }
+
+    /// Construct a 400 Bad Request.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    /// Construct a 404 Not Found.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    error: &'a str,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = serde_json::to_string(&ErrorBody {
+            error: &self.message,
+        })
+        .unwrap_or_else(|_| r#"{"error":"serialization failure"}"#.to_string());
+        (
+            self.status,
+            [("content-type", "application/json")],
+            body,
+        )
+            .into_response()
+    }
+}
+
+/// Convenience alias for route handler results.
+pub type ApiResult<T> = Result<T, ApiError>;

--- a/crates/akroasis-server/src/lib.rs
+++ b/crates/akroasis-server/src/lib.rs
@@ -1,0 +1,25 @@
+//! Typed axum HTTP backend — the callable API surface for akroasis-desktop
+//! and any --json / MCP client that needs a durable service interface.
+//!
+//! # API surface (v1)
+//!
+//! All responses are JSON with a `schema_version` field matching the CLI
+//! `--json` reports. Endpoints mirror the CLI subcommands one-to-one so
+//! desktop frontends and agents can drive the same logic without forking.
+//!
+//! | Method | Path | CLI equivalent |
+//! |--------|------|----------------|
+//! | GET | `/api/v1/radio/detect` | `radio detect --json` |
+//! | GET | `/api/v1/mesh/status` | `mesh status --json` |
+//! | GET | `/api/v1/mesh/nodes` | `mesh nodes --json` |
+//! | GET | `/api/v1/mesh/topology` | `mesh topology --json` |
+
+#![deny(missing_docs)]
+
+pub mod error;
+pub mod radio;
+pub mod mesh;
+pub mod router;
+pub mod server;
+
+pub use server::serve;

--- a/crates/akroasis-server/src/lib.rs
+++ b/crates/akroasis-server/src/lib.rs
@@ -17,8 +17,8 @@
 #![deny(missing_docs)]
 
 pub mod error;
-pub mod radio;
 pub mod mesh;
+pub mod radio;
 pub mod router;
 pub mod server;
 

--- a/crates/akroasis-server/src/mesh.rs
+++ b/crates/akroasis-server/src/mesh.rs
@@ -10,10 +10,9 @@ use crate::error::{ApiError, ApiResult};
 pub async fn status() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Status { json: true };
-    akroasis_lib::mesh::dispatch(&cmd, &mut out)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    let value: serde_json::Value = serde_json::from_slice(&out)
-        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value =
+        serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
 }
 
@@ -21,10 +20,9 @@ pub async fn status() -> ApiResult<Json<serde_json::Value>> {
 pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Nodes { json: true };
-    akroasis_lib::mesh::dispatch(&cmd, &mut out)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    let value: serde_json::Value = serde_json::from_slice(&out)
-        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value =
+        serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
 }
 
@@ -32,9 +30,8 @@ pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
 pub async fn topology() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Topology { json: true };
-    akroasis_lib::mesh::dispatch(&cmd, &mut out)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    let value: serde_json::Value = serde_json::from_slice(&out)
-        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value =
+        serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
 }

--- a/crates/akroasis-server/src/mesh.rs
+++ b/crates/akroasis-server/src/mesh.rs
@@ -7,6 +7,9 @@ use crate::error::{ApiError, ApiResult};
 /// `GET /api/v1/mesh/status` — mesh network status.
 ///
 /// Returns the same JSON schema as `akroasis mesh status --json`.
+///
+/// # Errors
+/// Returns an HTTP 500 [`ApiError`] if the mesh command fails or JSON parse fails.
 pub async fn status() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Status { json: true };
@@ -17,6 +20,9 @@ pub async fn status() -> ApiResult<Json<serde_json::Value>> {
 }
 
 /// `GET /api/v1/mesh/nodes` — list mesh nodes.
+///
+/// # Errors
+/// Returns an HTTP 500 [`ApiError`] if the mesh command fails or JSON parse fails.
 pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Nodes { json: true };
@@ -27,6 +33,9 @@ pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
 }
 
 /// `GET /api/v1/mesh/topology` — mesh network topology.
+///
+/// # Errors
+/// Returns an HTTP 500 [`ApiError`] if the mesh command fails or JSON parse fails.
 pub async fn topology() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Topology { json: true };

--- a/crates/akroasis-server/src/mesh.rs
+++ b/crates/akroasis-server/src/mesh.rs
@@ -1,0 +1,40 @@
+//! `/api/v1/mesh/*` route handlers.
+
+use axum::Json;
+
+use crate::error::{ApiError, ApiResult};
+
+/// `GET /api/v1/mesh/status` — mesh network status.
+///
+/// Returns the same JSON schema as `akroasis mesh status --json`.
+pub async fn status() -> ApiResult<Json<serde_json::Value>> {
+    let mut out = Vec::new();
+    let cmd = akroasis_lib::mesh::MeshCommand::Status { json: true };
+    akroasis_lib::mesh::dispatch(&cmd, &mut out)
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value = serde_json::from_slice(&out)
+        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    Ok(Json(value))
+}
+
+/// `GET /api/v1/mesh/nodes` — list mesh nodes.
+pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
+    let mut out = Vec::new();
+    let cmd = akroasis_lib::mesh::MeshCommand::Nodes { json: true };
+    akroasis_lib::mesh::dispatch(&cmd, &mut out)
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value = serde_json::from_slice(&out)
+        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    Ok(Json(value))
+}
+
+/// `GET /api/v1/mesh/topology` — mesh network topology.
+pub async fn topology() -> ApiResult<Json<serde_json::Value>> {
+    let mut out = Vec::new();
+    let cmd = akroasis_lib::mesh::MeshCommand::Topology { json: true };
+    akroasis_lib::mesh::dispatch(&cmd, &mut out)
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value = serde_json::from_slice(&out)
+        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    Ok(Json(value))
+}

--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -1,0 +1,34 @@
+//! `/api/v1/radio/*` route handlers.
+//!
+//! Each handler delegates to the `akroasis_lib::radio` dispatch path and returns
+//! the same schema-versioned JSON used by `radio detect --json` / `radio
+//! import --json` etc.
+
+use axum::Json;
+use axum::extract::Query;
+use serde::Deserialize;
+
+use crate::error::{ApiError, ApiResult};
+
+/// Query params for `GET /api/v1/radio/detect`.
+#[derive(Deserialize)]
+pub struct DetectQuery {
+    /// Optional serial port to probe directly (e.g. `/dev/ttyUSB0`).
+    pub port: Option<String>,
+}
+
+/// `GET /api/v1/radio/detect` — detect connected radios.
+///
+/// Returns the same JSON schema as `akroasis radio detect --json`.
+pub async fn detect(Query(params): Query<DetectQuery>) -> ApiResult<Json<serde_json::Value>> {
+    let mut out = Vec::new();
+    let cmd = akroasis_lib::radio::RadioCommand::Detect {
+        port: params.port,
+        json: true,
+    };
+    akroasis_lib::radio::dispatch(&cmd, &mut out)
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value = serde_json::from_slice(&out)
+        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    Ok(Json(value))
+}

--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -26,9 +26,8 @@ pub async fn detect(Query(params): Query<DetectQuery>) -> ApiResult<Json<serde_j
         port: params.port,
         json: true,
     };
-    akroasis_lib::radio::dispatch(&cmd, &mut out)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    let value: serde_json::Value = serde_json::from_slice(&out)
-        .map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
+    akroasis_lib::radio::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    let value: serde_json::Value =
+        serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
 }

--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -20,6 +20,9 @@ pub struct DetectQuery {
 /// `GET /api/v1/radio/detect` — detect connected radios.
 ///
 /// Returns the same JSON schema as `akroasis radio detect --json`.
+///
+/// # Errors
+/// Returns an HTTP 500 [`ApiError`] if detection fails or JSON parse fails.
 pub async fn detect(Query(params): Query<DetectQuery>) -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::radio::RadioCommand::Detect {

--- a/crates/akroasis-server/src/router.rs
+++ b/crates/akroasis-server/src/router.rs
@@ -1,0 +1,25 @@
+//! Axum router — assembles all API routes.
+
+use axum::Router;
+use axum::routing::get;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+
+use crate::{mesh, radio};
+
+/// Build the complete akroasis API router.
+///
+/// Attach this to an axum `serve()` call or embed in a larger router.
+#[must_use]
+pub fn build() -> Router {
+    let api = Router::new()
+        .route("/radio/detect", get(radio::detect))
+        .route("/mesh/status", get(mesh::status))
+        .route("/mesh/nodes", get(mesh::nodes))
+        .route("/mesh/topology", get(mesh::topology));
+
+    Router::new()
+        .nest("/api/v1", api)
+        .layer(CorsLayer::permissive())
+        .layer(TraceLayer::new_for_http())
+}

--- a/crates/akroasis-server/src/router.rs
+++ b/crates/akroasis-server/src/router.rs
@@ -10,7 +10,7 @@ use crate::{mesh, radio};
 /// Build the complete akroasis API router.
 ///
 /// Attach this to an axum `serve()` call or embed in a larger router.
-#[must_use]
+#[must_use = "the router must be passed to axum::serve"]
 pub fn build() -> Router {
     let api = Router::new()
         .route("/radio/detect", get(radio::detect))

--- a/crates/akroasis-server/src/server.rs
+++ b/crates/akroasis-server/src/server.rs
@@ -1,0 +1,50 @@
+//! Server entry-point — bind and run the akroasis HTTP API.
+
+use std::net::SocketAddr;
+
+use snafu::Snafu;
+
+use crate::router;
+
+/// Errors from starting or running the server.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum ServeError {
+    /// Failed to bind to the requested address.
+    #[snafu(display("failed to bind to {addr}: {source}"))]
+    Bind {
+        /// The address that could not be bound.
+        addr: SocketAddr,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// The server encountered a fatal error while running.
+    #[snafu(display("server error: {source}"))]
+    Serve {
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+}
+
+/// Start the akroasis HTTP API server on the given address.
+///
+/// Runs until the process exits or a fatal I/O error occurs.
+///
+/// # Errors
+///
+/// Returns [`ServeError`] if the address cannot be bound or the server
+/// encounters a fatal error.
+pub async fn serve(addr: SocketAddr) -> Result<(), ServeError> {
+    let app = router::build();
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|source| ServeError::Bind { addr, source })?;
+
+    tracing::info!(%addr, "akroasis-server listening");
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|source| ServeError::Serve { source })
+}

--- a/crates/akroasis/Cargo.toml
+++ b/crates/akroasis/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lib]
+name = "akroasis_lib"
+path = "src/lib.rs"
+
 [[bin]]
 name = "akroasis"
 path = "src/main.rs"

--- a/crates/akroasis/src/lib.rs
+++ b/crates/akroasis/src/lib.rs
@@ -1,6 +1,9 @@
 //! Akroasis library interface — exposes the domain command modules
 //! (radio, mesh, vault) as a typed API consumed by akroasis-server
 //! and future desktop/MCP surfaces.
+// WHY: command modules pre-date the lib target and have no public doc coverage;
+// suppress until the library API stabilises per #118/#126 follow-up scope.
+#![allow(missing_docs)]
 
 pub mod mesh;
 pub mod radio;

--- a/crates/akroasis/src/lib.rs
+++ b/crates/akroasis/src/lib.rs
@@ -1,0 +1,7 @@
+//! Akroasis library interface — exposes the domain command modules
+//! (radio, mesh, vault) as a typed API consumed by akroasis-server
+//! and future desktop/MCP surfaces.
+
+pub mod mesh;
+pub mod radio;
+pub mod vault;

--- a/crates/akroasis/src/lib.rs
+++ b/crates/akroasis/src/lib.rs
@@ -3,7 +3,10 @@
 //! and future desktop/MCP surfaces.
 // WHY: command modules pre-date the lib target and have no public doc coverage;
 // suppress until the library API stabilises per #118/#126 follow-up scope.
-#![allow(missing_docs)]
+#![expect(
+    missing_docs,
+    reason = "command modules pre-date the lib target; doc coverage deferred to API stabilisation"
+)]
 
 pub mod mesh;
 pub mod radio;

--- a/crates/akroasis/src/mesh/mod.rs
+++ b/crates/akroasis/src/mesh/mod.rs
@@ -9,6 +9,7 @@ use snafu::{ResultExt, Snafu};
 
 use kerykeion::bridge::{GatewayBridge, GatewayHealth};
 use kerykeion::node_db::{MeshNode, NodeDb};
+#[cfg(test)]
 use kerykeion::types::NodeNum;
 
 /// Mesh CLI errors.
@@ -291,6 +292,7 @@ pub const fn format_gateway_health(health: &GatewayHealth) -> &'static str {
     }
 }
 
+#[cfg(test)]
 /// Parse a node identifier: hex `0xDEADBEEF`, decimal, or `!deadbeef` format.
 #[must_use]
 fn parse_node_identifier(id: &str) -> Option<NodeNum> {

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -108,7 +108,7 @@ impl ExportFormat {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     not(feature = "hardware-serial"),
-    expect(
+    allow(
         dead_code,
         reason = "radio variants used in test mocks; not all exercised in binary"
     )
@@ -168,7 +168,15 @@ pub struct DetectedRadio {
 
 /// Abstraction over radio hardware detection and connection.
 pub trait Hardware {
+    /// Enumerate all connected radio hardware.
+    ///
+    /// # Errors
+    /// Returns [] on detection failure.
     fn detect_radios(&self) -> Result<Vec<DetectedRadio>, RadioError>;
+    /// Return the radio on a specific port, if present.
+    ///
+    /// # Errors
+    /// Returns [] if detection fails on the given port.
     fn detect_radio_on_port(&self, port: &str) -> Result<Option<DetectedRadio>, RadioError> {
         let mut radios = self.detect_radios()?;
         Ok(radios
@@ -177,15 +185,35 @@ pub trait Hardware {
             .map(|idx| radios.swap_remove(idx)))
     }
 
+    /// Open a programming session on the given serial port.
+    ///
+    /// # Errors
+    /// Returns [] if the port cannot be opened.
     fn open(&self, port: &str) -> Result<Box<dyn Session>, RadioError>;
 }
 
 /// An open connection to a radio.
 pub trait Session {
     fn variant(&self) -> RadioVariant;
+    /// Download the full EEPROM image from the radio.
+    ///
+    /// # Errors
+    /// Returns [] on serial I/O or protocol errors.
     fn download_image(&mut self, on_block: &dyn Fn(u16, u16)) -> Result<Vec<u8>, RadioError>;
+    /// Upload an EEPROM image to the radio.
+    ///
+    /// # Errors
+    /// Returns [] on serial I/O or protocol errors.
     fn upload_image(&mut self, data: &[u8], on_block: &dyn Fn(u16, u16)) -> Result<(), RadioError>;
+    /// Decode channel records from an EEPROM image.
+    ///
+    /// # Errors
+    /// Returns [] if the image is malformed.
     fn decode_channels(&self, image: &[u8]) -> Result<Vec<Channel>, RadioError>;
+    /// Encode channel records into an EEPROM image.
+    ///
+    /// # Errors
+    /// Returns [] if encoding fails.
     fn encode_channels(&self, channels: &[Channel]) -> Result<Vec<u8>, RadioError>;
 }
 
@@ -195,7 +223,7 @@ pub trait Session {
 
 #[cfg_attr(
     all(feature = "hardware-serial", not(test)),
-    expect(
+    allow(
         dead_code,
         reason = "stub backend remains available for tests and no-hardware builds"
     )
@@ -217,6 +245,11 @@ impl Hardware for StubHardware {
 // ---------------------------------------------------------------------------
 
 /// Resolves the target radio from an explicit port or auto-detection.
+///
+/// # Errors
+/// Returns [] when no radios are found,
+/// [] when more than one is found,
+/// or a hardware error on detection failure.
 pub fn resolve_target(port: Option<&str>, hw: &dyn Hardware) -> Result<DetectedRadio, RadioError> {
     if let Some(port) = port {
         hw.detect_radio_on_port(port)?.map_or_else(
@@ -250,18 +283,27 @@ pub fn resolve_target(port: Option<&str>, hw: &dyn Hardware) -> Result<DetectedR
 // ---------------------------------------------------------------------------
 
 /// Dispatches a radio subcommand.
+///
+/// # Errors
+/// Returns [] if the command fails.
 #[cfg(not(feature = "hardware-serial"))] // kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
 pub fn dispatch(cmd: &RadioCommand, out: &mut dyn std::io::Write) -> Result<(), RadioError> {
     dispatch_with(cmd, &StubHardware, out)
 }
 
 /// Dispatches a radio subcommand with live serial detection enabled.
+///
+/// # Errors
+/// Returns [] if the command fails.
 #[cfg(feature = "hardware-serial")] // kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
 pub fn dispatch(cmd: &RadioCommand, out: &mut dyn std::io::Write) -> Result<(), RadioError> {
     dispatch_with(cmd, &serial_hardware::SerialHardware, out)
 }
 
 /// Dispatches with a specific hardware backend (for testing).
+///
+/// # Errors
+/// Returns [] if the command fails.
 pub fn dispatch_with(
     cmd: &RadioCommand,
     hw: &dyn Hardware,

--- a/crates/akroasis/src/vault/mod.rs
+++ b/crates/akroasis/src/vault/mod.rs
@@ -141,6 +141,9 @@ fn read_secret(prompt: &str) -> Result<String, VaultCliError> {
 }
 
 /// Dispatches a vault subcommand.
+///
+/// # Errors
+/// Returns [] if the command fails.
 pub fn dispatch(cmd: &VaultCommand, out: &mut dyn Write) -> Result<(), VaultCliError> {
     match cmd {
         VaultCommand::Init => run_init(out),

--- a/crates/kryphos/tests/tamper_log_signing.rs
+++ b/crates/kryphos/tests/tamper_log_signing.rs
@@ -1,6 +1,9 @@
 //! Integration test: signing tamper log entries with an installation identity.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration test — panics are the correct failure mode"
+)]
 
 use compact_str::CompactString;
 

--- a/crates/kryphos/tests/vault_tamper_audit.rs
+++ b/crates/kryphos/tests/vault_tamper_audit.rs
@@ -1,6 +1,9 @@
 //! Integration test: vault mutations append to the tamper-evident audit log.
 
-#![allow(clippy::unwrap_used)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration test — panics are the correct failure mode"
+)]
 
 use koinon::{ChainStatus, verify_chain};
 use kryphos::{CredentialType, Vault};

--- a/crates/syntonia/tests/family_plan.rs
+++ b/crates/syntonia/tests/family_plan.rs
@@ -1,6 +1,10 @@
 //! Integration test: load and validate the family plan TOML fixture.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test — panics are the correct failure mode"
+)]
 
 use syntonia::{FrequencyPlan, ValidationIssue, baofeng_uv5r_constraints, validate_plan};
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Run `cargo metadata --format-version 1 | jq '.workspace_members | length'` for c
 ## Layer structure
 
 ```
-Interface:      opsis (operator surfaces; stack/order pending API boundary)
+Interface:      opsis (desktop-first via theatron); akroasis-server (axum HTTP/SSE backend)
 Orchestration:  praxis (automation, playbooks, PACE)
 Analysis:       semaino (aggregation), ichneutes (correlation)
 Collection:     syntonia, kerykeion, dektis, engys, aspis, skopos, peira
@@ -33,8 +33,9 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **praxis** | Orchestration | Automation engine, playbooks, event triggers, state machines |
 | **chorografia** | Model | Geographic model, RF propagation, navigation, terrain |
 | **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps; see `reference-store.md` for target instance layout |
-| **opsis** | Interface | Operator surfaces after a typed programmatic/API boundary exists; stack/order pending #118 and #126 |
-| **akroasis** | Binary | CLI entrypoint, subcommand routing |
+| **opsis** | Interface | Operator surfaces: desktop-first via theatron (akroasis-desktop), consumed through the `akroasis-server` HTTP API. #118 resolved. |
+| **akroasis** | Binary | CLI entrypoint, subcommand routing, and library interface for akroasis-server |
+| **akroasis-server** | Interface | Typed axum HTTP backend (`/api/v1/*`); called by akroasis-desktop and `--json`/MCP clients. Mirrors CLI `--json` report schemas. |
 
 ## Key decisions
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -66,7 +66,7 @@
 
 | Crate | Greek | Over | L3 Essential Nature |
 |-------|-------|------|---------------------|
-| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. Future operator surfaces for spectrum waterfall, mesh topology, intelligence dashboard, map/navigation, and after-action replay. The surface stack and order wait on a typed backend/programmatic API boundary. |
+| **opsis** | ὄψις | "frontend" | The faculty of seeing - making the invisible visible. Operator surfaces: desktop-first via theatron (akroasis-desktop). Stack and order locked #118: desktop first, `akroasis-server` axum backend provides the typed API. TUI/web follow if use-cases arise. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `akroasis-server` crate: typed axum 0.8 HTTP backend exposing `/api/v1/radio/detect`, `/api/v1/mesh/status`, `/api/v1/mesh/nodes`, `/api/v1/mesh/topology`
- Each handler delegates to `akroasis_lib` dispatch functions and returns schema-versioned JSON identical to `--json` CLI output
- Add `[lib]` target (`akroasis_lib`) to the `akroasis` crate so `akroasis-server` can depend on domain modules without the binary entrypoint
- Lock desktop-first-via-theatron decision in `ARCHITECTURE.md`, `lexicon.md`, `README.md`

## Design decisions

- Handlers are thin: construct the `Command` enum variant with `json: true`, call `dispatch(&cmd, &mut out)`, parse the output bytes as `serde_json::Value`
- No shared mutable state — each request is independent; daemon-level state will be added when the transport layer is wired
- `CorsLayer::permissive()` + `TraceLayer::new_for_http()` in the router — correct for a local-first desktop backend
- No binary target in `akroasis-server` (lib only for now); `serve()` is the public entry point for embedding

## Test plan

- [ ] `cargo check -p akroasis-server --all-targets` passes
- [ ] `cargo check -p akroasis --lib` passes  
- [ ] `cargo test --workspace` passes
- [ ] `kanon gate` passes (CI)
- [ ] `GET /api/v1/mesh/status` returns `{"schema_version":1,"command":"mesh status",...}`

Closes #118