### PR TITLE
fix(lint): satisfy unwired-dead-code-untracked markers + clear pre-existing clippy/fmt fails

### DIFF
--- a/crates/akroasis/src/main.rs
+++ b/crates/akroasis/src/main.rs
@@ -8,7 +8,7 @@ mod cli;
     not(test),
     expect(
         dead_code,
-        reason = "mesh helpers used by daemon; unused in CLI binary build"
+        reason = "mesh table/status helpers await daemon integration, tracked in #264"
     )
 )]
 mod mesh;
@@ -57,7 +57,11 @@ enum Error {
 
 /// Application configuration loaded from TOML file and environment overrides.
 #[derive(Debug, Deserialize, Default)]
-#[expect(dead_code, reason = "config fields reserved for future CLI options")]
+#[serde(deny_unknown_fields)]
+#[expect(
+    dead_code,
+    reason = "config fields reserved for future CLI options, tracked in #264"
+)]
 struct Config {
     /// Path to the configuration file (default: `~/.config/akroasis/config.toml`).
     config_path: Option<PathBuf>,

--- a/crates/akroasis/src/radio/mod.rs
+++ b/crates/akroasis/src/radio/mod.rs
@@ -110,7 +110,7 @@ impl ExportFormat {
     not(feature = "hardware-serial"),
     allow(
         dead_code,
-        reason = "radio variants used in test mocks; not all exercised in binary"
+        reason = "radio variants used in test mocks; not all exercised in binary (test-fixture)"
     )
 )]
 pub enum RadioVariant {
@@ -225,7 +225,7 @@ pub trait Session {
     all(feature = "hardware-serial", not(test)),
     allow(
         dead_code,
-        reason = "stub backend remains available for tests and no-hardware builds"
+        reason = "stub backend remains available for tests and no-hardware builds (test-fixture)"
     )
 )]
 pub struct StubHardware;

--- a/crates/kerykeion/src/store_forward.rs
+++ b/crates/kerykeion/src/store_forward.rs
@@ -43,7 +43,7 @@ pub struct StoreForward {
     /// Monotonic base time for TTL checks in-process.
     #[expect(
         dead_code,
-        reason = "used for TTL baseline in production; tests use stored_at_ms"
+        reason = "used for TTL baseline in production; tests use stored_at_ms, tracked in #244"
     )]
     base_instant: Instant,
 }

--- a/crates/syntonia/src/baofeng/constants.rs
+++ b/crates/syntonia/src/baofeng/constants.rs
@@ -9,7 +9,7 @@
     not(feature = "hardware-serial"),
     expect(
         dead_code,
-        reason = "protocol constants used only with hardware-serial feature"
+        reason = "protocol constants used only with hardware-serial feature, tracked in #264"
     )
 )]
 

--- a/crates/syntonia/src/baofeng/variant.rs
+++ b/crates/syntonia/src/baofeng/variant.rs
@@ -6,7 +6,7 @@
     not(feature = "hardware-serial"),
     expect(
         dead_code,
-        reason = "variant API used only with hardware-serial feature"
+        reason = "variant API used only with hardware-serial feature, tracked in #264"
     )
 )]
 

--- a/crates/syntonia/src/hardware/warnings.rs
+++ b/crates/syntonia/src/hardware/warnings.rs
@@ -67,7 +67,7 @@ impl fmt::Display for HardwareWarning {
     not(test),
     expect(
         dead_code,
-        reason = "crate-local warning helpers are staged for the akroasis hardware backend"
+        reason = "crate-local warning helpers are staged for the akroasis hardware backend, tracked in #264"
     )
 )]
 pub(crate) fn collect_scan_warnings(cables: &[UsbCable]) -> Vec<HardwareWarning> {
@@ -95,7 +95,7 @@ pub(crate) fn collect_scan_warnings(cables: &[UsbCable]) -> Vec<HardwareWarning>
     not(test),
     expect(
         dead_code,
-        reason = "crate-local warning helpers are staged for the akroasis hardware backend"
+        reason = "crate-local warning helpers are staged for the akroasis hardware backend, tracked in #264"
     )
 )]
 pub(crate) fn collect_detection_warnings(detected: &[DetectedRadio]) -> Vec<HardwareWarning> {
@@ -114,7 +114,7 @@ pub(crate) fn collect_detection_warnings(detected: &[DetectedRadio]) -> Vec<Hard
     not(test),
     expect(
         dead_code,
-        reason = "crate-local warning helpers are staged for the akroasis hardware backend"
+        reason = "crate-local warning helpers are staged for the akroasis hardware backend, tracked in #264"
     )
 )]
 pub(crate) fn port_access_denied(port: &str) -> HardwareWarning {

--- a/crates/syntonia/src/serial.rs
+++ b/crates/syntonia/src/serial.rs
@@ -132,7 +132,10 @@ pub mod mock {
         /// Queue response bytes that will be returned by subsequent reads.
         #[cfg_attr(
             not(feature = "hardware-serial"),
-            expect(dead_code, reason = "used only by hardware-serial protocol tests")
+            expect(
+                dead_code,
+                reason = "used only by hardware-serial protocol tests (test-fixture)"
+            )
         )]
         pub fn enqueue_response(&mut self, data: &[u8]) {
             self.rx_queue.extend(data);
@@ -141,7 +144,10 @@ pub mod mock {
         /// Make the next read return an error of the given kind.
         #[cfg_attr(
             not(feature = "hardware-serial"),
-            expect(dead_code, reason = "used only by hardware-serial protocol tests")
+            expect(
+                dead_code,
+                reason = "used only by hardware-serial protocol tests (test-fixture)"
+            )
         )]
         pub fn inject_error(&mut self, kind: io::ErrorKind) {
             self.pending_error = Some(kind);


### PR DESCRIPTION
## What

`kanon lint` now enforces `WORKFLOW/unwired-dead-code-untracked` (error severity), which postdates the akroasis#261 baseline and is currently live-blocking `kanon gate --stamp`. This fixes the 12 flagged sites:

- 4 get the `test-fixture` marker (radio variant/stub mocks, hardware-serial protocol test doubles) — genuinely test-only.
- 1 (`kerykeion::store_forward::base_instant`) references the existing akroasis#244 — the same TTL-never-invoked gap.
- 7 (mesh CLI helpers, `Config.config_path`, baofeng constants/variant feature gates, hardware warning helpers) are genuinely forward-looking/awaiting integration; filed as akroasis#264 and referenced.

Unrelated to the dead-code markers, but needed for a clean gate on this branch: `cargo fmt` (the lengthened reason strings needed rewrapping) and `cargo clippy --workspace` (which was already failing on main independent of this PR — `koinon::baseline` `suboptimal_flops`, 2 sites, fixed via clippy's own `mul_add` suggestion). Also added `#[serde(deny_unknown_fields)]` to `akroasis::Config` since the reason-string line shift moved that struct off its akroasis#261 baseline entry, re-exposing `RUST/config-deny-unknown-fields`.

## Remaining

`VOCAB/crate-name-collision` (`crates/koinon` vs. the standalone `koinon` repo) is warning-severity, pre-existing, and not fixable in this repo alone (needs a fleet-wide `hub-words.toml` entry or a rename) — tracked in akroasis#264, left for an explicit naming decision. This is currently the **only** failing gate step; `kanon gate --stamp` cannot fully pass on `main` until it's resolved.

## Verification

Full `kanon gate --stamp` on this branch: fmt, check (workspace), advisory-ignore parity, derive check, kanon fitness, cargo-deny, clippy (workspace), nextest (workspace, 757/757 passed) all PASS. Only `kanon lint` fails, solely on the VOCAB warning above.