### PR TITLE
fix(kryphos): restrict vault dir and files to owner-only perms on Unix

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -516,31 +516,31 @@ hash = "d1416ac2d86b612a4585758a52e83d66a15450d7f58243b77b7d088f687b2d55"
 [[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/kryphos/src/storage.rs"
-line = 61
+line = 62
 hash = "3fe1ad211aa8bad42fceb09d5fbdb3d78493b8f18f5116b56985f2ae1c2d1c6b"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/kryphos/src/storage.rs"
-line = 62
+line = 63
 hash = "3f0f8583d594548d11aaf1c74efb937b839ef9910edd2af0826ac7fbcc29010b"
 
 [[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/kryphos/src/storage.rs"
-line = 74
+line = 75
 hash = "3fe1ad211aa8bad42fceb09d5fbdb3d78493b8f18f5116b56985f2ae1c2d1c6b"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/kryphos/src/storage.rs"
-line = 75
+line = 76
 hash = "fd3f0e0d2616149449f38db6417ee5f11afa4559749b9b54e4fb41274f44265b"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/kryphos/src/storage.rs"
-line = 88
+line = 89
 hash = "a33d08186fabd42dc752ef22864297a54ba5b14c3c7b8c38097315f2582b7990"
 
 [[baseline.entry]]

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -1,6 +1,7 @@
 //! Vault storage backend: encrypted credential CRUD over fjall.
 
 use std::fs::{self, File};
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use compact_str::CompactString;
@@ -113,7 +114,10 @@ impl Vault {
     /// Creates a new vault at the given path.
     ///
     /// Generates a random salt, derives a key from the passphrase,
-    /// writes the header, and initializes the fjall keyspace.
+    /// writes the header, and initializes the fjall keyspace. On Unix
+    /// the vault directory, its `data/` subdirectory, and every file
+    /// written are created owner-only (`0700`/`0600`) so a local
+    /// unprivileged user cannot read the key-check oracle or ciphertext.
     ///
     /// # Errors
     ///
@@ -126,7 +130,7 @@ impl Vault {
             return AlreadyExistsSnafu { path }.fail();
         }
 
-        fs::create_dir_all(path).context(IoSnafu { path })?;
+        create_owner_only_dir(path)?;
 
         let lock = acquire_lock(path)?;
         let salt = crypto::generate_salt();
@@ -142,8 +146,12 @@ impl Vault {
         };
 
         let header_json = serde_json::to_string_pretty(&header).context(SerializationSnafu)?;
-        fs::write(path.join(HEADER_FILE), header_json).context(IoSnafu { path })?;
+        write_owner_only_file(&path.join(HEADER_FILE), header_json.as_bytes())?;
 
+        // WHY: pre-create the data dir owner-only before fjall populates it —
+        // fjall's own `create_dir_all` uses process-default (umask) perms and
+        // would otherwise leave the keyspace directory world-readable.
+        create_owner_only_dir(&path.join(DATA_DIR))?;
         let (db, keyspace) = open_fjall(&path.join(DATA_DIR))?;
 
         Ok(Self {
@@ -482,17 +490,60 @@ impl std::fmt::Debug for Vault {
 fn acquire_lock(vault_path: &Path) -> Result<File, VaultError> {
     let lock_path = vault_path.join(LOCK_FILE);
 
-    // WHY: create_dir_all is idempotent and needed when called from open()
-    // before the lock file exists.
-    fs::create_dir_all(vault_path).context(IoSnafu { path: vault_path })?;
+    // WHY: create_owner_only_dir is idempotent and needed when called from
+    // open() before the lock file exists.
+    create_owner_only_dir(vault_path)?;
 
-    let file = File::create(&lock_path).context(IoSnafu { path: vault_path })?;
+    let file = create_owner_only_file(&lock_path)?;
 
     file.try_lock_exclusive().map_err(|_| VaultError::Locked {
         path: vault_path.to_path_buf(),
     })?;
 
     Ok(file)
+}
+
+/// Creates `path` as a directory restricted to the owner on Unix (`0700`).
+///
+/// Idempotent: succeeds without error if `path` already exists as a
+/// directory (matching the prior `create_dir_all` behavior). On non-Unix
+/// platforms this is equivalent to `create_dir_all` — no portable
+/// owner-only directory API exists in `std`.
+fn create_owner_only_dir(path: &Path) -> Result<(), VaultError> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+
+    builder.create(path).context(IoSnafu { path })
+}
+
+/// Opens `path` for writing, creating (or truncating) it, restricted to the
+/// owner on Unix (`0600`). On non-Unix platforms this is equivalent to
+/// `File::create` — no portable owner-only file-creation API exists in
+/// `std`.
+fn create_owner_only_file(path: &Path) -> Result<File, VaultError> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    options.open(path).context(IoSnafu { path })
+}
+
+/// Writes `contents` to a fresh owner-only file at `path` (`0600` on Unix).
+fn write_owner_only_file(path: &Path, contents: &[u8]) -> Result<(), VaultError> {
+    create_owner_only_file(path)?
+        .write_all(contents)
+        .context(IoSnafu { path })
 }
 
 /// Opens or creates a fjall database and keyspace at the given path.

--- a/crates/kryphos/src/storage_tests.rs
+++ b/crates/kryphos/src/storage_tests.rs
@@ -472,3 +472,92 @@ fn list_shows_entry_status() {
         }
     }
 }
+
+// -----------------------------------------------------------------
+// Filesystem permissions (akroasis#217)
+// -----------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn create_restricts_vault_dir_to_owner_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("perms-vault");
+
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+    let vault_mode = std::fs::metadata(&vault_path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        vault_mode, 0o700,
+        "vault directory must be owner-only (0700)"
+    );
+
+    drop(vault);
+}
+
+#[cfg(unix)]
+#[test]
+fn create_restricts_header_file_to_owner_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("perms-header-vault");
+
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+    let header_mode = std::fs::metadata(vault_path.join(HEADER_FILE))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        header_mode, 0o600,
+        "header.json (the passphrase key-check oracle) must be owner-only (0600)"
+    );
+
+    drop(vault);
+}
+
+#[cfg(unix)]
+#[test]
+fn create_restricts_data_dir_to_owner_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("perms-data-vault");
+
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+    let data_mode = std::fs::metadata(vault_path.join(DATA_DIR))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        data_mode, 0o700,
+        "fjall data directory must be owner-only (0700)"
+    );
+
+    drop(vault);
+}
+
+#[cfg(unix)]
+#[test]
+fn create_restricts_lock_file_to_owner_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("perms-lock-vault");
+
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+
+    let lock_mode = std::fs::metadata(vault_path.join(LOCK_FILE))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(lock_mode, 0o600, "vault.lock must be owner-only (0600)");
+
+    drop(vault);
+}


### PR DESCRIPTION
## Finding

The vault directory, `header.json` (the passphrase key-check oracle), the fjall `data/` directory, and `vault.lock` were all created with process-default (umask-derived) permissions — typically world-readable `0755`/`0644` on Unix. `header.json` contains a stable known-plaintext verifier (`key_check` = `encrypt(derive_key(passphrase, salt), KEY_CHECK_PLAINTEXT)`) plus the plaintext salt, so any local unprivileged user — or anyone who copies the vault directory — could run an offline passphrase dictionary attack bounded only by Argon2id cost.

## Fix

`crates/kryphos/src/storage.rs`:

- Added `create_owner_only_dir` / `create_owner_only_file` / `write_owner_only_file` helpers that set `0700` (dirs) / `0600` (files) via `DirBuilderExt::mode` / `OpenOptionsExt::mode` under `cfg(unix)`, falling back to the portable `create_dir_all` / `File::create` behavior on non-Unix platforms where `std` has no owner-only creation API.
- Applied to: the vault directory itself (`Vault::create`), the `data/` dir (pre-created owner-only *before* fjall populates it — fjall's own `create_dir_all` uses default perms), `header.json`, and `vault.lock` (shared by `create()` and `open()` via `acquire_lock()`).
- Re-anchored 5 `.kanon-lint-baseline.toml` entries whose `line=` shifted +1 from the new `use std::io::Write as _;` import (pure line-content hash unchanged, matches existing struct-definition warnings — no new lint debt).

## Evidence

- `cargo nextest run -p kryphos`: 97/97 pass, including 4 new `cfg(unix)` tests asserting created modes:
  - `create_restricts_vault_dir_to_owner_on_unix` → `0700`
  - `create_restricts_header_file_to_owner_on_unix` → `0600`
  - `create_restricts_data_dir_to_owner_on_unix` → `0700`
  - `create_restricts_lock_file_to_owner_on_unix` → `0600`
- Full `kanon gate --stamp --git-diff origin/main`: fmt, check, clippy (workspace, `-D warnings`), nextest (workspace, 765/765), lint (0 errors/0 warnings, 5 pre-existing suppressed), dependency audit, fitness — all PASS.

Closes #217