### PR TITLE
fix(deps): clear RUSTSEC-2026-0190/-0204 + yanked crates via lockfile bumps

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -1,0 +1,1114 @@
+[baseline]
+created = "2026-07-16"
+remove_after = "2026-08-13"
+reason = "akroasis#261 lint-debt burn-down — errors first (vault plain-string-secret, kerykeion crypto indexing); entries deleted as each family clears; expiry enforces completion (expired non-empty baseline fails the gate)"
+
+[[baseline.entry]]
+rule = "CI/release-yml-missing-attestation"
+file = ".github/workflows/release-please.yml"
+line = 1
+hash = "b525087c2878d94b7bcb773fc6795d4e90b36c64bb32ad2ec421a37935890fb1"
+
+[[baseline.entry]]
+rule = "CI/release-yml-missing-attestation"
+file = ".github/workflows/release.yml"
+line = 1
+hash = "9e6e791f1b05cede5dfd31eaae37ed4247523c2547406b17126c0601e3f1e1b0"
+
+[[baseline.entry]]
+rule = "SHELL/unpinned-action"
+file = ".github/workflows/release.yml"
+line = 18
+hash = "187f0380db28d2fb6a8ce9b80cbe3a5647916f4b67d274ca8fbda774fe4737a5"
+
+[[baseline.entry]]
+rule = "SHELL/unpinned-action"
+file = ".github/workflows/release.yml"
+line = 42
+hash = "187f0380db28d2fb6a8ce9b80cbe3a5647916f4b67d274ca8fbda774fe4737a5"
+
+[[baseline.entry]]
+rule = "SHELL/unpinned-action"
+file = ".github/workflows/stale.yml"
+line = 16
+hash = "2cdff95bb8b0c14e79315f927a8e1140c74f616b06c1017665db7b5831cecbbc"
+
+[[baseline.entry]]
+rule = "TOML/missing-trailing-comma"
+file = ".gitleaks.toml"
+line = 40
+hash = "725011530d3abd84a570798b9d272d44d36de3c2a2fac6d6b2e0eda8aeba371b"
+
+[[baseline.entry]]
+rule = "CONTEXT/preamble-required"
+file = "AGENTS.md"
+line = 1
+hash = "d6c6de7896975f22e5f97d6bf55cb4655039d229c52e088100f6d8a03afb79da"
+
+[[baseline.entry]]
+rule = "TOML/inline-table-too-long"
+file = "Cargo.toml"
+line = 73
+hash = "82a093966bee2615e5f782ffd8fbe2e9eee3511eb02dc6f23d44291730d4bd7e"
+
+[[baseline.entry]]
+rule = "ARCH/substrate-floating-ref"
+file = "Cargo.toml"
+line = 73
+hash = "82a093966bee2615e5f782ffd8fbe2e9eee3511eb02dc6f23d44291730d4bd7e"
+
+[[baseline.entry]]
+rule = "ARCH/substrate-dead-dep"
+file = "Cargo.toml"
+line = 73
+hash = "82a093966bee2615e5f782ffd8fbe2e9eee3511eb02dc6f23d44291730d4bd7e"
+
+[[baseline.entry]]
+rule = "TESTING/no-tests"
+file = "crates/akroasis/src/lib.rs"
+line = 1
+hash = "47086693071e4f1a9db9a32d219cefeb23f6737c569c3639123303b3bc0e551d"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/akroasis/src/main.rs"
+line = 61
+hash = "ca04381360c24528a9fbcbde88a9964fcbb2ba55255a7eef878c961d011021ea"
+
+[[baseline.entry]]
+rule = "RUST/import-order"
+file = "crates/akroasis/src/mesh/mod.rs"
+line = 385
+hash = "5b54f313105239b61375bef02b418e356eb8085e75be84bd9e7a0a4b462f57d0"
+
+[[baseline.entry]]
+rule = "RUST/non-exhaustive-enum"
+file = "crates/akroasis/src/radio/import.rs"
+line = 29
+hash = "bbf2dc4b6d71202dd426a6e20a8b382d6508708c7dae169f929d6b489c61c313"
+
+[[baseline.entry]]
+rule = "RUST/non-exhaustive-enum"
+file = "crates/akroasis/src/radio/mod.rs"
+line = 23
+hash = "d47998f8bcefc657af832db9881164ea3baa207b648ccc1ebd08a3c256620665"
+
+[[baseline.entry]]
+rule = "RUST/non-exhaustive-enum"
+file = "crates/akroasis/src/radio/mod.rs"
+line = 85
+hash = "a028142e5cd9c0f19673d16b996f11b89d8836a593c65232371a6298500b17e1"
+
+[[baseline.entry]]
+rule = "RUST/non-exhaustive-enum"
+file = "crates/akroasis/src/radio/mod.rs"
+line = 116
+hash = "1e39c08c59461ac3d28322fe2b8046c30d260e5ce2c19c417686dff744bb6d33"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/akroasis/src/radio/mod.rs"
+line = 158
+hash = "7487358fa292ef927ecee876f17511d618055f1996189ef3a3f8b77682ff36f4"
+
+[[baseline.entry]]
+rule = "ARCHITECTURE/trait-impl-colocation"
+file = "crates/akroasis/src/radio/mod.rs"
+line = 233
+hash = "2274fe9e5edf207e194b67d41e75430d09100cc97d03f63d9bcab8e9a53961d6"
+
+[[baseline.entry]]
+rule = "RUST/unreachable-in-match"
+file = "crates/akroasis/src/radio/mod.rs"
+line = 274
+hash = "c5620a6e1be15dc30789e24b9d828bae9426991232af028213a7c6bb4fca02da"
+
+[[baseline.entry]]
+rule = "RUST/non-exhaustive-enum"
+file = "crates/akroasis/src/vault/mod.rs"
+line = 26
+hash = "660431f0990e53029cb1b3bb0fc47cc456b622d4fbef0b18278947eb810ded15"
+
+[[baseline.entry]]
+rule = "RUST/non-exhaustive-enum"
+file = "crates/akroasis/src/vault/mod.rs"
+line = 75
+hash = "004cb692ae2d8e57506bb7f28c076a28a9b78d7ed9454fbb724852f81a1c8a92"
+
+[[baseline.entry]]
+rule = "RUST/plain-string-secret"
+file = "crates/akroasis/src/vault/mod.rs"
+line = 296
+hash = "01adcd08767a47a81357cb88176d195b9a83327798a7b9b241382d860f511071"
+
+[[baseline.entry]]
+rule = "NAMING/no-owner-prefix"
+file = "crates/akroasis-server/Cargo.toml"
+line = 1
+hash = "70acf00586aa7b90c3866278505be7b81fb7ee1f7e21c17c1a22ac239be3c72a"
+
+[[baseline.entry]]
+rule = "TESTING/no-tests"
+file = "crates/akroasis-server/src/lib.rs"
+line = 1
+hash = "a529bce94bd386f6470a75ecc35333d89834ae7a3dcfaf4c6ee950cce50bad98"
+
+[[baseline.entry]]
+rule = "MANIFEST/package-workspace-inheritance"
+file = "crates/kerykeion/Cargo.toml"
+line = 3
+hash = "f5efcadb7997ba8b6ca6beff5736bac673ec74e183fd36e83c81accd3fe98e11"
+
+[[baseline.entry]]
+rule = "RUST/doc-promised-observability"
+file = "crates/kerykeion/src/bridge.rs"
+line = 216
+hash = "c09a96434169a8ae9108ffc46f642e53d544223cb91a2f3440d65e6eab6bd29a"
+
+[[baseline.entry]]
+rule = "TESTING/tautological-test"
+file = "crates/kerykeion/src/codec.rs"
+line = 409
+hash = "f4e3722bf1e40afc787a8bf0c533a85d771d9f4c4ebaabc87eef5fb7603d75e9"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 72
+hash = "f60d0069a0d2e6d68b21dd930fd67a2dec18ffd776f518c5130c2ce9d42a19dd"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 73
+hash = "87e62cb369226d468724266ee7344273d1483738ca0056c4d944bb187c99d35d"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 74
+hash = "fe75cd33cc7a9ea08308572303acddc654b313d47a6c7969553439d2cd8339dd"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 90
+hash = "66a44347aa0c1acbfeb2455fee08a85be3fd484c806394dcb7f25e61eefa9829"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 91
+hash = "0d4073760f1ebe7e73974e46124c16b5da87b10270467cece025c6328cf71a00"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 92
+hash = "2d9c8320b59599d1782ff8daafb374b2499e406f5824db7531b3d6d5585550b5"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 104
+hash = "ad0d86da92a848c61af1c7775fe391010a69f41869191c5c50575f0b3a99aaf7"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 110
+hash = "2f8fcd5f7821da2a2130a18aa25513d1c98cc441391f01a7c499637447351790"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 116
+hash = "6a06b74f070ed7106dd94ee3413828f8c7a171437a3338fa22527aa88886f164"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 196
+hash = "6c4fbdc699709e234c39f0621e36131eabe6268dee8700e65bd8765a1c0b02a6"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 210
+hash = "9e8262782b39ce943612317d40851d93d1040432f2479d2201dcd2b84c9db818"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 223
+hash = "6126ff9755ca718aded3f0a24e05cadaf317d3edad98f9aedbd00c123b19319a"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 239
+hash = "5e18bdda2077885c5995a7b1e486419e3c37a328e8ccf861cb234288e0420668"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 240
+hash = "76da9249c02084d15c951639a9643e705682e786062e46b648768d514edeb97b"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 361
+hash = "bf306ffa19e0898259628da1f361f4eb4ae5c88aad26958e332195a046bc5ce6"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 457
+hash = "fe75cd33cc7a9ea08308572303acddc654b313d47a6c7969553439d2cd8339dd"
+
+[[baseline.entry]]
+rule = "RUST/no-arc-mutex-anti-pattern"
+file = "crates/kerykeion/src/collector.rs"
+line = 458
+hash = "016035fd0887be2ed9c1d41200342155076e945454ac95fbcd579ad42072e79d"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 27
+hash = "e23cb6e73a71989c6e9c01170dea62ed7f329b3f8d22654e50dc30eacf552384"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 106
+hash = "78d24d0929797553f0f4f4a45acadd78ffa2105c163aa96a8351f2ba336bc127"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 128
+hash = "248682e91b041336faf78e667ac5da1a548ef9fd2c37de888340ce49ea6b616b"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 174
+hash = "ce9074283c89cec4033d0f13a23b14cfb428b38bc34fb27914e28270be0e3a2d"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 229
+hash = "122fae2cdb8d604d88125131a2b5eddb2e257e5258919a094dc9edc4a91733db"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 268
+hash = "41e612dd7fb9b95d564b6197046c69e25a4b0cf0caf478b81fb378960a9cd2a4"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 312
+hash = "619d7c83c8636069af210264a817d4d5651440ce2f75e623e8a39d5c12dd6a80"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 335
+hash = "b8552d62a844d85361e82f416348aeea43dee219d50b12a7365313b26c7698e4"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 357
+hash = "b5384b257499dddc22df4949252c29b27a6ec746bd3b7a5d57894c0e1f2ee869"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/kerykeion/src/config.rs"
+line = 382
+hash = "67f8165b62376e44487eadafc322f2a260cfb28c78919f067b98760df674a902"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/kerykeion/src/crypto.rs"
+line = 43
+hash = "307ebc7b35b89760a59160a54499126372b68e897569ee366857562ac7e3025c"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/kerykeion/src/discovery.rs"
+line = 205
+hash = "9e452f58b6170d285ddf6f7c9446321dd3c65a9ba58cb9d9ff66aafc1a9e8ced"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/kerykeion/src/discovery.rs"
+line = 217
+hash = "9e452f58b6170d285ddf6f7c9446321dd3c65a9ba58cb9d9ff66aafc1a9e8ced"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/gateway.rs"
+line = 26
+hash = "11f77fc4329f7df36a71622f0909a92005282f47aae8050bda481e2ebb777b80"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/handshake.rs"
+line = 33
+hash = "98cb97a400498d30cd70ec9324dd61862e1bcba044762c9d6ba25ff008a3868c"
+
+[[baseline.entry]]
+rule = "RUST/test-missing-use-super"
+file = "crates/kerykeion/src/lib.rs"
+line = 93
+hash = "15095e6982f525afaf069c212cd0973c3d0a4db99a58960b495d2172c790bee0"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/mqtt.rs"
+line = 18
+hash = "5487a713071c6288b1a2a61176198016b969cde903312b94ff575e0a2bb23796"
+
+[[baseline.entry]]
+rule = "RUST/primitive-for-domain-id"
+file = "crates/kerykeion/src/mqtt.rs"
+line = 22
+hash = "469194516e531d6f640ab778c5988cac2514ae85c0cbdcbc83829c4b863ef966"
+
+[[baseline.entry]]
+rule = "RUST/primitive-for-domain-id"
+file = "crates/kerykeion/src/mqtt.rs"
+line = 24
+hash = "d6dfe29afd84ce9ac1063aa59cc70216c424be08d3ed56b3d766b28b05835ed1"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/mqtt.rs"
+line = 29
+hash = "a04b3aadbc8d64a86fea640b20557f3e255a4ba5a7ea194595c11d0a9c34a670"
+
+[[baseline.entry]]
+rule = "TESTING/tautological-test"
+file = "crates/kerykeion/src/mqtt.rs"
+line = 261
+hash = "aed7ebc1ed72490359ff4b52f3b92e3b67b0e3e922ff8142e8f0d052796d689a"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/node_db.rs"
+line = 19
+hash = "ecc87c63ce69f7fad064ff830b2715e03e77cde5ccdf2adc7b9a32468c7d4dfa"
+
+[[baseline.entry]]
+rule = "RUST/primitive-for-domain-id"
+file = "crates/kerykeion/src/node_db.rs"
+line = 40
+hash = "914ca450c19248c590d633739b2fe50c28b57d5c4b58ef3c9084292269bb935c"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/outbound.rs"
+line = 25
+hash = "9724a97f4418c40bb414d0783973f91cd804f57b0d396ec96a06c9c44273a04f"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/outbound.rs"
+line = 40
+hash = "f28d8457ac1f397d47a7e1db846e1638b130dbf187cd2bb719a689b1110dd5cb"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/kerykeion/src/processor.rs"
+line = 142
+hash = "12d8c877131f8e3d806c7b15851366aab2dcee5f079623731a8f08e9761ec603"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/kerykeion/src/store_forward.rs"
+line = 96
+hash = "ffee530f9331c287d2e80f4aeb2cb8ab4544ef469a3f79b4048dae6adbb8fa9e"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kerykeion/src/topology.rs"
+line = 21
+hash = "58ac07a178793d818497e2038344c4e3a533ad64520f13209fbb46bd2494cb2b"
+
+[[baseline.entry]]
+rule = "RUST/import-order"
+file = "crates/kerykeion/src/transport/mod.rs"
+line = 17
+hash = "c748ba4baeb994b8a2debd5b431ccc64fcea69ec31dd2fd3c5949665516d44c0"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/kerykeion/src/transport/serial.rs"
+line = 86
+hash = "5ce82f70d7d59647b30a63ee7b2de37d000ec2444e14be8772db32c07b77e4eb"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/kerykeion/src/transport/serial.rs"
+line = 87
+hash = "30388c4f275c5e989b26e991a23eb3e09f75fb1b298e515c1fdf9f2ca73aaeee"
+
+[[baseline.entry]]
+rule = "NAMING/no-fleet-collision"
+file = "crates/koinon/Cargo.toml"
+line = 1
+hash = "70acf00586aa7b90c3866278505be7b81fb7ee1f7e21c17c1a22ac239be3c72a"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/koinon/src/hardware.rs"
+line = 259
+hash = "635566a5376aca1bf92ec855cbe96b69003a02f89b19a6dbdc822d59e580ed34"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/koinon/src/tamper_log.rs"
+line = 46
+hash = "ab6fa7ce2a569a6a8354104318c49f7ae1f5b147a2c0685363a8b09356549fe2"
+
+[[baseline.entry]]
+rule = "RUST/no-debug-derive-on-public-types"
+file = "crates/koinon/src/tamper_log.rs"
+line = 114
+hash = "50d045131e1a2f659ef9b7d91f23499570d3c0ff047998ea759d704128bf5265"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/koinon/src/tamper_log.rs"
+line = 235
+hash = "8c45bee0afc5b671fa5c4e4691d11d232504f3a410456c18e3d22e94134777aa"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/koinon/src/tamper_log.rs"
+line = 282
+hash = "3a82e225fc3e3091c19d16433c344bc468c91f63799cc74461cdecc11ca44675"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/koinon/src/tamper_log.rs"
+line = 341
+hash = "8c45bee0afc5b671fa5c4e4691d11d232504f3a410456c18e3d22e94134777aa"
+
+[[baseline.entry]]
+rule = "TESTING/tautological-test"
+file = "crates/koinon/src/tamper_log_tests.rs"
+line = 420
+hash = "26a67c8087ce26d3ebc7f99316e15d35ecafdaff41db965676ded36d5acd328e"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/kryphos/src/key.rs"
+line = 285
+hash = "d1416ac2d86b612a4585758a52e83d66a15450d7f58243b77b7d088f687b2d55"
+
+[[baseline.entry]]
+rule = "RUST/no-debug-derive-on-public-types"
+file = "crates/kryphos/src/storage.rs"
+line = 61
+hash = "3fe1ad211aa8bad42fceb09d5fbdb3d78493b8f18f5116b56985f2ae1c2d1c6b"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kryphos/src/storage.rs"
+line = 62
+hash = "3f0f8583d594548d11aaf1c74efb937b839ef9910edd2af0826ac7fbcc29010b"
+
+[[baseline.entry]]
+rule = "RUST/no-debug-derive-on-public-types"
+file = "crates/kryphos/src/storage.rs"
+line = 74
+hash = "3fe1ad211aa8bad42fceb09d5fbdb3d78493b8f18f5116b56985f2ae1c2d1c6b"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kryphos/src/storage.rs"
+line = 75
+hash = "fd3f0e0d2616149449f38db6417ee5f11afa4559749b9b54e4fb41274f44265b"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/kryphos/src/storage.rs"
+line = 88
+hash = "a33d08186fabd42dc752ef22864297a54ba5b14c3c7b8c38097315f2582b7990"
+
+[[baseline.entry]]
+rule = "RUST/no-debug-derive-on-public-types"
+file = "crates/kryphos/src/vault.rs"
+line = 127
+hash = "a85be4952c9a87f308d10cad4c842cd4cd070bcec42e0a21ffec4f7e5d609d6d"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/semaino/src/aggregator.rs"
+line = 36
+hash = "e2b4ce893357523f00039ab78959a5718aa3935094a254aaecf5a1dbdc97729d"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/semaino/src/alert.rs"
+line = 73
+hash = "4e5ef5104b47dd039767e8e2d6ef6699ade3e36c5770ac0a821dea0561c1c0b2"
+
+[[baseline.entry]]
+rule = "TESTING/tautological-test"
+file = "crates/semaino/src/alert.rs"
+line = 476
+hash = "c43ccc9fb9b8d49a4905b0d517d3add4728d7b7650d4bf947ebd82e3b66324c0"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/semaino/src/convergence.rs"
+line = 57
+hash = "dec169442aee0de6b2df4199fdd662a5599fed4f5fd1f38f111c613e1cd37c78"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/semaino/src/convergence.rs"
+line = 71
+hash = "dd90b9266e1f8688febf46643505424d3c37c1d50b285839f80688dd0e16e6e0"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/semaino/src/pipeline.rs"
+line = 31
+hash = "262ca345a0b206c9528ef353f9371d7575f0ea817b276dfb2226b0af5b1a6045"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/semaino/src/pipeline.rs"
+line = 141
+hash = "05145eba731ce322a30ffd1d8c7f5c7bb739f4c2057d24cccab943afd98cce2b"
+
+[[baseline.entry]]
+rule = "TESTING/tautological-test"
+file = "crates/semaino/tests/smoke.rs"
+line = 18
+hash = "c1aaacd548343771dde0d6e32030314b43af7915b9d4552bd3d6744a0e2d449e"
+
+[[baseline.entry]]
+rule = "TESTING/tautological-test"
+file = "crates/semaino/tests/smoke.rs"
+line = 23
+hash = "5da81cd310c82f090c6d51d13b5eef7e1272be3300a2c05709cddcd6da5893e1"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/syntonia/src/baofeng/codec.rs"
+line = 209
+hash = "ac043efdc2bafc96f1c1ce44a051a00625778a9fba330a805a16e727512d56db"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/syntonia/src/baofeng/codec.rs"
+line = 210
+hash = "f0c8192172ae70c887b64e43139d1ad4d067a3171fdf9517bf68f110165377fa"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/syntonia/src/baofeng/codec.rs"
+line = 211
+hash = "1b4fb109e8c34ef8d19cb165c430c48fe6113897aca0ad6ccd9311f64ebac052"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/codec.rs"
+line = 283
+hash = "e488eefce5cd7ae80c4714fa9d5809c8510643deb440796f75028444439356f6"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 63
+hash = "5e33c46d8abc082f98f1c260c83e44cd55d7fcb63d110192b5f87368a97ec844"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 86
+hash = "f3d465ac7f5cef277893a0054d9601776e937adbeaab0ef5f4012787c834094b"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 89
+hash = "3ebe4a9e355f93fc8f447aff0fc6774a0e24e7f23cdfc5fdb179eb9ab353e0ff"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 97
+hash = "f3d465ac7f5cef277893a0054d9601776e937adbeaab0ef5f4012787c834094b"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 105
+hash = "7873fbbe232236ad2463b12d7f999f4356d4c3390b18905072f1a62117e531f2"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 137
+hash = "f3d465ac7f5cef277893a0054d9601776e937adbeaab0ef5f4012787c834094b"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 142
+hash = "21cbca9402679a28ad5d3a7fb9280100b9298c2eb37f0fe999f9bc757fcf736e"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 160
+hash = "f3d465ac7f5cef277893a0054d9601776e937adbeaab0ef5f4012787c834094b"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 163
+hash = "3ebe4a9e355f93fc8f447aff0fc6774a0e24e7f23cdfc5fdb179eb9ab353e0ff"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 171
+hash = "f3d465ac7f5cef277893a0054d9601776e937adbeaab0ef5f4012787c834094b"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 174
+hash = "21cbca9402679a28ad5d3a7fb9280100b9298c2eb37f0fe999f9bc757fcf736e"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/protocol.rs"
+line = 582
+hash = "084eef55326958bd663e7dc65a6c22e0d5fb8043e8149e28b824ac8eab3cab43"
+
+[[baseline.entry]]
+rule = "RUST/no-result-unwrap-or-default"
+file = "crates/syntonia/src/baofeng/tone_codec.rs"
+line = 63
+hash = "b44e129c748dadd29d016db78aee5ac27164544a785789026aa87334efddd2e1"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 65
+hash = "2df5f344710c8c41cfdc1db5db970823dbe71b1d8257e9ed33213093e61f2cfb"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 331
+hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 332
+hash = "8a40d5727b684435291907633696a452ba80ca083a800b6733134ac112ef6ec9"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 340
+hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 341
+hash = "8a40d5727b684435291907633696a452ba80ca083a800b6733134ac112ef6ec9"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 349
+hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 350
+hash = "8a40d5727b684435291907633696a452ba80ca083a800b6733134ac112ef6ec9"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 358
+hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 359
+hash = "7e74063cc42d1a76680e2ccd4d06ef81cde1650c2a8cefe4a13cfff33fd24c0b"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 367
+hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 368
+hash = "7e74063cc42d1a76680e2ccd4d06ef81cde1650c2a8cefe4a13cfff33fd24c0b"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 376
+hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 377
+hash = "7e74063cc42d1a76680e2ccd4d06ef81cde1650c2a8cefe4a13cfff33fd24c0b"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 396
+hash = "82e2d02602b541a81f7204320c75e300f1fb6f39d5ad7563874b098876e92f87"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 397
+hash = "0d4e5f305d5037c921999f90a079868e4cde916f76303aae87d83bf68f7ab5a9"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 399
+hash = "f0c4c923f192332c2eb321f715419ea1c9d746438ed7983212dcef5bc9ab6c85"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 405
+hash = "82e2d02602b541a81f7204320c75e300f1fb6f39d5ad7563874b098876e92f87"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 406
+hash = "0d4e5f305d5037c921999f90a079868e4cde916f76303aae87d83bf68f7ab5a9"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 407
+hash = "623acb6bae40a087d60a38c5fa6dc9cdc8ef96d68d2d351c6c3f0a5a5d7b067f"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 413
+hash = "38e9ab1ef1c4c968a33c6d58f8bf43fb6db8a12b934b60ba833877db2a2ad385"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 414
+hash = "7ba330c5dc67ec0d1c2a5b9e50c59f594308ff07f0423ddc32f8c86d099bf543"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 415
+hash = "231bf6514a8e0f85b0c8066d0286a9b910e67ebe40a909f251d7a415779d01ce"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 416
+hash = "49cdeb321eb086bf1e93ba7bbbb9a5eceab49cbe793e4aabe7f4677e21f6a949"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 423
+hash = "41c2164cbb32013c1ca3612dad96f68abff893b36751851009cecd8769abba8a"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 424
+hash = "b57494707a3a1e2c2722980a4ca7a92f44e9abf9e1781948f610a9a5893ea96d"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 431
+hash = "0ba4f2348046839d346a79f9a564c9d702e7600fb113bf72142d82d81053fdcc"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 432
+hash = "594907db99377fa6032e504fd2036558b14f3a26ab5fc05210022e1dd3d48aec"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 438
+hash = "2a14c3f17396e825d34f4adc97ebab46d47816903d89418b33baf6035fa5f7d5"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 439
+hash = "52f1e7cbafea09bffd78f0989f585651d5457794d9acd9585a1f723866698314"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 445
+hash = "0ba4f2348046839d346a79f9a564c9d702e7600fb113bf72142d82d81053fdcc"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 446
+hash = "594907db99377fa6032e504fd2036558b14f3a26ab5fc05210022e1dd3d48aec"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 447
+hash = "2b4aacec45ed139a2d69cd3fcf3d903832f3b39ae933e59e0c13eac35c4b42aa"
+
+[[baseline.entry]]
+rule = "RUST/unwrap"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 453
+hash = "768ddb73b8a45e552aab286432b1359f724bd84afa0d7730d4c7f96fb81b1729"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 454
+hash = "bb62c3e119c9d2c7ea589c560edc932de96a4a5e5828d5b7a3c2687359175934"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 474
+hash = "fbdbbc3dfeb1f54d254bf4e86c02ac5532500dcf20b32b9b3ea559cecb6cc947"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 480
+hash = "0626f20170f347be01920b5925e64f33884c186e9f9ae83bc7eebe5b11f3f689"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 481
+hash = "00626b7ea54b9ae26341f77da74be0109e696a71de72d00c52a7b435332c92ad"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 486
+hash = "8e8d7f935dab7cdc4d1a1c8d336eb7ab59cba4d9db446ca8300bcf9b1e7aece4"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 487
+hash = "0c7e704838ba3fb9a457184230be426be022401aae87f85e6cbc73c0dd66f43e"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 487
+hash = "0c7e704838ba3fb9a457184230be426be022401aae87f85e6cbc73c0dd66f43e"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 488
+hash = "f42b2cb757ae1e2643e0e397afc86d2371f6e953de554a13cbe9d7e311c6c694"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 488
+hash = "f42b2cb757ae1e2643e0e397afc86d2371f6e953de554a13cbe9d7e311c6c694"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 489
+hash = "80d16f04190b8ea1927bb2a127d41ace988c6bb5282d51e01a58098f03308937"
+
+[[baseline.entry]]
+rule = "RUST/indexing-slicing"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 489
+hash = "80d16f04190b8ea1927bb2a127d41ace988c6bb5282d51e01a58098f03308937"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 500
+hash = "71335c3733396048bcd74191f9cd71084d4900d6fcd26e3ca06a81f281355ed6"
+
+[[baseline.entry]]
+rule = "RUST/bare-assert"
+file = "crates/syntonia/src/baofeng/variant.rs"
+line = 512
+hash = "60f47864faae784f0e41fbde70f1a1defc1596257ecde0bdf82de546d1404e71"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/syntonia/src/config.rs"
+line = 27
+hash = "410fb7612200122375fc747129a01ede3e4590c80fff90c532f233ee62cc9596"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/syntonia/src/config.rs"
+line = 92
+hash = "25a7ddf94b9a455321aa2e3cead3023ca7a56f8e1a40556160913a7cca11cf4c"
+
+[[baseline.entry]]
+rule = "RUST/config-deny-unknown-fields"
+file = "crates/syntonia/src/config.rs"
+line = 119
+hash = "6c9bedf9cc6694a9f8539534da5451fe5217da127b552849c472e6ea2d81d3d9"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/hardware/cables.rs"
+line = 40
+hash = "ce003a646d8a4e2c5c9b14306e00d6371dde5125f2ded47e02dd0246b97472d3"
+
+[[baseline.entry]]
+rule = "RUST/prefer-expect-over-allow"
+file = "crates/syntonia/src/hardware/cables.rs"
+line = 95
+hash = "0658fa78601251d1573deba75582c9589bcbc36324981ec0bca0a4e9a97c4c1f"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/hardware/detect.rs"
+line = 27
+hash = "917455a45e772a67e7e9d38282ebc83298c41de1939c3d4e905761b070166b10"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/hardware/detect.rs"
+line = 36
+hash = "7487358fa292ef927ecee876f17511d618055f1996189ef3a3f8b77682ff36f4"
+
+[[baseline.entry]]
+rule = "ARCHITECTURE/trait-impl-colocation"
+file = "crates/syntonia/src/hardware/detect.rs"
+line = 150
+hash = "1bc9066d5ae2e65da4a2695d046b2eff0dd24529d00e524083a25a7c7b092824"
+
+[[baseline.entry]]
+rule = "RUST/no-silent-result-swallow"
+file = "crates/syntonia/src/hardware/detect.rs"
+line = 186
+hash = "f3d0d06e10d904c01d32243c62f68946bdf2059520b200e0cab1b050ca7a7e28"
+
+[[baseline.entry]]
+rule = "RUST/prefer-expect-over-allow"
+file = "crates/syntonia/src/hardware/detect.rs"
+line = 299
+hash = "0658fa78601251d1573deba75582c9589bcbc36324981ec0bca0a4e9a97c4c1f"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/hardware/usb.rs"
+line = 9
+hash = "2853363ceb61b9bd069d0f41199902da670d028dc90abd81e5a04a762a48237f"
+
+[[baseline.entry]]
+rule = "RUST/prefer-expect-over-allow"
+file = "crates/syntonia/src/hardware/usb.rs"
+line = 113
+hash = "0658fa78601251d1573deba75582c9589bcbc36324981ec0bca0a4e9a97c4c1f"
+
+[[baseline.entry]]
+rule = "RUST/prefer-expect-over-allow"
+file = "crates/syntonia/src/hardware/warnings.rs"
+line = 127
+hash = "0658fa78601251d1573deba75582c9589bcbc36324981ec0bca0a4e9a97c4c1f"
+
+[[baseline.entry]]
+rule = "TOPOLOGY/shallow-struct"
+file = "crates/syntonia/src/validate.rs"
+line = 23
+hash = "53a89a35fc4f3511c628c1c477ded84f399e2f1d305a778bd301faa74fb57e0b"
+
+[[baseline.entry]]
+rule = "RUST/todo-marker-needs-quadrant-and-artifact"
+file = "crates/syntonia/src/yaesu/codec.rs"
+line = 49
+hash = "d0ffbb52894edff5a26763a23bee1ffa0fc59d71cacd3af59a330fb38f4cb3ab"
+
+[[baseline.entry]]
+rule = "RUST/todo-marker-needs-quadrant-and-artifact"
+file = "crates/syntonia/src/yaesu/codec.rs"
+line = 76
+hash = "35da0788c6b8da8c28aff18e1e753aaec829100e3a134d2ec532e99055284d98"
+
+[[baseline.entry]]
+rule = "RUST/todo-marker-needs-quadrant-and-artifact"
+file = "crates/syntonia/src/yaesu/protocol.rs"
+line = 57
+hash = "933a0685039066c1c91ad30fcfdea174dd29d4ab5f079d411aa20ee8640f8640"
+
+[[baseline.entry]]
+rule = "RUST/todo-marker-needs-quadrant-and-artifact"
+file = "crates/syntonia/src/yaesu/variant.rs"
+line = 21
+hash = "04a68f255b72e353634d0b6f8320f695e9e336912be9ee77a21d99ad049bd126"
+
+[[baseline.entry]]
+rule = "WRITING/weasel-word"
+file = "docs/fjall-column-encryption.md"
+line = 24
+hash = "232a7f89b46c0e7e8e4230e151a37f11f11066a4cc28ccc8f80900e00a6562d9"
+
+[[baseline.entry]]
+rule = "DOCS/stale-local-link"
+file = "docs/lexicon.md"
+line = 4
+hash = "fc87d21d559fcde14292dfd5cc556da5caf9490a5187f2fcb799b9e1776cdddc"
+
+[[baseline.entry]]
+rule = "WRITING/elegant-variation"
+file = "docs/reference-store.md"
+line = 107
+hash = "61d61f68639e1d69a3bd7f313c5552c746cbdde45afa62cf514bb387b2546db9"
+
+[[baseline.entry]]
+rule = "WRITING/temporal-staleness"
+file = "docs/reference-store.md"
+line = 119
+hash = "0e86e21cdd2928545ab3a5f2baf12ad50e27522bcc7b4c7630d0b9b0e76f58a3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -840,7 +840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -883,9 +883,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038acd422d607e0eca09e093f299f9eccf9bd097554343d93746afff81a45113"
+checksum = "9fcdc69609906151dff9b534e30eaf8515082055d36f628e382bd0b5d6a1d362"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -1463,9 +1463,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef86c3c797c10eefcc73407c43ae48c19d4df686131a8334b2895a513e91df4"
+checksum = "39ca67401338b98d58447387dd5230552d2241bc388206e491d137b18dfea9d6"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -1588,7 +1588,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2031,7 +2031,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -2380,7 +2380,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/kerykeion/src/collector.rs
+++ b/crates/kerykeion/src/collector.rs
@@ -375,7 +375,7 @@ impl Collector for MeshCollector { // kanon:ignore ARCHITECTURE/trait-impl-coloc
                     .first()
                     .ok_or_else(|| Error::ConnectionLost {
                         detail: "no active connections".into(),
-                        location: snafu::Location::new(file!(), line!(), column!()),
+                        location: snafu::location!(),
                     })?,
             );
 

--- a/crates/kerykeion/src/crypto.rs
+++ b/crates/kerykeion/src/crypto.rs
@@ -85,7 +85,7 @@ pub(crate) fn apply_aes_ctr(
             let mut cipher = Ctr128LE::<Aes128>::new_from_slices(key, &nonce).map_err(|e| {
                 Error::Encryption {
                     detail: format!("AES-128 init failed: {e}"),
-                    location: snafu::Location::new(file!(), line!(), column!()),
+                    location: snafu::location!(),
                 }
             })?;
             cipher.apply_keystream(data);
@@ -94,7 +94,7 @@ pub(crate) fn apply_aes_ctr(
             let mut cipher = Ctr128LE::<Aes256>::new_from_slices(key, &nonce).map_err(|e| {
                 Error::Encryption {
                     detail: format!("AES-256 init failed: {e}"),
-                    location: snafu::Location::new(file!(), line!(), column!()),
+                    location: snafu::location!(),
                 }
             })?;
             cipher.apply_keystream(data);

--- a/crates/kerykeion/src/error.rs
+++ b/crates/kerykeion/src/error.rs
@@ -242,7 +242,7 @@ impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Self::ConnectionLost {
             detail: e.to_string(),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         }
     }
 }
@@ -271,7 +271,7 @@ mod tests {
     fn invalid_channel_message() {
         let err = Error::InvalidChannel {
             index: 9,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         };
         assert!(err.to_string().contains('9'));
     }
@@ -280,7 +280,7 @@ mod tests {
     fn node_not_found_message() {
         let err = Error::NodeNotFound {
             node_num: 0xDEAD_BEEF,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         };
         assert!(err.to_string().contains("0xdeadbeef"));
     }

--- a/crates/kerykeion/src/handshake.rs
+++ b/crates/kerykeion/src/handshake.rs
@@ -154,12 +154,12 @@ pub async fn handshake_with_config(
                 "config dump timed out after {}s (want_config_id={want_config_id})",
                 handshake_timeout.as_secs()
             ),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         })??;
 
     let my_node_num = my_node_num.ok_or_else(|| Error::HandshakeFailed {
         detail: "radio did not send MyNodeInfo".to_owned(),
-        location: snafu::Location::new(file!(), line!(), column!()),
+        location: snafu::location!(),
     })?;
 
     Ok(HandshakeResult {

--- a/crates/kerykeion/src/store_forward.rs
+++ b/crates/kerykeion/src/store_forward.rs
@@ -138,7 +138,7 @@ impl StoreForward {
             .collect();
         serde_json::to_vec(&serializable).map_err(|source| Error::StoreForwardSerde {
             source,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         })
     }
 
@@ -151,7 +151,7 @@ impl StoreForward {
         let raw: HashMap<u32, Vec<StoredMessage>> =
             serde_json::from_slice(data).map_err(|source| Error::StoreForwardSerde {
                 source,
-                location: snafu::Location::new(file!(), line!(), column!()),
+                location: snafu::location!(),
             })?;
         self.queues = raw
             .into_iter()

--- a/crates/kerykeion/src/topology.rs
+++ b/crates/kerykeion/src/topology.rs
@@ -330,7 +330,7 @@ impl MeshTopology {
         let snapshot = TopologySnapshot { nodes, links };
         serde_json::to_vec(&snapshot).map_err(|source| crate::Error::TopologySnapshot {
             source,
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         })
     }
 
@@ -343,7 +343,7 @@ impl MeshTopology {
         let snapshot: TopologySnapshot =
             serde_json::from_slice(data).map_err(|source| crate::Error::TopologySnapshot {
                 source,
-                location: snafu::Location::new(file!(), line!(), column!()),
+                location: snafu::location!(),
             })?;
 
         let mut topo = Self::new();

--- a/crates/kerykeion/src/transport/serial.rs
+++ b/crates/kerykeion/src/transport/serial.rs
@@ -78,7 +78,7 @@ fn open_serial_stream(port: &str, baud: u32) -> Result<SerialStream, Error> {
         .map_err(|e| Error::SerialConnect {
             source: std::io::Error::other(e),
             port: port.to_owned(),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         })?;
 
     // WHY: Meshtastic firmware does not use hardware handshake lines; asserting

--- a/crates/kerykeion/src/transport/tcp.rs
+++ b/crates/kerykeion/src/transport/tcp.rs
@@ -84,7 +84,7 @@ async fn tcp_connect(addr: &str, port: u16, timeout: Duration) -> Result<TcpStre
                 format!("connect to {target} timed out after {}s", timeout.as_secs()),
             ),
             addr: target.clone(),
-            location: snafu::Location::new(file!(), line!(), column!()),
+            location: snafu::location!(),
         })?
         .context(TcpConnectSnafu { addr: target })
 }

--- a/crates/kerykeion/src/types.rs
+++ b/crates/kerykeion/src/types.rs
@@ -53,13 +53,13 @@ impl ChannelIndex {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::InvalidChannel`] if `index >= MAX_CHANNELS`.
-    pub fn new(index: u8) -> Result<Self, crate::error::Error> {
+    pub const fn new(index: u8) -> Result<Self, crate::error::Error> {
         if index < MAX_CHANNELS {
             Ok(Self(index))
         } else {
             Err(crate::error::Error::InvalidChannel {
                 index,
-                location: snafu::Location::new(file!(), line!(), column!()),
+                location: snafu::location!(),
             })
         }
     }

--- a/deny.toml
+++ b/deny.toml
@@ -7,13 +7,17 @@ all-features = false
 # WHY: keep in sync with .cargo/audit.toml's [advisories.ignore] array.
 # cargo-audit does not read deny.toml, so any ignore lives in both files.
 
-[[advisories.ignore]]
-id = "RUSTSEC-2025-0119"
-reason = "number_prefix unmaintained, transitive via indicatif; no safe upgrade available upstream."
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0097"
-reason = "rand 0.9.2 unsound only when a custom logger re-enters rand::rng(); akroasis uses tracing-subscriber with no custom logger that calls into rand, so the condition is unreachable. Pulled in transitively via ulid 1.2.1 (semaino/koinon/syntonia/kryphos/kerykeion) and proptest 1.11.0 (dev-only)."
+ignore = [
+    # number_prefix unmaintained, transitive via indicatif; no safe
+    # upgrade available upstream.
+    "RUSTSEC-2025-0119",
+    # rand 0.9.2 unsound only when a custom logger re-enters rand::rng();
+    # akroasis uses tracing-subscriber with no custom logger that calls
+    # into rand, so the condition is unreachable. Pulled in transitively
+    # via ulid 1.2.1 (semaino/koinon/syntonia/kryphos/kerykeion) and
+    # proptest 1.11.0 (dev-only).
+    "RUSTSEC-2026-0097",
+]
 
 [licenses]
 # WHY: AGPL-3.0-only is the workspace license itself (declared in

--- a/deny.toml
+++ b/deny.toml
@@ -7,17 +7,13 @@ all-features = false
 # WHY: keep in sync with .cargo/audit.toml's [advisories.ignore] array.
 # cargo-audit does not read deny.toml, so any ignore lives in both files.
 
-ignore = [
-    # number_prefix unmaintained, transitive via indicatif; no safe
-    # upgrade available upstream.
-    "RUSTSEC-2025-0119",
-    # rand 0.9.2 unsound only when a custom logger re-enters rand::rng();
-    # akroasis uses tracing-subscriber with no custom logger that calls
-    # into rand, so the condition is unreachable. Pulled in transitively
-    # via ulid 1.2.1 (semaino/koinon/syntonia/kryphos/kerykeion) and
-    # proptest 1.11.0 (dev-only).
-    "RUSTSEC-2026-0097",
-]
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0119"
+reason = "number_prefix unmaintained, transitive via indicatif; no safe upgrade available upstream."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.9.2 unsound only when a custom logger re-enters rand::rng(); akroasis uses tracing-subscriber with no custom logger that calls into rand, so the condition is unreachable. Pulled in transitively via ulid 1.2.1 (semaino/koinon/syntonia/kryphos/kerykeion) and proptest 1.11.0 (dev-only)."
 
 [licenses]
 # WHY: AGPL-3.0-only is the workspace license itself (declared in

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,11 @@
+# osv-scanner ignore list — mirrors deny.toml's [[advisories.ignore]] set
+# (deny.toml is the single source of truth; kanon gate enforces three-way
+# parity across deny.toml, .cargo/audit.toml, and this file).
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0119"
+reason = "number_prefix unmaintained, transitive via indicatif; no safe upgrade available upstream."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.9.2 unsound only when a custom logger re-enters rand::rng(); unreachable in akroasis. Transitive via ulid + proptest (dev-only)."


### PR DESCRIPTION
Clears the Security-workflow failures red since 2026-07-14: RUSTSEC-2026-0190 (anyhow 1.0.103), RUSTSEC-2026-0204 (crossbeam-epoch 0.9.20), and the yanked fjall/lsm-tree/spin releases. Lockfile-only; every fix is admitted by existing manifest constraints. Unblocks the stalled dependabot auto-merge queue.