### PR TITLE
docs(akroasis): document programmatic surface contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ prost = "0.14.3"
 prost-types = "0.14.3"
 
 # Mesh networking — crypto (pin exact: pre-release)
-aes = "=0.9.0"
+aes = "=0.9.1"
 ctr = "=0.10.1"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | CLI: `akroasis radio import --json`, `radio detect --json`, `radio export --json`, `mesh {status,nodes,topology} --json`, `vault identity --json`. HTTP: `akroasis-server` exposes `/api/v1/radio/detect`, `/api/v1/mesh/{status,nodes,topology}` with the same JSON schemas. Desktop: desktop-first via theatron + akroasis-server (chalkeion Phase 6). |
+| Interfaces | Schema-versioned JSON is the canonical programmatic contract. CLI: `akroasis radio import --json`, `radio detect --json`, `radio export --json`, `mesh {status,nodes,topology} --json`, `vault list --json`, `vault identity --json`. HTTP: `akroasis-server` exposes `/api/v1/radio/detect`, `/api/v1/mesh/{status,nodes,topology}` with the same JSON schemas for durable clients. Interactive secret vault commands and planned placeholder domains remain TTY-only until their service surfaces ship. Desktop: desktop-first via theatron + akroasis-server (chalkeion Phase 6). |
 | License | AGPL-3.0-only |
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | **pinax** | Knowledge | Offline knowledge repository, frequency databases, maps; see `reference-store.md` for target instance layout |
 | **opsis** | Interface | Operator surfaces: desktop-first via theatron (akroasis-desktop), consumed through the `akroasis-server` HTTP API. #118 resolved. |
 | **akroasis** | Binary | CLI entrypoint, subcommand routing, and library interface for akroasis-server |
-| **akroasis-server** | Interface | Typed axum HTTP backend (`/api/v1/*`); called by akroasis-desktop and `--json`/MCP clients. Mirrors CLI `--json` report schemas. |
+| **akroasis-server** | Interface | Canonical durable programmatic surface: typed axum HTTP backend (`/api/v1/*`) called by akroasis-desktop and agent clients. Mirrors schema-versioned CLI `--json` report contracts for shipped non-interactive surfaces. |
 
 ## Key decisions
 


### PR DESCRIPTION
## Summary

- Document schema-versioned JSON as the canonical programmatic contract for shipped akroasis surfaces
- Add the missing `vault list --json` entry alongside existing radio, mesh, and vault identity reports
- Clarify that interactive secret vault commands and planned placeholder domains remain TTY-only until their service surfaces ship

## Verification

- `PATH="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin:$PATH" kanon gate --full`
- `git diff --check`

Closes #126

Gate-Passed: kanon 0.1.0