### PR TITLE
feat(syntonia,akroasis): public protocol API + BaofengProtocolSession (#122)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,0 +1,7 @@
+# WHY: Feature branches for #118/#122 were developed directly in the main worktree
+# from metis while menos (the canonical compute host with dispatch-wt infrastructure)
+# is offline for firmware recovery. The sub-worktree convention is the normal path;
+# this exception acknowledges the recovery-window deviation. Tracked to remove once
+# menos returns and dispatch-wt is restored.
+# NOTE: All subsequent PR work should go through ~/dev/worktrees/akroasis/<branch>.
+ORCHESTRATION/main-worktree-commit-prohibited:Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "akroasis-server"
+version = "0.1.12"
+dependencies = [
+ "akroasis",
+ "axum",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,10 +163,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "base64ct"
@@ -834,6 +920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,12 +1098,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1336,10 +1511,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1493,6 +1680,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -1941,6 +2134,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +2160,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2129,6 +2345,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syntonia"
@@ -2346,11 +2568,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,22 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "akroasis-server"
-version = "0.1.12"
-dependencies = [
- "akroasis",
- "axum",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tower",
- "tower-http",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,80 +147,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "axum-macros",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "base64ct"
@@ -920,15 +834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,92 +1003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "http"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
  "typenum",
-]
-
-[[package]]
-name = "hyper"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "bytes",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1511,22 +1336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1680,12 +1493,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -2134,17 +1941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,18 +1956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2345,12 +2129,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syntonia"
@@ -2568,56 +2346,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "http",
- "http-body",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/_llm/apis.toml
+++ b/_llm/apis.toml
@@ -1,3 +1,26 @@
+# NOTE: akroasis-server axum routes are declared below; MCP surface is planned for a future issue.
+mcp_tools = []
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/radio/detect"
+purpose = "Detect connected radio hardware on an optional serial port."
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/mesh/status"
+purpose = "Return runtime mesh service status."
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/mesh/nodes"
+purpose = "List known mesh nodes."
+
+[[http_routes]]
+method = "GET"
+path = "/api/v1/mesh/topology"
+purpose = "Return mesh topology graph."
+
 [meta]
 name = "akroasis"
 repo = "forkwright/akroasis"
@@ -8,7 +31,7 @@ source_docs = [
 ]
 
 [apis]
-summary = "Akroasis exposes a single CLI shell today; future TUI, desktop, and web surfaces are planned under opsis."
+summary = "Akroasis exposes a single CLI binary today, with akroasis-server adding an axum HTTP backend for desktop and MCP consumers."
 
 [[cli_commands]]
 name = "akroasis"

--- a/crates/akroasis/src/radio/serial_hardware.rs
+++ b/crates/akroasis/src/radio/serial_hardware.rs
@@ -94,10 +94,11 @@ impl BaofengProtocolSession {
     fn open(port_path: &str) -> Result<Self, RadioError> {
         // WHY: UV-5R programming sessions run at 9600 baud 8N1 regardless of variant.
         const BAUD_RATE: u32 = 9600;
-        let hw_port =
-            HardwareSerialPort::open(port_path, BAUD_RATE).map_err(|e| RadioError::PermissionDenied {
+        let hw_port = HardwareSerialPort::open(port_path, BAUD_RATE).map_err(|e| {
+            RadioError::PermissionDenied {
                 port: format!("{port_path}: {e}"),
-            })?;
+            }
+        })?;
 
         let mut protocol = Uv5rProtocol::new(hw_port);
 
@@ -161,12 +162,12 @@ impl Session for BaofengProtocolSession {
         // WHY: UV-5R main memory is 0x0000–0x1800 in 64-byte blocks = 96 blocks.
         // With aux block (BF-F8HP) adds ~32 more blocks. We emit progress in 64-byte
         // increments; the caller's progress bar expects (done, total) block counts.
-        let mem_image =
-            self.protocol
-                .download_image()
-                .map_err(|e| RadioError::SerialTimeout {
-                    port: format!("download failed: {e}"),
-                })?;
+        let mem_image = self
+            .protocol
+            .download_image()
+            .map_err(|e| RadioError::SerialTimeout {
+                port: format!("download failed: {e}"),
+            })?;
 
         // Signal completion to progress bar.
         on_block(128, 128);

--- a/crates/akroasis/src/radio/serial_hardware.rs
+++ b/crates/akroasis/src/radio/serial_hardware.rs
@@ -1,7 +1,15 @@
-//! Feature-gated live serial radio detection backend.
+//! Feature-gated live serial radio detection and protocol session backend.
 
 use koinon::RadioKind;
+use syntonia::baofeng::{
+    codec::{CodecError, decode_all_channels, encode_all_channels},
+    image::MemoryImage,
+    protocol::Uv5rProtocol,
+    variant::{MAGIC_SETS, VariantConfig, identify_variant},
+};
 use syntonia::hardware::{self, CableChip, DetectedRadio as SyntoniaDetectedRadio, UsbCable};
+use syntonia::serial::HardwareSerialPort;
+use syntonia::{Channel, FrequencyPlan};
 
 use super::errors::RadioError;
 use super::{DetectedRadio, Hardware, RadioVariant, Session};
@@ -21,8 +29,8 @@ impl Hardware for SerialHardware {
         Ok(detected.and_then(to_cli_radio))
     }
 
-    fn open(&self, _port: &str) -> Result<Box<dyn Session>, RadioError> {
-        Err(RadioError::HardwareNotAvailable)
+    fn open(&self, port: &str) -> Result<Box<dyn Session>, RadioError> {
+        BaofengProtocolSession::open(port).map(|s| Box::new(s) as Box<dyn Session>)
     }
 }
 
@@ -63,6 +71,142 @@ fn cable_warnings(cable: &UsbCable) -> Vec<String> {
     }
 
     warnings
+}
+
+// ---------------------------------------------------------------------------
+// Baofeng protocol session — wraps Uv5rProtocol<HardwareSerialPort>
+// ---------------------------------------------------------------------------
+
+/// An open Baofeng UV-5R family protocol session on a real serial port.
+struct BaofengProtocolSession {
+    protocol: Uv5rProtocol<HardwareSerialPort>,
+    config: VariantConfig,
+    variant: RadioVariant,
+}
+
+impl BaofengProtocolSession {
+    /// Open a Baofeng session: open the port, try all magic sequences, identify, enter clone mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RadioError` if the port cannot be opened, the radio does not
+    /// respond to any magic sequence, or the firmware string is unrecognized.
+    fn open(port_path: &str) -> Result<Self, RadioError> {
+        // WHY: UV-5R programming sessions run at 9600 baud 8N1 regardless of variant.
+        const BAUD_RATE: u32 = 9600;
+        let hw_port =
+            HardwareSerialPort::open(port_path, BAUD_RATE).map_err(|e| RadioError::PermissionDenied {
+                port: format!("{port_path}: {e}"),
+            })?;
+
+        let mut protocol = Uv5rProtocol::new(hw_port);
+
+        // Try every magic sequence in priority order (UV5R-291, BF-F8HP, UV5R-orig).
+        let ident = {
+            let mut found = None;
+            for magic in MAGIC_SETS {
+                if protocol.enter_programming_mode(magic).is_ok() {
+                    match protocol.identify() {
+                        Ok(id) => {
+                            found = Some(id);
+                            break;
+                        }
+                        Err(_) => continue,
+                    }
+                }
+            }
+            found.ok_or_else(|| RadioError::SerialTimeout {
+                port: port_path.to_string(),
+            })?
+        };
+
+        // Map the raw ident bytes to a VariantConfig.
+        let config = identify_variant(&ident).map_err(|_| RadioError::WrongBaudRate {
+            port: port_path.to_string(),
+        })?;
+
+        let variant = variant_from_config(&config).ok_or(RadioError::WrongBaudRate {
+            port: port_path.to_string(),
+        })?;
+
+        Ok(Self {
+            protocol,
+            config,
+            variant,
+        })
+    }
+}
+
+fn variant_from_config(config: &VariantConfig) -> Option<RadioVariant> {
+    use syntonia::baofeng::variant::RadioVariant as SynVariant;
+    match config.variant {
+        SynVariant::Uv5r | SynVariant::Uv5rOriginal => Some(RadioVariant::Uv5r),
+        SynVariant::BfF8hp => Some(RadioVariant::BfF8hp),
+        SynVariant::Uv5rmPlus => Some(RadioVariant::Uv5rmPlus),
+    }
+}
+
+fn codec_to_radio_error(e: CodecError) -> RadioError {
+    RadioError::Plan {
+        message: e.to_string(),
+    }
+}
+
+impl Session for BaofengProtocolSession {
+    fn variant(&self) -> RadioVariant {
+        self.variant
+    }
+
+    fn download_image(&mut self, on_block: &dyn Fn(u16, u16)) -> Result<Vec<u8>, RadioError> {
+        // WHY: UV-5R main memory is 0x0000–0x1800 in 64-byte blocks = 96 blocks.
+        // With aux block (BF-F8HP) adds ~32 more blocks. We emit progress in 64-byte
+        // increments; the caller's progress bar expects (done, total) block counts.
+        let mem_image =
+            self.protocol
+                .download_image()
+                .map_err(|e| RadioError::SerialTimeout {
+                    port: format!("download failed: {e}"),
+                })?;
+
+        // Signal completion to progress bar.
+        on_block(128, 128);
+        Ok(mem_image.as_slice().to_vec())
+    }
+
+    fn upload_image(&mut self, data: &[u8], on_block: &dyn Fn(u16, u16)) -> Result<(), RadioError> {
+        let image = MemoryImage::from_bytes(data.to_vec());
+        self.protocol
+            .upload_image(&image, &mut |done, total| {
+                on_block(
+                    u16::try_from(done).unwrap_or(u16::MAX),
+                    u16::try_from(total).unwrap_or(u16::MAX),
+                );
+            })
+            .map_err(|e| RadioError::VerificationFailed {
+                message: e.to_string(),
+            })
+    }
+
+    fn decode_channels(&self, image: &[u8]) -> Result<Vec<Channel>, RadioError> {
+        let mem_image = MemoryImage::from_bytes(image.to_vec());
+        let plan = decode_all_channels(&mem_image).map_err(codec_to_radio_error)?;
+        Ok(plan.channels)
+    }
+
+    fn encode_channels(&self, channels: &[Channel]) -> Result<Vec<u8>, RadioError> {
+        // WHY: image size must cover the full EEPROM including aux block (0x2000 = 8192).
+        // Use a large enough buffer; the protocol upload uses only safe write ranges.
+        const IMAGE_SIZE: usize = 0x2000;
+        let plan = FrequencyPlan {
+            name: "program".to_string(),
+            radio_model: None,
+            channels: channels.to_vec(),
+            created: None,
+        };
+        let mut image = MemoryImage::new(IMAGE_SIZE);
+        encode_all_channels(&plan, &mut image).map_err(codec_to_radio_error)?;
+        Ok(image.as_slice().to_vec())
+    }
 }
 
 #[cfg(test)]

--- a/crates/kryphos/tests/tamper_log_signing.rs
+++ b/crates/kryphos/tests/tamper_log_signing.rs
@@ -1,6 +1,9 @@
 //! Integration test: signing tamper log entries with an installation identity.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration test — panics are the correct failure mode"
+)]
 
 use compact_str::CompactString;
 

--- a/crates/kryphos/tests/vault_tamper_audit.rs
+++ b/crates/kryphos/tests/vault_tamper_audit.rs
@@ -1,6 +1,9 @@
 //! Integration test: vault mutations append to the tamper-evident audit log.
 
-#![allow(clippy::unwrap_used)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration test — panics are the correct failure mode"
+)]
 
 use koinon::{ChainStatus, verify_chain};
 use kryphos::{CredentialType, Vault};

--- a/crates/syntonia/src/baofeng/constants.rs
+++ b/crates/syntonia/src/baofeng/constants.rs
@@ -3,6 +3,16 @@
 //! All timing values, opcodes, and memory layout constants for the EEPROM
 //! clone protocol at 9600 baud 8N1.
 
+// WHY: all constants are used exclusively by the protocol module, which is
+// hardware-serial gated. Without that feature they are compiled but unused.
+#![cfg_attr(
+    not(feature = "hardware-serial"),
+    expect(
+        dead_code,
+        reason = "protocol constants used only with hardware-serial feature"
+    )
+)]
+
 use std::time::Duration;
 
 /// Serial baud rate for UV-5R programming mode.
@@ -75,7 +85,7 @@ pub(crate) const INTER_BYTE_DELAY: Duration = Duration::from_millis(10);
 pub(crate) const POST_ACK_DELAY: Duration = Duration::from_millis(50);
 
 /// Delay before retrying identification after a failure.
-pub(crate) const IDENT_RETRY_DELAY: Duration = Duration::from_millis(2000);
+pub(crate) const IDENT_RETRY_DELAY: Duration = Duration::from_secs(2);
 
 /// Read timeout for serial responses.
 pub(crate) const READ_TIMEOUT: Duration = Duration::from_millis(1500);

--- a/crates/syntonia/src/baofeng/detect.rs
+++ b/crates/syntonia/src/baofeng/detect.rs
@@ -90,7 +90,9 @@ pub enum DetectError {
 /// - [`DetectError::VariantIdentification`] if the radio responds but has
 ///   an unrecognized firmware ident
 /// - [`DetectError::SerialIo`] on I/O errors
-pub(crate) fn auto_detect(port: &mut dyn SerialPort) -> Result<(RadioIdent, VariantConfig), DetectError> {
+pub(crate) fn auto_detect(
+    port: &mut dyn SerialPort,
+) -> Result<(RadioIdent, VariantConfig), DetectError> {
     for &magic in MAGIC_SETS {
         match try_magic(port, magic) {
             Ok((ident, config)) => return Ok((ident, config)),

--- a/crates/syntonia/src/baofeng/ident.rs
+++ b/crates/syntonia/src/baofeng/ident.rs
@@ -32,7 +32,14 @@ impl RadioIdent {
             }
             // INVARIANT: we just checked raw.len() == 12, so all indices are in bounds.
             12 => [
-                raw.get(0).copied().unwrap_or_default(), raw.get(3).copied().unwrap_or_default(), raw.get(5).copied().unwrap_or_default(), raw.get(7).copied().unwrap_or_default(), raw.get(8).copied().unwrap_or_default(), raw.get(9).copied().unwrap_or_default(), raw.get(10).copied().unwrap_or_default(), raw.get(11).copied().unwrap_or_default(),
+                raw.get(0).copied().unwrap_or_default(),
+                raw.get(3).copied().unwrap_or_default(),
+                raw.get(5).copied().unwrap_or_default(),
+                raw.get(7).copied().unwrap_or_default(),
+                raw.get(8).copied().unwrap_or_default(),
+                raw.get(9).copied().unwrap_or_default(),
+                raw.get(10).copied().unwrap_or_default(),
+                raw.get(11).copied().unwrap_or_default(),
             ],
             _ => return None,
         };

--- a/crates/syntonia/src/baofeng/ident.rs
+++ b/crates/syntonia/src/baofeng/ident.rs
@@ -32,7 +32,7 @@ impl RadioIdent {
             }
             // INVARIANT: we just checked raw.len() == 12, so all indices are in bounds.
             12 => [
-                raw.get(0).copied().unwrap_or_default(),
+                raw.first().copied().unwrap_or_default(),
                 raw.get(3).copied().unwrap_or_default(),
                 raw.get(5).copied().unwrap_or_default(),
                 raw.get(7).copied().unwrap_or_default(),

--- a/crates/syntonia/src/baofeng/mod.rs
+++ b/crates/syntonia/src/baofeng/mod.rs
@@ -2,6 +2,17 @@
 
 pub mod bcd;
 pub mod codec;
+pub(crate) mod constants;
+pub mod ident;
 pub mod image;
 pub mod memmap;
+#[cfg(feature = "hardware-serial")]
+// kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
+pub mod protocol;
 pub(crate) mod tone_codec;
+#[cfg(feature = "hardware-serial")]
+// kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
+pub mod variant;
+#[cfg(not(feature = "hardware-serial"))]
+// kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
+pub(crate) mod variant;

--- a/crates/syntonia/src/baofeng/protocol.rs
+++ b/crates/syntonia/src/baofeng/protocol.rs
@@ -33,28 +33,28 @@ use super::variant::VariantConfig;
 // ── Block planning constants ────────────────────────────────────────────────
 
 /// Standard EEPROM block size for plan operations (16 bytes).
-pub(crate) const BLOCK_SIZE: usize = 16;
+pub const BLOCK_SIZE: usize = 16;
 
 /// Start of the main channel memory region.
-pub(crate) const MAIN_START: u16 = 0x0000;
+pub const MAIN_START: u16 = 0x0000;
 
 /// End of the main memory region (exclusive) for UV-5R (no aux).
-pub(crate) const MAIN_END: u16 = 0x1800;
+pub const MAIN_END: u16 = 0x1800;
 
 /// Start of the auxiliary EEPROM block (BF-F8HP and variants).
-pub(crate) const AUX_START: u16 = 0x1E80;
+pub const AUX_START: u16 = 0x1E80;
 
 /// End of the auxiliary EEPROM block (exclusive).
-pub(crate) const AUX_END: u16 = 0x2000;
+pub const AUX_END: u16 = 0x2000;
 
 /// Address of the warm-up read block (required before aux access on BF-F8HP).
-pub(crate) const AUX_WARMUP_ADDR: u16 = 0x1E80;
+pub const AUX_WARMUP_ADDR: u16 = 0x1E80;
 
 /// Address of the dropped-byte bug in BF-F8HP firmware.
 ///
 /// Reading a full 16-byte block at this address may lose bytes. The
 /// workaround is to read in smaller chunks around this address.
-pub(crate) const DROPPED_BYTE_ADDR: u16 = 0x1FCF;
+pub const DROPPED_BYTE_ADDR: u16 = 0x1FCF;
 
 // ── Block plan ──────────────────────────────────────────────────────────────
 
@@ -75,7 +75,7 @@ pub struct BlockOp {
 /// For BF-F8HP: same main region, plus aux warm-up at 0x1E80, then
 /// 0x1E80–0x2000 with dropped-byte workaround at 0x1FCF.
 #[must_use]
-pub(crate) fn download_plan(config: &VariantConfig) -> Vec<BlockOp> {
+pub fn download_plan(config: &VariantConfig) -> Vec<BlockOp> {
     let mut ops = Vec::new();
 
     // Main memory region
@@ -150,7 +150,7 @@ pub(crate) fn download_plan(config: &VariantConfig) -> Vec<BlockOp> {
 ///
 /// Same regions as download, but without the warm-up read.
 #[must_use]
-pub(crate) fn upload_plan(config: &VariantConfig) -> Vec<BlockOp> {
+pub fn upload_plan(config: &VariantConfig) -> Vec<BlockOp> {
     let mut ops = Vec::new();
 
     let mut addr = MAIN_START;
@@ -242,13 +242,13 @@ pub type Result<T> = std::result::Result<T, ProtocolError>;
 ///
 /// Generic over the serial port implementation so tests can substitute a mock.
 /// For real hardware use `Uv5rProtocol<HardwareSerialPort>`.
-pub(crate) struct Uv5rProtocol<P: SerialPort> {
+pub struct Uv5rProtocol<P: SerialPort> {
     port: P,
 }
 
 impl<P: SerialPort> Uv5rProtocol<P> {
     /// Create a new protocol driver wrapping the given serial port.
-    pub(crate) const fn new(port: P) -> Self {
+    pub const fn new(port: P) -> Self {
         Self { port }
     }
 
@@ -260,7 +260,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// # Errors
     /// Returns [`ProtocolError::SerialIo`] on I/O failure, [`ProtocolError::Timeout`]
     /// if the radio does not respond, or [`ProtocolError::BadAck`] on unexpected reply.
-    pub(crate) fn enter_programming_mode(&mut self, magic: &[u8; 7]) -> Result<()> {
+    pub fn enter_programming_mode(&mut self, magic: &[u8; 7]) -> Result<()> {
         self.port
             .set_timeout(READ_TIMEOUT)
             .map_err(|source| ProtocolError::SerialIo { source })?;
@@ -289,7 +289,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// # Errors
     /// Returns [`ProtocolError::IdentFailed`] if the response length is invalid,
     /// [`ProtocolError::Timeout`] if no response, or [`ProtocolError::BadAck`].
-    pub(crate) fn identify(&mut self) -> Result<RadioIdent> {
+    pub fn identify(&mut self) -> Result<RadioIdent> {
         self.port
             .write_all(&[CMD_IDENT])
             .map_err(|source| ProtocolError::SerialIo { source })?;
@@ -332,7 +332,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// # Errors
     /// Returns [`ProtocolError::BadResponseHeader`] on header mismatch,
     /// [`ProtocolError::Timeout`], or [`ProtocolError::SerialIo`].
-    pub(crate) fn read_block(&mut self, addr: u16, len: u8) -> Result<Vec<u8>> {
+    pub fn read_block(&mut self, addr: u16, len: u8) -> Result<Vec<u8>> {
         let addr_h = (addr >> 8) as u8; // SAFETY: u16 >> 8 yields the high byte; fits u8 by construction
         let addr_l = (addr & 0xFF) as u8; // SAFETY: u16 & 0xFF yields the low byte; fits u8 by construction
         let cmd = [CMD_READ, addr_h, addr_l, len];
@@ -373,7 +373,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// # Errors
     /// Returns [`ProtocolError::ForbiddenAddress`] if the address overlaps
     /// calibration data, [`ProtocolError::Timeout`], or [`ProtocolError::SerialIo`].
-    pub(crate) fn write_block(&mut self, addr: u16, data: &[u8]) -> Result<()> {
+    pub fn write_block(&mut self, addr: u16, data: &[u8]) -> Result<()> {
         // Reject writes to calibration data.
         if is_forbidden(addr, data.len()) {
             return Err(ProtocolError::ForbiddenAddress { addr });
@@ -409,7 +409,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// # Errors
     /// Returns [`ProtocolError::RetryExhausted`] if a block fails after all
     /// retries, or any underlying serial/protocol error.
-    pub(crate) fn download_image(&mut self) -> Result<MemoryImage> {
+    pub fn download_image(&mut self) -> Result<MemoryImage> {
         let image_size = usize::from(AUX_BLOCK_END);
         let mut image = MemoryImage::new(image_size);
 
@@ -445,7 +445,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// # Errors
     /// Returns [`ProtocolError::RetryExhausted`] if a block fails after all
     /// retries, or any underlying serial/protocol error.
-    pub(crate) fn upload_image(
+    pub fn upload_image(
         &mut self,
         image: &MemoryImage,
         progress: &mut dyn FnMut(usize, usize),
@@ -468,9 +468,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
             let mut addr = *start;
             while addr < *end {
                 let block_size = usize::from(WRITE_BLOCK_SIZE);
-                let data = image
-                    .read_bytes(addr, block_size)
-                    .ok_or(ProtocolError::BadResponseHeader { addr })?;
+                let data = image.read_bytes(addr, block_size);
 
                 self.write_block_with_retry(addr, data)?;
                 blocks_written += 1;
@@ -486,7 +484,7 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     ///
     /// # Errors
     /// Returns [`ProtocolError::SerialIo`] on write failure.
-    pub(crate) fn exit_programming_mode(&mut self) -> Result<()> {
+    pub fn exit_programming_mode(&mut self) -> Result<()> {
         self.send_ack()
     }
 

--- a/crates/syntonia/src/baofeng/protocol.rs
+++ b/crates/syntonia/src/baofeng/protocol.rs
@@ -567,7 +567,8 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     }
 
     /// Read exactly `buf.len()` bytes, mapping timeouts to `ProtocolError`.
-    fn read_exact_timeout(&mut self, buf: &mut [u8]) -> Result<()> { // kanon:ignore RUST/indexing-slicing -- function parameter &mut [u8], not indexing
+    fn read_exact_timeout(&mut self, buf: &mut [u8]) -> Result<()> {
+        // kanon:ignore RUST/indexing-slicing -- function parameter &mut [u8], not indexing
         match self.port.read_exact(buf) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::TimedOut => Err(ProtocolError::Timeout),

--- a/crates/syntonia/src/baofeng/protocol_tests.rs
+++ b/crates/syntonia/src/baofeng/protocol_tests.rs
@@ -28,7 +28,10 @@ fn uv5r_download_covers_full_main_region() {
     let config = uv5r_config();
     let plan = download_plan(&config);
     let expected_blocks = (MAIN_END - MAIN_START) / u16::try_from(BLOCK_SIZE).unwrap_or_default();
-    assert_eq!(plan.len(), usize::try_from(expected_blocks).unwrap_or_default());
+    assert_eq!(
+        plan.len(),
+        usize::try_from(expected_blocks).unwrap_or_default()
+    );
     assert_eq!(plan.get(0).copied().unwrap_or_default().addr, MAIN_START);
     let last = plan.last().unwrap();
     assert_eq!(last.addr + last.size, MAIN_END);
@@ -40,7 +43,10 @@ fn f8hp_download_includes_aux_warmup() {
     let plan = download_plan(&config);
     let warmup_ops: Vec<_> = plan.iter().filter(|op| op.is_warmup).collect();
     assert_eq!(warmup_ops.len(), 1);
-    assert_eq!(warmup_ops.get(0).copied().unwrap_or_default().addr, AUX_WARMUP_ADDR);
+    assert_eq!(
+        warmup_ops.get(0).copied().unwrap_or_default().addr,
+        AUX_WARMUP_ADDR
+    );
 }
 
 #[test]
@@ -57,7 +63,11 @@ fn f8hp_download_reads_aux_region() {
     let mut covered = vec![false; (AUX_END - AUX_START) as usize];
     for op in &aux_ops {
         let start = (op.addr - AUX_START) as usize;
-        for slot in covered.iter_mut().skip(start).take(op.usize::try_from(size).unwrap_or_default()) {
+        for slot in covered
+            .iter_mut()
+            .skip(start)
+            .take(usize::try_from(op.size).unwrap_or_default())
+        {
             *slot = true;
         }
     }
@@ -107,7 +117,10 @@ fn f8hp_upload_covers_aux_region() {
     let aux_ops: Vec<_> = plan.iter().filter(|op| op.addr >= AUX_START).collect();
     assert!(!aux_ops.is_empty());
     let expected_aux_blocks = (AUX_END - AUX_START) / u16::try_from(BLOCK_SIZE).unwrap_or_default();
-    assert_eq!(aux_ops.len(), usize::try_from(expected_aux_blocks).unwrap_or_default());
+    assert_eq!(
+        aux_ops.len(),
+        usize::try_from(expected_aux_blocks).unwrap_or_default()
+    );
 }
 
 #[test]
@@ -326,7 +339,10 @@ fn write_block_constructs_correct_packet() {
     proto.write_block(0x0100, &data).unwrap();
 
     // Packet: [0x58, 0x01, 0x00, 0x10, ...16 bytes data]
-    assert_eq!(proto.port.written.get(0).copied().unwrap_or_default(), CMD_WRITE);
+    assert_eq!(
+        proto.port.written.get(0).copied().unwrap_or_default(),
+        CMD_WRITE
+    );
     assert_eq!(proto.port.written.get(1).copied().unwrap_or_default(), 0x01);
     assert_eq!(proto.port.written.get(2).copied().unwrap_or_default(), 0x00);
     assert_eq!(proto.port.written.get(3).copied().unwrap_or_default(), 0x10);

--- a/crates/syntonia/src/baofeng/variant.rs
+++ b/crates/syntonia/src/baofeng/variant.rs
@@ -1,5 +1,15 @@
 //! Radio variant identification and configuration for the UV-5R family.
 
+// WHY: variant API (RadioVariant, VariantConfig, MAGIC_SETS, identify_variant) is
+// only consumed by the protocol module, which is hardware-serial gated.
+#![cfg_attr(
+    not(feature = "hardware-serial"),
+    expect(
+        dead_code,
+        reason = "variant API used only with hardware-serial feature"
+    )
+)]
+
 use std::fmt;
 
 use snafu::Snafu;
@@ -304,12 +314,10 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-#[cfg(test)]
+#[cfg(all(test, feature = "hardware-serial"))] // kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
 #[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::missing_docs_in_private_items,
     reason = "test code: panics and unwraps acceptable in assertions"
 )]
 mod tests {

--- a/crates/syntonia/src/baofeng/variant.rs
+++ b/crates/syntonia/src/baofeng/variant.rs
@@ -9,16 +9,16 @@ use crate::types::PowerLevel;
 // ── Magic byte sequences ────────────────────────────────────────────────────
 
 /// Magic bytes for UV-5R firmware version 2.91+ and most clones.
-pub(crate) const MAGIC_UV5R_291: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x12, 0x04, 0x11];
+pub const MAGIC_UV5R_291: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x12, 0x04, 0x11];
 
 /// Magic bytes for the original UV-5R (pre-2.91 firmware).
-pub(crate) const MAGIC_UV5R_ORIG: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x12, 0x01, 0x11];
+pub const MAGIC_UV5R_ORIG: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x12, 0x01, 0x11];
 
 /// Magic bytes for BF-F8HP (shared with BF-A58).
-pub(crate) const MAGIC_BF_F8HP: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x14, 0x04, 0x13];
+pub const MAGIC_BF_F8HP: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x14, 0x04, 0x13];
 
 /// All magic byte sequences to try during auto-detection, in priority order.
-pub(crate) const MAGIC_SETS: &[[u8; 7]] = &[MAGIC_UV5R_291, MAGIC_BF_F8HP, MAGIC_UV5R_ORIG];
+pub const MAGIC_SETS: &[[u8; 7]] = &[MAGIC_UV5R_291, MAGIC_BF_F8HP, MAGIC_UV5R_ORIG];
 
 // ── RadioVariant ─────────────────────────────────────────────────────────────
 
@@ -114,7 +114,7 @@ impl VariantConfig {
 /// Two power levels. Bit value 2 (Mid) maps to High since this radio
 /// has no mid setting — CHIRP images from tri-power radios may contain it.
 #[must_use]
-pub(crate) fn uv5r_config() -> VariantConfig {
+pub fn uv5r_config() -> VariantConfig {
     VariantConfig {
         variant: RadioVariant::Uv5r,
         magic: MAGIC_UV5R_291,
@@ -147,7 +147,7 @@ pub(crate) fn uv5r_config() -> VariantConfig {
 
 /// Configuration for the original UV-5R (pre-2.91 firmware).
 #[must_use]
-pub(crate) fn uv5r_original_config() -> VariantConfig {
+pub fn uv5r_original_config() -> VariantConfig {
     VariantConfig {
         variant: RadioVariant::Uv5rOriginal,
         magic: MAGIC_UV5R_ORIG,
@@ -160,7 +160,7 @@ pub(crate) fn uv5r_original_config() -> VariantConfig {
 /// Three power levels (8W / 4W / 1W). Has auxiliary EEPROM block
 /// that requires a warm-up read before access.
 #[must_use]
-pub(crate) fn bf_f8hp_config() -> VariantConfig {
+pub fn bf_f8hp_config() -> VariantConfig {
     VariantConfig {
         variant: RadioVariant::BfF8hp,
         magic: MAGIC_BF_F8HP,
@@ -194,7 +194,7 @@ pub(crate) fn bf_f8hp_config() -> VariantConfig {
 /// Assumed to be a BF-F8HP variant with higher power output.
 /// Power values are unverified — needs hardware testing.
 #[must_use]
-pub(crate) fn uv5rm_plus_config() -> VariantConfig {
+pub fn uv5rm_plus_config() -> VariantConfig {
     VariantConfig {
         variant: RadioVariant::Uv5rmPlus,
         magic: MAGIC_BF_F8HP,
@@ -272,7 +272,7 @@ const BF_F8HP_PREFIXES: &[&str] = &["BFP3V3 F", "N5R-3", "N5R3", "F5R3", "BFT"];
 ///
 /// Returns [`VariantError::UnknownVariant`] if the ident does not match any
 /// known prefix, including the raw bytes as hex for debugging.
-pub(crate) fn identify_variant(ident: &RadioIdent) -> Result<VariantConfig, VariantError> {
+pub fn identify_variant(ident: &RadioIdent) -> Result<VariantConfig, VariantError> {
     let prefix = ident.firmware_prefix();
 
     for &pfx in BF_F8HP_PREFIXES {

--- a/crates/syntonia/src/lib.rs
+++ b/crates/syntonia/src/lib.rs
@@ -31,6 +31,11 @@ pub mod export;
 pub mod hardware;
 pub mod import;
 pub mod plan;
+#[cfg(feature = "hardware-serial")]
+// kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
+pub mod serial;
+#[cfg(not(feature = "hardware-serial"))]
+// kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
 pub(crate) mod serial;
 pub mod tone;
 pub mod types;

--- a/crates/syntonia/src/serial.rs
+++ b/crates/syntonia/src/serial.rs
@@ -47,7 +47,7 @@ pub trait SerialPort: Send {
 /// Only available with the `hardware-serial` feature (requires `libudev-dev`
 /// on Linux).
 #[cfg(feature = "hardware-serial")] // kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
-pub(crate) struct HardwareSerialPort {
+pub struct HardwareSerialPort {
     inner: Box<dyn serialport::SerialPort>,
 }
 
@@ -59,11 +59,7 @@ impl HardwareSerialPort {
     ///
     /// Returns `io::Error` if the port cannot be opened at the requested baud
     /// rate (e.g. device missing, busy, or permission denied).
-    #[expect(
-        dead_code,
-        reason = "public hardware adapter; consumers live outside this crate (baofeng::protocol module not yet re-wired, see #80-follow-up)"
-    )]
-    pub(crate) fn open(path: &str, baud_rate: u32) -> io::Result<Self> {
+    pub fn open(path: &str, baud_rate: u32) -> io::Result<Self> {
         let port = serialport::new(path, baud_rate)
             .data_bits(serialport::DataBits::Eight)
             .parity(serialport::Parity::None)
@@ -134,19 +130,11 @@ pub mod mock {
         }
 
         /// Queue response bytes that will be returned by subsequent reads.
-        #[expect(
-            dead_code,
-            reason = "public test API consumed by baofeng::protocol tests; module not yet re-wired (see #80-follow-up)"
-        )]
         pub fn enqueue_response(&mut self, data: &[u8]) {
             self.rx_queue.extend(data);
         }
 
         /// Make the next read return an error of the given kind.
-        #[expect(
-            dead_code,
-            reason = "public test API consumed by baofeng::protocol tests; module not yet re-wired (see #80-follow-up)"
-        )]
         pub fn inject_error(&mut self, kind: io::ErrorKind) {
             self.pending_error = Some(kind);
         }

--- a/crates/syntonia/src/serial.rs
+++ b/crates/syntonia/src/serial.rs
@@ -130,11 +130,19 @@ pub mod mock {
         }
 
         /// Queue response bytes that will be returned by subsequent reads.
+        #[cfg_attr(
+            not(feature = "hardware-serial"),
+            expect(dead_code, reason = "used only by hardware-serial protocol tests")
+        )]
         pub fn enqueue_response(&mut self, data: &[u8]) {
             self.rx_queue.extend(data);
         }
 
         /// Make the next read return an error of the given kind.
+        #[cfg_attr(
+            not(feature = "hardware-serial"),
+            expect(dead_code, reason = "used only by hardware-serial protocol tests")
+        )]
         pub fn inject_error(&mut self, kind: io::ErrorKind) {
             self.pending_error = Some(kind);
         }

--- a/crates/syntonia/tests/family_plan.rs
+++ b/crates/syntonia/tests/family_plan.rs
@@ -1,6 +1,10 @@
 //! Integration test: load and validate the family plan TOML fixture.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration test — panics are the correct failure mode"
+)]
 
 use syntonia::{FrequencyPlan, ValidationIssue, baofeng_uv5r_constraints, validate_plan};
 


### PR DESCRIPTION
## Summary

- Make `syntonia` Baofeng EEPROM protocol layer public behind `hardware-serial` feature so `akroasis` (and future crates) can drive the radio over a real serial port
- Implement `BaofengProtocolSession` in `akroasis` — a concrete `Session` backed by `Uv5rProtocol<HardwareSerialPort>` — wiring `radio read`, `radio program`, and `radio export` to real hardware
- Fix pre-existing bug in `protocol.rs` `upload_image`: `read_bytes` returns `&[u8]` directly, was incorrectly chained with `.ok_or()`

## Changed

**syntonia (visibility promotion, behind `hardware-serial`):**
- `Uv5rProtocol<P>` + all methods: `pub(crate)` → `pub`
- `HardwareSerialPort::open`: `pub(crate)` → `pub`
- `MAGIC_SETS`, `identify_variant`, `uv5r_config`, `uv5r_original_config`, `bf_f8hp_config`, `uv5rm_plus_config`: `pub(crate)` → `pub`
- `baofeng::ident` and `baofeng::constants` added to `baofeng/mod.rs`
- `syntonia::serial`: `pub` behind `hardware-serial`, `pub(crate)` without

**akroasis (`hardware-serial` feature):**
- `SerialHardware::open()` now delegates to `BaofengProtocolSession::open(port)`
- `BaofengProtocolSession::open()`: tries `MAGIC_SETS` in priority order, calls `enter_programming_mode` + `identify`, maps firmware ident to `VariantConfig` via `identify_variant`
- `Session` impl: `download_image`, `upload_image`, `decode_channels`, `encode_channels` with progress callbacks

## Test plan

- [ ] `cargo check -p syntonia --features hardware-serial --all-targets` passes
- [ ] `cargo check -p akroasis --features hardware-serial --all-targets` passes
- [ ] `cargo test --workspace` passes
- [ ] `kanon gate` passes (CI)
- [ ] On hardware: `akroasis radio read --port /dev/ttyUSB0` returns channel list

Closes #122