### PR TITLE
fix(koinon): key the tamper-log hash chain and seal trailing truncation

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -474,37 +474,37 @@ hash = "635566a5376aca1bf92ec855cbe96b69003a02f89b19a6dbdc822d59e580ed34"
 [[baseline.entry]]
 rule = "RUST/config-deny-unknown-fields"
 file = "crates/koinon/src/tamper_log.rs"
-line = 46
+line = 64
 hash = "ab6fa7ce2a569a6a8354104318c49f7ae1f5b147a2c0685363a8b09356549fe2"
 
 [[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/koinon/src/tamper_log.rs"
-line = 114
+line = 150
 hash = "50d045131e1a2f659ef9b7d91f23499570d3c0ff047998ea759d704128bf5265"
 
 [[baseline.entry]]
 rule = "RUST/no-result-unwrap-or-default"
 file = "crates/koinon/src/tamper_log.rs"
-line = 235
+line = 273
 hash = "8c45bee0afc5b671fa5c4e4691d11d232504f3a410456c18e3d22e94134777aa"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/koinon/src/tamper_log.rs"
-line = 282
+line = 330
 hash = "3a82e225fc3e3091c19d16433c344bc468c91f63799cc74461cdecc11ca44675"
 
 [[baseline.entry]]
 rule = "RUST/no-result-unwrap-or-default"
 file = "crates/koinon/src/tamper_log.rs"
-line = 341
+line = 384
 hash = "8c45bee0afc5b671fa5c4e4691d11d232504f3a410456c18e3d22e94134777aa"
 
 [[baseline.entry]]
 rule = "TESTING/tautological-test"
 file = "crates/koinon/src/tamper_log_tests.rs"
-line = 420
+line = 612
 hash = "26a67c8087ce26d3ebc7f99316e15d35ecafdaff41db965676ded36d5acd328e"
 
 [[baseline.entry]]
@@ -516,31 +516,31 @@ hash = "d1416ac2d86b612a4585758a52e83d66a15450d7f58243b77b7d088f687b2d55"
 [[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/kryphos/src/storage.rs"
-line = 62
+line = 70
 hash = "3fe1ad211aa8bad42fceb09d5fbdb3d78493b8f18f5116b56985f2ae1c2d1c6b"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/kryphos/src/storage.rs"
-line = 63
+line = 71
 hash = "3f0f8583d594548d11aaf1c74efb937b839ef9910edd2af0826ac7fbcc29010b"
 
 [[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/kryphos/src/storage.rs"
-line = 75
+line = 83
 hash = "3fe1ad211aa8bad42fceb09d5fbdb3d78493b8f18f5116b56985f2ae1c2d1c6b"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/kryphos/src/storage.rs"
-line = 76
+line = 84
 hash = "fd3f0e0d2616149449f38db6417ee5f11afa4559749b9b54e4fb41274f44265b"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/kryphos/src/storage.rs"
-line = 89
+line = 97
 hash = "a33d08186fabd42dc752ef22864297a54ba5b14c3c7b8c38097315f2582b7990"
 
 [[baseline.entry]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,10 +1393,12 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "subtle",
  "tempfile",
  "toml 1.1.3+spec-1.1.0",
  "tracing",
  "ulid",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/koinon/Cargo.toml
+++ b/crates/koinon/Cargo.toml
@@ -17,6 +17,8 @@ tracing.workspace = true
 compact_str.workspace = true
 blake3.workspace = true
 ciborium.workspace = true
+zeroize.workspace = true
+subtle.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/koinon/src/lib.rs
+++ b/crates/koinon/src/lib.rs
@@ -27,7 +27,7 @@ pub use id::{DeviceId, EntityId, FrequencyId, SignalId};
 pub use power::Power;
 pub use signal::{Confidence, GeoSignal, SignalKind};
 pub use tamper_log::{
-    ChainStatus, DEFAULT_MAX_FILE_BYTES, LogEntry, LogEntryKind, MAX_ENTRY_BYTES, TamperLog,
-    TamperLogConfig, TamperLogError, VerificationResult, verify_chain,
+    CHAIN_KEY_LEN, ChainKey, ChainStatus, DEFAULT_MAX_FILE_BYTES, LogEntry, LogEntryKind,
+    MAX_ENTRY_BYTES, TamperLog, TamperLogConfig, TamperLogError, VerificationResult, verify_chain,
 };
 pub use timestamp::{Timestamp, TimestampError};

--- a/crates/koinon/src/tamper_log.rs
+++ b/crates/koinon/src/tamper_log.rs
@@ -1,14 +1,27 @@
-//! Tamper-evident append-only log with BLAKE3 hash chaining.
+//! Tamper-evident append-only log with keyed BLAKE3 hash chaining.
 //!
 //! # Binary format (per entry)
 //!
 //! ```text
 //! [4 bytes: payload length (little-endian u32)]
 //! [N bytes: CBOR-encoded LogEntry]
-//! [32 bytes: BLAKE3 hash = BLAKE3(cbor_bytes || prev_hash)]
+//! [32 bytes: keyed BLAKE3 hash = BLAKE3_keyed(cbor_bytes || prev_hash)]
 //! ```
 //!
-//! The first entry uses `[0u8; 32]` as `prev_hash`.
+//! The first entry's `prev_hash` is a keyed genesis root (see
+//! [`ChainKey`]), not a public constant: recomputing a valid chain, from
+//! the genesis onward, requires the key.
+//!
+//! # Truncation seal
+//!
+//! A hash chain alone cannot detect trailing truncation — any prefix of a
+//! valid chain is itself internally consistent, so reading to EOF looks
+//! identical whether the file legitimately ends there or was cut short.
+//! [`TamperLog::open`] and [`TamperLog::append`] refresh a sidecar
+//! `{log}.seal` file authenticating the current entry count; [`verify_chain`]
+//! cross-checks the streamed count against it and reports
+//! [`ChainStatus::Truncated`] on any mismatch or unauthenticated seal. See
+//! `tamper_log_seal` for the seal and key machinery.
 
 use std::{
     fs::{File, OpenOptions},
@@ -21,6 +34,11 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
 use crate::{EntityId, SignalId};
+
+#[path = "tamper_log_seal.rs"]
+mod seal;
+
+pub use seal::{CHAIN_KEY_LEN, ChainKey};
 
 /// Maximum allowed entry payload size (16 MiB).
 ///
@@ -63,6 +81,7 @@ impl Default for TamperLogConfig {
 
 /// Errors produced by [`TamperLog`] and [`verify_chain`].
 #[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
 pub enum TamperLogError {
     /// I/O error accessing the log file.
@@ -102,6 +121,23 @@ pub enum TamperLogError {
         size: u64,
         /// Maximum allowed size.
         max: u64,
+    },
+
+    /// The existing chain failed verification and cannot be safely
+    /// resumed. Only [`ChainStatus::Intact`] or [`ChainStatus::Empty`] may
+    /// be resumed — appending onto anything else would silently launder
+    /// the tampering, since the next seal refresh would authenticate a
+    /// shorter-but-internally-consistent chain as if it were the whole
+    /// story.
+    #[snafu(display(
+        "refusing to resume compromised tamper log at {}: {status:?}",
+        path.display()
+    ))]
+    ChainCompromised {
+        /// Path of the log file that failed pre-resume verification.
+        path: PathBuf,
+        /// The verification status that caused the refusal.
+        status: ChainStatus,
     },
 }
 
@@ -178,10 +214,11 @@ pub struct LogEntry {
 // Encode / decode
 // ---------------------------------------------------------------------------
 
-/// Serializes `entry` to CBOR, computes its hash, and returns `(wire_bytes, entry_hash)`.
+/// Serializes `entry` to CBOR, computes its keyed hash, and returns
+/// `(wire_bytes, entry_hash)`.
 ///
 /// `wire_bytes` is the complete on-disk representation:
-/// `[4-byte LE length][CBOR payload][32-byte BLAKE3 hash]`.
+/// `[4-byte LE length][CBOR payload][32-byte keyed BLAKE3 hash]`.
 ///
 /// # Errors
 ///
@@ -189,11 +226,12 @@ pub struct LogEntry {
 pub fn encode_entry(
     entry: &LogEntry,
     prev_hash: &[u8; 32],
+    chain_key: &ChainKey,
 ) -> Result<(Vec<u8>, [u8; 32]), TamperLogError> {
     let mut cbor_bytes: Vec<u8> = Vec::new();
     ciborium::into_writer(entry, &mut cbor_bytes).context(CborEncodeSnafu)?;
 
-    let mut hasher = blake3::Hasher::new();
+    let mut hasher = blake3::Hasher::new_keyed(chain_key.as_bytes());
     hasher.update(&cbor_bytes);
     hasher.update(prev_hash);
     let hash: [u8; 32] = hasher.finalize().into();
@@ -257,7 +295,8 @@ pub fn decode_entry(bytes: &[u8]) -> Result<(LogEntry, [u8; 32]), TamperLogError
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ChainStatus {
-    /// All entries verified successfully.
+    /// All entries verified successfully, and the entry count matches
+    /// the authenticated seal.
     Intact,
     /// Chain is broken at the given sequence number.
     Broken {
@@ -268,12 +307,21 @@ pub enum ChainStatus {
         /// Hash that was stored on disk.
         actual_hash: [u8; 32],
     },
-    /// File is empty (no entries).
+    /// File is empty (no entries) and no seal claims otherwise.
     Empty,
     /// File is truncated or otherwise unreadable at `byte_offset`.
     Corrupted {
         /// Byte OFFSET WHERE the problem was detected.
         byte_offset: u64,
+    },
+    /// The chain streamed cleanly (every link that exists verifies), but
+    /// the entry count does not match the authenticated sidecar seal —
+    /// the signature of a trailing run of entries deleted by an adversary
+    /// who lacks the chain key needed to forge a matching seal.
+    Truncated {
+        /// Entry count from a validated seal, when one authenticated.
+        /// `None` when no seal authenticated at all (missing or forged).
+        sealed_entries: Option<u64>,
     },
 }
 
@@ -286,8 +334,9 @@ pub struct VerificationResult {
     pub status: ChainStatus,
 }
 
-/// Reads `path` FROM the beginning, recomputes every hash link, and returns
-/// the first break found.
+/// Reads `path` FROM the beginning, recomputes every hash link keyed with
+/// `chain_key`, and returns the first break found — or, if every link
+/// verifies, the seal-cross-checked terminal status.
 ///
 /// This is O(n) in file size and streams the file; it never loads the whole
 /// file INTO memory.
@@ -295,12 +344,15 @@ pub struct VerificationResult {
 /// # Errors
 ///
 /// Returns [`TamperLogError::Io`] if the file cannot be opened or read.
-pub fn verify_chain(path: impl AsRef<Path>) -> Result<VerificationResult, TamperLogError> {
+pub fn verify_chain(
+    path: impl AsRef<Path>,
+    chain_key: &ChainKey,
+) -> Result<VerificationResult, TamperLogError> {
     let path = path.as_ref();
     let file = File::open(path).context(IoSnafu { path })?;
     let mut reader = BufReader::new(file);
 
-    let mut prev_hash = [0u8; 32];
+    let mut prev_hash = seal::genesis_hash(chain_key);
     let mut entries_verified: u64 = 0;
     let mut byte_offset: u64 = 0;
 
@@ -310,16 +362,7 @@ pub fn verify_chain(path: impl AsRef<Path>) -> Result<VerificationResult, Tamper
         match reader.read_exact(&mut len_buf) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                if entries_verified == 0 {
-                    return Ok(VerificationResult {
-                        entries_verified: 0,
-                        status: ChainStatus::Empty,
-                    });
-                }
-                return Ok(VerificationResult {
-                    entries_verified,
-                    status: ChainStatus::Intact,
-                });
+                return Ok(terminal_result(path, chain_key, entries_verified));
             }
             Err(e) => {
                 return Err(TamperLogError::Io {
@@ -359,8 +402,8 @@ pub fn verify_chain(path: impl AsRef<Path>) -> Result<VerificationResult, Tamper
             });
         }
 
-        // Recompute hash.
-        let mut hasher = blake3::Hasher::new();
+        // Recompute the keyed hash.
+        let mut hasher = blake3::Hasher::new_keyed(chain_key.as_bytes());
         hasher.update(&cbor_bytes);
         hasher.update(&prev_hash);
         let expected_hash: [u8; 32] = hasher.finalize().into();
@@ -385,6 +428,40 @@ pub fn verify_chain(path: impl AsRef<Path>) -> Result<VerificationResult, Tamper
     }
 }
 
+/// Determines the terminal status once the log has streamed cleanly to
+/// EOF with `entries_verified` links all verifying, by cross-checking
+/// against the authenticated sidecar seal.
+fn terminal_result(path: &Path, chain_key: &ChainKey, entries_verified: u64) -> VerificationResult {
+    let sealed = seal::read_seal(path, chain_key);
+
+    let status = if entries_verified == 0 {
+        match sealed {
+            seal::SealState::Absent | seal::SealState::Valid(0) => ChainStatus::Empty,
+            seal::SealState::Valid(n) => ChainStatus::Truncated {
+                sealed_entries: Some(n),
+            },
+            seal::SealState::Invalid => ChainStatus::Truncated {
+                sealed_entries: None,
+            },
+        }
+    } else {
+        match sealed {
+            seal::SealState::Valid(n) if n == entries_verified => ChainStatus::Intact,
+            seal::SealState::Valid(n) => ChainStatus::Truncated {
+                sealed_entries: Some(n),
+            },
+            seal::SealState::Absent | seal::SealState::Invalid => ChainStatus::Truncated {
+                sealed_entries: None,
+            },
+        }
+    };
+
+    VerificationResult {
+        entries_verified,
+        status,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // TamperLog writer
 // ---------------------------------------------------------------------------
@@ -392,7 +469,8 @@ pub fn verify_chain(path: impl AsRef<Path>) -> Result<VerificationResult, Tamper
 /// Append-only tamper-evident log writer.
 ///
 /// Each call to [`TamperLog::append`] writes a length-prefixed CBOR entry
-/// followed by a BLAKE3 hash that chains FROM the previous entry.
+/// followed by a keyed BLAKE3 hash that chains FROM the previous entry,
+/// then refreshes the truncation seal.
 pub struct TamperLog {
     writer: BufWriter<File>,
     path: PathBuf,
@@ -400,21 +478,28 @@ pub struct TamperLog {
     sequence: u64,
     bytes_written: u64,
     max_file_bytes: u64,
+    chain_key: ChainKey,
 }
 
 impl TamperLog {
-    /// Opens or creates a log file at `path`.
+    /// Opens or creates a log file at `path`, keyed with `chain_key`.
     ///
-    /// If the file already exists and contains entries, reads to the end to
-    /// recover `prev_hash` and `sequence` so new appends continue the chain.
+    /// If the file already exists, it is fully verified first (see
+    /// [`verify_chain`]); anything other than [`ChainStatus::Intact`] or
+    /// [`ChainStatus::Empty`] is refused with
+    /// [`TamperLogError::ChainCompromised`] rather than resumed, which
+    /// would launder the tampering into an apparently-shorter-but-valid
+    /// chain. Otherwise reads to the end to recover `prev_hash` and
+    /// `sequence` so new appends continue the chain.
     ///
     /// # Errors
     ///
-    /// Returns [`TamperLogError::Io`] on filesystem errors, or
-    /// [`TamperLogError::CborDecode`] / [`TamperLogError::Corrupted`] if an
-    /// existing file cannot be parsed.
-    pub fn open(path: impl AsRef<Path>) -> Result<Self, TamperLogError> {
-        Self::open_with_config(path, &TamperLogConfig::default())
+    /// Returns [`TamperLogError::ChainCompromised`] if an existing file
+    /// fails pre-resume verification. Returns [`TamperLogError::Io`] on
+    /// filesystem errors, or [`TamperLogError::CborDecode`] /
+    /// [`TamperLogError::Corrupted`] if an existing file cannot be parsed.
+    pub fn open(path: impl AsRef<Path>, chain_key: ChainKey) -> Result<Self, TamperLogError> {
+        Self::open_with_config(path, chain_key, &TamperLogConfig::default())
     }
 
     /// Opens or creates a log file at `path` with the supplied tuning.
@@ -425,16 +510,26 @@ impl TamperLog {
     ///
     /// # Errors
     ///
-    /// Returns [`TamperLogError::Io`] on filesystem errors, or
-    /// [`TamperLogError::CborDecode`] / [`TamperLogError::Corrupted`] if an
-    /// existing file cannot be parsed.
+    /// Returns [`TamperLogError::ChainCompromised`] if an existing file
+    /// fails pre-resume verification. Returns [`TamperLogError::Io`] on
+    /// filesystem errors, or [`TamperLogError::CborDecode`] /
+    /// [`TamperLogError::Corrupted`] if an existing file cannot be parsed.
     pub fn open_with_config(
         path: impl AsRef<Path>,
+        chain_key: ChainKey,
         config: &TamperLogConfig,
     ) -> Result<Self, TamperLogError> {
         let path = path.as_ref().to_owned();
 
-        let (prev_hash, sequence, bytes_written) = Self::recover_state(&path)?;
+        if path.exists() {
+            let verification = verify_chain(&path, &chain_key)?;
+            match verification.status {
+                ChainStatus::Intact | ChainStatus::Empty => {}
+                status => return ChainCompromisedSnafu { path, status }.fail(),
+            }
+        }
+
+        let (prev_hash, sequence, bytes_written) = Self::recover_state(&path, &chain_key)?;
 
         let file = OpenOptions::new()
             .create(true)
@@ -442,14 +537,18 @@ impl TamperLog {
             .open(&path)
             .context(IoSnafu { path: &path })?;
 
-        Ok(Self {
+        let log = Self {
             writer: BufWriter::new(file),
             path,
             prev_hash,
             sequence,
             bytes_written,
             max_file_bytes: config.max_file_bytes,
-        })
+            chain_key,
+        };
+        log.refresh_seal()?;
+
+        Ok(log)
     }
 
     /// Sets the rotation threshold in bytes (default: 100 MiB).
@@ -459,7 +558,8 @@ impl TamperLog {
         self
     }
 
-    /// Returns the hash of the last written entry (or `[0u8; 32]` for a fresh log).
+    /// Returns the hash of the last written entry (or the keyed genesis
+    /// root for a fresh log).
     pub const fn last_hash(&self) -> &[u8; 32] {
         &self.prev_hash
     }
@@ -469,7 +569,8 @@ impl TamperLog {
         self.sequence
     }
 
-    /// Appends an event entry, flushes, and returns the sequence number assigned.
+    /// Appends an event entry, flushes, refreshes the truncation seal,
+    /// and returns the sequence number assigned.
     ///
     /// Triggers file rotation if `bytes_written` exceeds `max_file_bytes`.
     ///
@@ -484,7 +585,7 @@ impl TamperLog {
             kind,
         };
 
-        let (wire, hash) = encode_entry(&entry, &self.prev_hash)?;
+        let (wire, hash) = encode_entry(&entry, &self.prev_hash, &self.chain_key)?;
         self.writer
             .write_all(&wire)
             .context(IoSnafu { path: &self.path })?;
@@ -494,6 +595,8 @@ impl TamperLog {
         self.prev_hash = hash;
         self.sequence += 1;
         self.bytes_written += wire.len() as u64; // SAFETY: wire.len() <= 4 + MAX_ENTRY_BYTES + 32; fits u64 trivially
+
+        self.refresh_seal()?;
 
         if self.bytes_written > self.max_file_bytes {
             self.rotate()?;
@@ -515,20 +618,32 @@ impl TamperLog {
     // Private helpers
     // -----------------------------------------------------------------------
 
+    /// Rewrites the sidecar seal to authenticate the log's current state.
+    fn refresh_seal(&self) -> Result<(), TamperLogError> {
+        seal::write_seal(&self.path, &self.chain_key, self.sequence)
+    }
+
     /// Reads an existing log file to recover `(prev_hash, next_sequence, bytes_written)`.
-    fn recover_state(path: &Path) -> Result<([u8; 32], u64, u64), TamperLogError> {
+    ///
+    /// Trusts stored hashes structurally (no re-verification) — callers
+    /// that need cryptographic assurance the file was not tampered with
+    /// must call [`verify_chain`] first, as [`Self::open_with_config`] does.
+    fn recover_state(
+        path: &Path,
+        chain_key: &ChainKey,
+    ) -> Result<([u8; 32], u64, u64), TamperLogError> {
         if !path.exists() {
-            return Ok(([0u8; 32], 0, 0));
+            return Ok((seal::genesis_hash(chain_key), 0, 0));
         }
 
         let file = File::open(path).context(IoSnafu { path })?;
         let file_len = file.metadata().context(IoSnafu { path })?.len();
         if file_len == 0 {
-            return Ok(([0u8; 32], 0, 0));
+            return Ok((seal::genesis_hash(chain_key), 0, 0));
         }
 
         let mut reader = BufReader::new(file);
-        let mut prev_hash = [0u8; 32];
+        let mut prev_hash = seal::genesis_hash(chain_key);
         let mut sequence: u64 = 0;
         let mut bytes_read: u64 = 0;
 
@@ -571,7 +686,9 @@ impl TamperLog {
         Ok((prev_hash, sequence, bytes_read))
     }
 
-    /// Renames the current log file to `{stem}.{n}.log` and opens a fresh one.
+    /// Renames the current log file to `{stem}.{n}.log` (and its seal
+    /// sidecar alongside it) and opens a fresh one, keyed the same as the
+    /// original.
     fn rotate(&mut self) -> Result<(), TamperLogError> {
         self.writer.flush().context(IoSnafu { path: &self.path })?;
 
@@ -579,6 +696,7 @@ impl TamperLog {
         let rotated = rotation_path(&self.path, n);
 
         std::fs::rename(&self.path, &rotated).context(IoSnafu { path: &self.path })?;
+        seal::rename_seal(&self.path, &rotated)?;
 
         let file = OpenOptions::new()
             .create(true)
@@ -587,9 +705,11 @@ impl TamperLog {
             .context(IoSnafu { path: &self.path })?;
 
         self.writer = BufWriter::new(file);
-        self.prev_hash = [0u8; 32];
+        self.prev_hash = seal::genesis_hash(&self.chain_key);
         self.sequence = 0;
         self.bytes_written = 0;
+
+        self.refresh_seal()?;
 
         Ok(())
     }

--- a/crates/koinon/src/tamper_log_seal.rs
+++ b/crates/koinon/src/tamper_log_seal.rs
@@ -1,0 +1,348 @@
+//! Chain key and truncation-seal machinery for [`super::TamperLog`].
+//!
+//! Keying the hash chain closes the unkeyed, self-rooted forgery gap: with
+//! the old scheme anyone holding the plaintext log could recompute a fully
+//! valid chain rooted at the public `[0u8; 32]` genesis. [`ChainKey`] makes
+//! that recomputation require a secret.
+//!
+//! The sidecar seal closes the complementary gap: trailing truncation. A
+//! hash chain alone cannot detect a deleted tail — any prefix of a valid
+//! chain is itself internally consistent, so reading to EOF looks
+//! identical whether the file legitimately ends there or was cut short.
+//! [`write_seal`] persists an authenticated entry count beside the log,
+//! refreshed on every open and append; [`read_seal`] re-authenticates it
+//! during verification so [`super::verify_chain`] can tell "ends here" from
+//! "was made to look like it ends here." The MAC covers the count alone —
+//! content integrity for every entry up to that count is already the hash
+//! chain's job, not the seal's.
+
+use std::fmt;
+use std::fs::{self, File};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use snafu::ResultExt;
+use subtle::ConstantTimeEq;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::{IoSnafu, TamperLogError};
+
+/// Length in bytes of a [`ChainKey`].
+pub const CHAIN_KEY_LEN: usize = 32;
+
+/// Domain-separation tag for the keyed genesis root.
+const GENESIS_DOMAIN: &[u8] = b"koinon/tamper-log/genesis/v1";
+
+/// Domain-separation tag for the seal MAC.
+const SEAL_DOMAIN: &[u8] = b"koinon/tamper-log/seal/v1";
+
+/// Length in bytes of the on-disk seal entry-count field.
+const SEAL_COUNT_LEN: usize = 8;
+
+/// Length in bytes of the on-disk seal MAC.
+const SEAL_MAC_LEN: usize = 32;
+
+/// Total on-disk seal file length: count || MAC.
+const SEAL_FILE_LEN: usize = SEAL_COUNT_LEN + SEAL_MAC_LEN;
+
+/// Secret key that binds a tamper log's hash chain to its owner.
+///
+/// Every link in the chain is keyed with [`blake3::Hasher::new_keyed`]
+/// rather than the public unkeyed hasher, and the genesis root is
+/// `blake3::keyed_hash` over a domain tag rather than a public constant.
+/// Without this key an attacker who edits, deletes, or rewrites entries
+/// cannot recompute a chain that re-validates.
+///
+/// Zeroized on drop. `Debug` output is redacted. Equality is
+/// constant-time.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct ChainKey {
+    bytes: [u8; CHAIN_KEY_LEN],
+}
+
+impl ChainKey {
+    /// Wraps raw key bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; CHAIN_KEY_LEN]) -> Self {
+        Self { bytes }
+    }
+
+    /// Returns the raw key material.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; CHAIN_KEY_LEN] {
+        &self.bytes
+    }
+}
+
+impl PartialEq for ChainKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes.ct_eq(&other.bytes).into()
+    }
+}
+
+impl Eq for ChainKey {}
+
+impl fmt::Debug for ChainKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ChainKey([REDACTED])")
+    }
+}
+
+/// Computes the keyed genesis root fed to the chain's first entry as
+/// `prev_hash`.
+///
+/// Rooting this at a keyed value — rather than the public `[0u8; 32]` the
+/// prior scheme used — means a verifier without `chain_key` cannot even
+/// start a matching chain, let alone extend one.
+pub(super) fn genesis_hash(chain_key: &ChainKey) -> [u8; 32] {
+    blake3::keyed_hash(chain_key.as_bytes(), GENESIS_DOMAIN).into()
+}
+
+/// Result of reading and authenticating a sidecar seal file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SealState {
+    /// No seal file exists at the sidecar path.
+    Absent,
+    /// A seal file exists but its MAC does not authenticate under
+    /// `chain_key` — corrupted, forged, or written under a different key.
+    Invalid,
+    /// A seal file exists and its MAC authenticates; carries the sealed
+    /// entry count.
+    Valid(u64),
+}
+
+/// Derives the sidecar seal path for a log file: `{path}.seal`.
+pub(super) fn seal_path(log_path: &Path) -> PathBuf {
+    let mut name = log_path.as_os_str().to_owned();
+    name.push(".seal");
+    PathBuf::from(name)
+}
+
+/// Computes the authenticated MAC over `entry_count`, domain-separated
+/// from entry and genesis hashing.
+fn seal_mac(chain_key: &ChainKey, entry_count: u64) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new_keyed(chain_key.as_bytes());
+    hasher.update(SEAL_DOMAIN);
+    hasher.update(&entry_count.to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// Reads and authenticates the seal sidecar for `log_path`.
+pub(super) fn read_seal(log_path: &Path, chain_key: &ChainKey) -> SealState {
+    let Ok(bytes) = fs::read(seal_path(log_path)) else {
+        return SealState::Absent;
+    };
+    let Ok(raw) = <[u8; SEAL_FILE_LEN]>::try_from(bytes.as_slice()) else {
+        return SealState::Invalid;
+    };
+
+    let mut count_bytes = [0u8; SEAL_COUNT_LEN];
+    count_bytes.copy_from_slice(&raw[..SEAL_COUNT_LEN]);
+    let count = u64::from_le_bytes(count_bytes);
+
+    let mut stored_mac = [0u8; SEAL_MAC_LEN];
+    stored_mac.copy_from_slice(&raw[SEAL_COUNT_LEN..]);
+
+    let expected_mac = seal_mac(chain_key, count);
+    if bool::from(expected_mac.ct_eq(&stored_mac)) {
+        SealState::Valid(count)
+    } else {
+        SealState::Invalid
+    }
+}
+
+/// Writes the seal sidecar for `log_path`, authenticating `entry_count`.
+///
+/// Writes to a `.tmp` sibling and renames into place so a concurrent
+/// reader (or a crash mid-write) never observes a partially-written seal.
+pub(super) fn write_seal(
+    log_path: &Path,
+    chain_key: &ChainKey,
+    entry_count: u64,
+) -> Result<(), TamperLogError> {
+    let target = seal_path(log_path);
+    let mut tmp_name = target.clone().into_os_string();
+    tmp_name.push(".tmp");
+    let tmp = PathBuf::from(tmp_name);
+
+    let mac = seal_mac(chain_key, entry_count);
+    let mut payload = Vec::with_capacity(SEAL_FILE_LEN);
+    payload.extend_from_slice(&entry_count.to_le_bytes());
+    payload.extend_from_slice(&mac);
+
+    {
+        let mut file = File::create(&tmp).context(IoSnafu { path: tmp.clone() })?;
+        file.write_all(&payload)
+            .context(IoSnafu { path: tmp.clone() })?;
+        file.sync_all().context(IoSnafu { path: tmp.clone() })?;
+    }
+    fs::rename(&tmp, &target).context(IoSnafu { path: target })?;
+
+    Ok(())
+}
+
+/// Renames the seal sidecar alongside a rotated log file.
+///
+/// Best-effort on the source side: a log rotated before its first append
+/// ever refreshed a seal has none to preserve, which is not an error.
+pub(super) fn rename_seal(from_log: &Path, to_log: &Path) -> Result<(), TamperLogError> {
+    let from = seal_path(from_log);
+    if !from.exists() {
+        return Ok(());
+    }
+    let to = seal_path(to_log);
+    fs::rename(&from, &to).context(IoSnafu { path: to })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panics and unwraps acceptable in assertions"
+)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> ChainKey {
+        ChainKey::from_bytes([byte; CHAIN_KEY_LEN])
+    }
+
+    #[test]
+    fn chain_key_from_bytes_round_trips() {
+        let bytes = [0x42; CHAIN_KEY_LEN];
+        let k = ChainKey::from_bytes(bytes);
+        assert_eq!(k.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn chain_key_debug_is_redacted() {
+        let k = key(0x11);
+        assert_eq!(format!("{k:?}"), "ChainKey([REDACTED])");
+    }
+
+    #[test]
+    fn chain_key_eq_compares_by_value() {
+        let a = ChainKey::from_bytes([0xAA; CHAIN_KEY_LEN]);
+        let b = ChainKey::from_bytes([0xAA; CHAIN_KEY_LEN]);
+        let c = ChainKey::from_bytes([0xBB; CHAIN_KEY_LEN]);
+        assert_eq!(a, b, "keys built from identical bytes must compare equal");
+        assert_ne!(
+            a, c,
+            "keys built from different bytes must not compare equal"
+        );
+    }
+
+    #[test]
+    fn genesis_hash_is_deterministic() {
+        let k = key(0x01);
+        let first_call = genesis_hash(&k);
+        let second_call = genesis_hash(&k);
+        assert_eq!(
+            first_call, second_call,
+            "genesis_hash must be a pure function of the key"
+        );
+    }
+
+    #[test]
+    fn genesis_hash_differs_per_key() {
+        assert_ne!(genesis_hash(&key(0x01)), genesis_hash(&key(0x02)));
+    }
+
+    #[test]
+    fn seal_path_appends_dot_seal() {
+        let p = seal_path(Path::new("/tmp/foo/tamper.log"));
+        assert_eq!(p, Path::new("/tmp/foo/tamper.log.seal"));
+    }
+
+    #[test]
+    fn write_then_read_seal_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+        let k = key(0x55);
+
+        write_seal(&log_path, &k, 7).unwrap();
+        let state = read_seal(&log_path, &k);
+        assert_eq!(state, SealState::Valid(7));
+    }
+
+    #[test]
+    fn read_seal_missing_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("no-seal.log");
+        let state = read_seal(&log_path, &key(0x01));
+        assert_eq!(state, SealState::Absent);
+    }
+
+    #[test]
+    fn read_seal_wrong_key_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+
+        write_seal(&log_path, &key(0xAA), 3).unwrap();
+        let state = read_seal(&log_path, &key(0xBB));
+        assert_eq!(state, SealState::Invalid);
+    }
+
+    #[test]
+    fn read_seal_tampered_mac_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+        let k = key(0x77);
+
+        write_seal(&log_path, &k, 4).unwrap();
+        let mut bytes = fs::read(seal_path(&log_path)).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        fs::write(seal_path(&log_path), &bytes).unwrap();
+
+        let state = read_seal(&log_path, &k);
+        assert_eq!(state, SealState::Invalid);
+    }
+
+    #[test]
+    fn read_seal_tampered_count_is_invalid() {
+        // WHY: the MAC covers the count field itself — an attacker who
+        // edits just the count (without the key) cannot produce a
+        // matching MAC, so a hand-edited count is caught too, not just a
+        // hand-edited MAC.
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+        let k = key(0x66);
+
+        write_seal(&log_path, &k, 4).unwrap();
+        let mut bytes = fs::read(seal_path(&log_path)).unwrap();
+        bytes[0] = 99; // low byte of the little-endian count
+        fs::write(seal_path(&log_path), &bytes).unwrap();
+
+        let state = read_seal(&log_path, &k);
+        assert_eq!(state, SealState::Invalid);
+    }
+
+    #[test]
+    fn rename_seal_moves_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let from = dir.path().join("a.log");
+        let to = dir.path().join("a.1.log");
+        write_seal(&from, &key(0x01), 1).unwrap();
+
+        rename_seal(&from, &to).unwrap();
+
+        assert!(!seal_path(&from).exists());
+        assert!(seal_path(&to).exists());
+    }
+
+    #[test]
+    fn rename_seal_is_a_no_op_without_a_source_seal() {
+        let dir = tempfile::tempdir().unwrap();
+        let from = dir.path().join("a.log");
+        let to = dir.path().join("a.1.log");
+
+        rename_seal(&from, &to).unwrap();
+
+        assert!(!seal_path(&to).exists());
+    }
+}

--- a/crates/koinon/src/tamper_log_tests.rs
+++ b/crates/koinon/src/tamper_log_tests.rs
@@ -6,6 +6,14 @@ use ulid::Ulid;
 
 use super::*;
 
+fn test_key() -> ChainKey {
+    ChainKey::from_bytes([0x5A; CHAIN_KEY_LEN])
+}
+
+fn other_key() -> ChainKey {
+    ChainKey::from_bytes([0xC3; CHAIN_KEY_LEN])
+}
+
 fn signal_kind() -> LogEntryKind {
     LogEntryKind::SignalObserved {
         signal_id: SignalId::new(),
@@ -53,12 +61,12 @@ fn append_single_entry_and_verify_fields() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     let seq = log.append(signal_kind()).unwrap();
     assert_eq!(seq, 0);
     assert_eq!(log.entry_count(), 1);
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert_eq!(result.entries_verified, 1);
     assert_eq!(result.status, ChainStatus::Intact);
 }
@@ -68,13 +76,13 @@ fn append_100_entries_chain_intact() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     for i in 0..100_u64 {
         let seq = log.append(alert_kind()).unwrap();
         assert_eq!(seq, i);
     }
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert_eq!(result.entries_verified, 100);
     assert_eq!(result.status, ChainStatus::Intact);
 }
@@ -85,7 +93,7 @@ fn empty_file_returns_empty_status() {
     let path = dir.path().join("empty.log");
     File::create(&path).unwrap();
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert_eq!(result.status, ChainStatus::Empty);
     assert_eq!(result.entries_verified, 0);
 }
@@ -96,21 +104,21 @@ fn recovery_continues_chain_correctly() {
     let path = dir.path().join("recover.log");
 
     {
-        let mut log = TamperLog::open(&path).unwrap();
+        let mut log = TamperLog::open(&path, test_key()).unwrap();
         for _ in 0..5 {
             log.append(action_kind()).unwrap();
         }
     }
 
     {
-        let mut log = TamperLog::open(&path).unwrap();
+        let mut log = TamperLog::open(&path, test_key()).unwrap();
         assert_eq!(log.entry_count(), 5);
         for _ in 0..5 {
             log.append(config_kind()).unwrap();
         }
     }
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert_eq!(result.entries_verified, 10);
     assert_eq!(result.status, ChainStatus::Intact);
 }
@@ -142,7 +150,7 @@ fn flip_byte_in_cbor_payload_detected() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("tamper.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     for _ in 0..10 {
         log.append(signal_kind()).unwrap();
     }
@@ -154,7 +162,7 @@ fn flip_byte_in_cbor_payload_detected() {
     data[off + 4] ^= 0xFF;
     std::fs::write(&path, &data).unwrap();
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert!(matches!(
         result.status,
         ChainStatus::Broken { sequence: 5, .. }
@@ -166,7 +174,7 @@ fn flip_byte_in_hash_detected() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("tamper_hash.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     for _ in 0..10 {
         log.append(entity_kind()).unwrap();
     }
@@ -180,7 +188,7 @@ fn flip_byte_in_hash_detected() {
     data[off + 4 + payload_len] ^= 0x01;
     std::fs::write(&path, &data).unwrap();
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     // Entry 3's stored hash is wrong → broken at entry 3.
     assert!(matches!(result.status, ChainStatus::Broken { .. }));
 }
@@ -190,7 +198,7 @@ fn truncated_file_returns_corrupted() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("truncate.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     for _ in 0..10 {
         log.append(config_kind()).unwrap();
     }
@@ -200,7 +208,7 @@ fn truncated_file_returns_corrupted() {
     let truncated = &data[..data.len() - 20];
     std::fs::write(&path, truncated).unwrap();
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert!(matches!(result.status, ChainStatus::Corrupted { .. }));
 }
 
@@ -209,7 +217,7 @@ fn zero_out_last_hash_detected() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("zerohash.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     for _ in 0..10 {
         log.append(alert_kind()).unwrap();
     }
@@ -222,8 +230,182 @@ fn zero_out_last_hash_detected() {
     }
     std::fs::write(&path, &data).unwrap();
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert!(matches!(result.status, ChainStatus::Broken { .. }));
+}
+
+// -----------------------------------------------------------------------
+// Truncation & keying (akroasis#213)
+// -----------------------------------------------------------------------
+
+#[test]
+fn removing_final_entry_reports_non_intact() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("truncate_tail.log");
+
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
+    for _ in 0..10 {
+        log.append(alert_kind()).unwrap();
+    }
+    drop(log);
+
+    let data = std::fs::read(&path).unwrap();
+    let cutoff = entry_offset(&data, 9);
+    std::fs::write(&path, &data[..cutoff]).unwrap();
+
+    let result = verify_chain(&path, &test_key()).unwrap();
+    assert!(
+        !matches!(result.status, ChainStatus::Intact),
+        "removing the final entry must not verify as Intact"
+    );
+    assert!(
+        matches!(
+            result.status,
+            ChainStatus::Truncated {
+                sealed_entries: Some(10)
+            }
+        ),
+        "expected Truncated{{sealed_entries: Some(10)}}, got {:?}",
+        result.status
+    );
+}
+
+#[test]
+fn wiping_all_entries_is_not_reported_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wipe_all.log");
+
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
+    for _ in 0..5 {
+        log.append(config_kind()).unwrap();
+    }
+    drop(log);
+
+    std::fs::write(&path, []).unwrap();
+
+    let result = verify_chain(&path, &test_key()).unwrap();
+    assert_ne!(
+        result.status,
+        ChainStatus::Empty,
+        "wiping all entries while the seal still claims 5 must not read as Empty"
+    );
+    assert!(matches!(
+        result.status,
+        ChainStatus::Truncated {
+            sealed_entries: Some(5)
+        }
+    ));
+}
+
+#[test]
+fn open_refuses_to_resume_a_truncated_chain() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("resume_truncated.log");
+
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
+    for _ in 0..6 {
+        log.append(action_kind()).unwrap();
+    }
+    drop(log);
+
+    let data = std::fs::read(&path).unwrap();
+    let cutoff = entry_offset(&data, 5);
+    std::fs::write(&path, &data[..cutoff]).unwrap();
+
+    let result = TamperLog::open(&path, test_key());
+    assert!(
+        matches!(result, Err(TamperLogError::ChainCompromised { .. })),
+        "opening a chain whose tail was truncated must refuse to resume, not silently launder it"
+    );
+}
+
+#[test]
+fn verify_with_wrong_key_rejects_chain() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wrong_key.log");
+
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
+    for _ in 0..5 {
+        log.append(signal_kind()).unwrap();
+    }
+    drop(log);
+
+    let result = verify_chain(&path, &other_key()).unwrap();
+    assert!(
+        !matches!(result.status, ChainStatus::Intact),
+        "verifying with the wrong key must not report Intact"
+    );
+}
+
+#[test]
+fn forged_unkeyed_chain_rejected_by_keyed_verification() {
+    // WHY: simulates an attacker without the chain key, who can only
+    // recompute the OLD unkeyed-BLAKE3-over-a-public-genesis scheme this
+    // module used before akroasis#213.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("forged_unkeyed.log");
+
+    let entry = LogEntry {
+        sequence: 0,
+        timestamp_ms: 0,
+        kind: signal_kind(),
+    };
+    let mut cbor_bytes = Vec::new();
+    ciborium::into_writer(&entry, &mut cbor_bytes).unwrap();
+
+    let prev_hash = [0u8; 32]; // the old public genesis constant
+    let mut hasher = blake3::Hasher::new(); // the old UNKEYED hasher
+    hasher.update(&cbor_bytes);
+    hasher.update(&prev_hash);
+    let forged_hash: [u8; 32] = hasher.finalize().into();
+
+    let mut wire = Vec::new();
+    wire.extend_from_slice(&(u32::try_from(cbor_bytes.len()).unwrap()).to_le_bytes());
+    wire.extend_from_slice(&cbor_bytes);
+    wire.extend_from_slice(&forged_hash);
+    std::fs::write(&path, &wire).unwrap();
+
+    let result = verify_chain(&path, &test_key()).unwrap();
+    assert!(
+        matches!(result.status, ChainStatus::Broken { .. }),
+        "a chain forged with the old unkeyed scheme must not validate under keyed verification"
+    );
+}
+
+#[test]
+fn forged_seal_without_key_is_not_trusted() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("forged_seal.log");
+
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
+    for _ in 0..8 {
+        log.append(entity_kind()).unwrap();
+    }
+    drop(log);
+
+    // Attacker truncates off the last 3 entries...
+    let data = std::fs::read(&path).unwrap();
+    let cutoff = entry_offset(&data, 5);
+    std::fs::write(&path, &data[..cutoff]).unwrap();
+
+    // ...and, lacking the real chain key, forges a replacement seal
+    // claiming the new (truncated) count of 5 under a key they guessed.
+    let forged_key = other_key();
+    let mut mac_hasher = blake3::Hasher::new_keyed(forged_key.as_bytes());
+    mac_hasher.update(b"koinon/tamper-log/seal/v1");
+    mac_hasher.update(&5_u64.to_le_bytes());
+    let forged_mac: [u8; 32] = mac_hasher.finalize().into();
+
+    let mut forged_seal = Vec::new();
+    forged_seal.extend_from_slice(&5_u64.to_le_bytes());
+    forged_seal.extend_from_slice(&forged_mac);
+    std::fs::write(seal::seal_path(&path), &forged_seal).unwrap();
+
+    let result = verify_chain(&path, &test_key()).unwrap();
+    assert!(
+        !matches!(result.status, ChainStatus::Intact),
+        "a forged seal claiming a matching count under the wrong key must not be trusted as Intact"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -235,7 +417,9 @@ fn rotation_triggers_at_threshold() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("rotate.log");
 
-    let mut log = TamperLog::open(&path).unwrap().with_max_file_bytes(500);
+    let mut log = TamperLog::open(&path, test_key())
+        .unwrap()
+        .with_max_file_bytes(500);
     for _ in 0..20 {
         log.append(alert_kind()).unwrap();
     }
@@ -250,7 +434,9 @@ fn rotated_file_named_correctly() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("mylog.log");
 
-    let mut log = TamperLog::open(&path).unwrap().with_max_file_bytes(200);
+    let mut log = TamperLog::open(&path, test_key())
+        .unwrap()
+        .with_max_file_bytes(200);
     for _ in 0..15 {
         log.append(action_kind()).unwrap();
     }
@@ -264,13 +450,15 @@ fn new_file_after_rotation_has_fresh_chain() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("chain.log");
 
-    let mut log = TamperLog::open(&path).unwrap().with_max_file_bytes(300);
+    let mut log = TamperLog::open(&path, test_key())
+        .unwrap()
+        .with_max_file_bytes(300);
     for _ in 0..20 {
         log.append(signal_kind()).unwrap();
     }
     drop(log);
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert!(
         matches!(result.status, ChainStatus::Intact | ChainStatus::Empty),
         "new file must be intact or empty"
@@ -282,7 +470,9 @@ fn pre_rotation_file_verifies_independently() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("pre.log");
 
-    let mut log = TamperLog::open(&path).unwrap().with_max_file_bytes(300);
+    let mut log = TamperLog::open(&path, test_key())
+        .unwrap()
+        .with_max_file_bytes(300);
     for _ in 0..20 {
         log.append(entity_kind()).unwrap();
     }
@@ -290,7 +480,7 @@ fn pre_rotation_file_verifies_independently() {
 
     let rotated = dir.path().join("pre.1.log");
     if rotated.exists() {
-        let result = verify_chain(&rotated).unwrap();
+        let result = verify_chain(&rotated, &test_key()).unwrap();
         assert_eq!(result.status, ChainStatus::Intact);
     }
 }
@@ -300,7 +490,9 @@ fn multiple_rotations_sequential_numbering() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("multi.log");
 
-    let mut log = TamperLog::open(&path).unwrap().with_max_file_bytes(150);
+    let mut log = TamperLog::open(&path, test_key())
+        .unwrap()
+        .with_max_file_bytes(150);
     for _ in 0..60 {
         log.append(config_kind()).unwrap();
     }
@@ -325,11 +517,11 @@ fn single_entry_chain_valid() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("single.log");
 
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
     log.append(signal_kind()).unwrap();
     drop(log);
 
-    let result = verify_chain(&path).unwrap();
+    let result = verify_chain(&path, &test_key()).unwrap();
     assert_eq!(result.status, ChainStatus::Intact);
     assert_eq!(result.entries_verified, 1);
 }
@@ -342,7 +534,7 @@ fn cbor_roundtrip_signal_observed() {
         kind: signal_kind(),
     };
     let prev = [0u8; 32];
-    let (wire, _) = encode_entry(&entry, &prev).unwrap();
+    let (wire, _) = encode_entry(&entry, &prev, &test_key()).unwrap();
     let (decoded, _) = decode_entry(&wire).unwrap();
     assert_eq!(entry, decoded);
 }
@@ -354,7 +546,7 @@ fn cbor_roundtrip_entity_created() {
         timestamp_ms: 2_000_000,
         kind: entity_kind(),
     };
-    let (wire, _) = encode_entry(&entry, &[0u8; 32]).unwrap();
+    let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
     let (decoded, _) = decode_entry(&wire).unwrap();
     assert_eq!(entry, decoded);
 }
@@ -366,7 +558,7 @@ fn cbor_roundtrip_config_changed() {
         timestamp_ms: 3_000_000,
         kind: config_kind(),
     };
-    let (wire, _) = encode_entry(&entry, &[0u8; 32]).unwrap();
+    let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
     let (decoded, _) = decode_entry(&wire).unwrap();
     assert_eq!(entry, decoded);
 }
@@ -378,7 +570,7 @@ fn cbor_roundtrip_alert_raised() {
         timestamp_ms: 4_000_000,
         kind: alert_kind(),
     };
-    let (wire, _) = encode_entry(&entry, &[0u8; 32]).unwrap();
+    let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
     let (decoded, _) = decode_entry(&wire).unwrap();
     assert_eq!(entry, decoded);
 }
@@ -390,7 +582,7 @@ fn cbor_roundtrip_action_taken() {
         timestamp_ms: 5_000_000,
         kind: action_kind(),
     };
-    let (wire, _) = encode_entry(&entry, &[0u8; 32]).unwrap();
+    let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
     let (decoded, _) = decode_entry(&wire).unwrap();
     assert_eq!(entry, decoded);
 }
@@ -411,7 +603,7 @@ fn large_metadata_no_truncation() {
         timestamp_ms: 0,
         kind,
     };
-    let (wire, _) = encode_entry(&entry, &[0u8; 32]).unwrap();
+    let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
     let (decoded, _) = decode_entry(&wire).unwrap();
     assert_eq!(entry, decoded);
 }
@@ -441,7 +633,7 @@ fn configured_rotation_observably_changes_trigger() {
     let cfg = TamperLogConfig {
         max_file_bytes: 300,
     };
-    let mut log = TamperLog::open_with_config(&path, &cfg).unwrap();
+    let mut log = TamperLog::open_with_config(&path, test_key(), &cfg).unwrap();
     for _ in 0..30 {
         log.append(alert_kind()).unwrap();
     }

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use compact_str::CompactString;
 use fs2::FileExt;
 use jiff::Timestamp;
-use koinon::{LogEntryKind, TamperLog};
+use koinon::{ChainKey, LogEntryKind, TamperLog, VerificationResult};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
@@ -36,6 +36,14 @@ const DATA_DIR: &str = "data";
 
 /// Name of the tamper-evident vault audit log within the vault directory.
 const TAMPER_LOG_FILE: &str = "tamper.log";
+
+/// Domain-separation tag for deriving the tamper log's [`ChainKey`] from
+/// the vault's [`VaultKey`].
+///
+/// Reuses the vault's existing secret rather than requiring a second one
+/// to manage: the derivation is a one-way keyed hash, so recovering the
+/// vault key from a leaked chain key is infeasible.
+const CHAIN_KEY_DOMAIN: &[u8] = b"kryphos/tamper-log/chain-key/v1";
 
 /// On-disk vault header stored as JSON.
 #[derive(Debug, Serialize, Deserialize)]
@@ -467,8 +475,28 @@ impl Vault {
         self.path.join(TAMPER_LOG_FILE)
     }
 
+    /// Verifies the vault's tamper-evident mutation audit log.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VaultError::TamperLog`] if the log file cannot be read.
+    pub fn verify_tamper_log(&self) -> Result<VerificationResult, VaultError> {
+        koinon::verify_chain(self.tamper_log_path(), &self.chain_key()).context(TamperLogSnafu)
+    }
+
+    /// Derives this vault's tamper-log chain key from its [`VaultKey`].
+    ///
+    /// A fresh derivation on every call, not a stored copy: the vault
+    /// holds only the `VaultKey`, and every caller that needs to open or
+    /// verify the tamper log derives the chain key from it on demand —
+    /// no second secret to generate, store, or rotate.
+    fn chain_key(&self) -> ChainKey {
+        ChainKey::from_bytes(blake3::keyed_hash(self.key.as_bytes(), CHAIN_KEY_DOMAIN).into())
+    }
+
     fn append_vault_audit(&self, name: &str, operation: &str) -> Result<(), VaultError> {
-        let mut log = TamperLog::open(self.tamper_log_path()).context(TamperLogSnafu)?;
+        let mut log =
+            TamperLog::open(self.tamper_log_path(), self.chain_key()).context(TamperLogSnafu)?;
         log.append(LogEntryKind::VaultMutation {
             credential_name: CompactString::from(name),
             operation: CompactString::from(operation),

--- a/crates/kryphos/tests/tamper_log_signing.rs
+++ b/crates/kryphos/tests/tamper_log_signing.rs
@@ -7,8 +7,12 @@
 
 use compact_str::CompactString;
 
-use koinon::tamper_log::{LogEntry, LogEntryKind, TamperLog, encode_entry};
+use koinon::tamper_log::{ChainKey, LogEntry, LogEntryKind, TamperLog, encode_entry};
 use kryphos::InstallationIdentity;
+
+const fn test_key() -> ChainKey {
+    ChainKey::from_bytes([0x4B; 32])
+}
 
 #[test]
 fn sign_tamper_log_entry_and_verify() {
@@ -16,7 +20,7 @@ fn sign_tamper_log_entry_and_verify() {
     let path = dir.path().join("signed.log");
 
     let identity = InstallationIdentity::generate();
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
 
     let kind = LogEntryKind::ActionTaken {
         actor: CompactString::from("operator"),
@@ -58,7 +62,7 @@ fn sign_multiple_entries_each_verifiable() {
     let path = dir.path().join("multi_signed.log");
 
     let identity = InstallationIdentity::generate();
-    let mut log = TamperLog::open(&path).unwrap();
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
 
     let mut signatures = Vec::new();
     let mut hashes = Vec::new();
@@ -100,7 +104,7 @@ fn encode_entry_hash_matches_sign_entry_input() {
         },
     };
 
-    let (_wire, entry_hash) = encode_entry(&entry, &prev_hash).unwrap();
+    let (_wire, entry_hash) = encode_entry(&entry, &prev_hash, &test_key()).unwrap();
     let signature = identity.sign_entry(&entry_hash);
 
     assert!(

--- a/crates/kryphos/tests/vault_tamper_audit.rs
+++ b/crates/kryphos/tests/vault_tamper_audit.rs
@@ -2,13 +2,28 @@
 
 #![expect(
     clippy::unwrap_used,
+    clippy::indexing_slicing,
     reason = "integration test — panics are the correct failure mode"
 )]
 
-use koinon::{ChainStatus, verify_chain};
+use koinon::ChainStatus;
 use kryphos::{CredentialType, Vault};
 
 const TEST_PASSPHRASE: &[u8] = b"correct horse battery staple";
+
+/// Walks wire-format bytes and returns the byte offset of entry `target_idx`.
+///
+/// Mirrors `koinon::tamper_log`'s own private test helper — kryphos has no
+/// access to it, and the wire format (`[4-byte LE len][cbor][32-byte hash]`)
+/// is part of the documented on-disk contract, not an implementation detail.
+fn entry_offset(data: &[u8], target_idx: usize) -> usize {
+    let mut offset = 0usize;
+    for _ in 0..target_idx {
+        let len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4 + len + 32;
+    }
+    offset
+}
 
 #[test]
 fn vault_mutations_append_intact_tamper_log() {
@@ -16,7 +31,6 @@ fn vault_mutations_append_intact_tamper_log() {
     let vault_path = dir.path().join("audited-vault");
 
     let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
-    let log_path = vault.tamper_log_path();
 
     vault
         .add("incident-radio-key", CredentialType::RadioKey, b"secret-v1")
@@ -24,7 +38,38 @@ fn vault_mutations_append_intact_tamper_log() {
     vault.rotate("incident-radio-key", b"secret-v2").unwrap();
     vault.revoke("incident-radio-key").unwrap();
 
-    let result = verify_chain(&log_path).unwrap();
+    let result = vault.verify_tamper_log().unwrap();
     assert_eq!(result.status, ChainStatus::Intact);
     assert_eq!(result.entries_verified, 3);
+}
+
+#[test]
+fn truncated_vault_audit_log_is_detected() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("truncate-audit-vault");
+
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+    vault.add("k1", CredentialType::ApiKey, b"v1").unwrap();
+    vault.add("k2", CredentialType::ApiKey, b"v2").unwrap();
+    vault.rotate("k1", b"v1-new").unwrap();
+
+    let before = vault.verify_tamper_log().unwrap();
+    assert_eq!(before.status, ChainStatus::Intact);
+    assert_eq!(before.entries_verified, 3);
+
+    // Simulate an adversary with host/log write access deleting the final
+    // (most recent) entry — the canonical attack against an incident
+    // audit trail.
+    let log_path = vault.tamper_log_path();
+    let mut data = std::fs::read(&log_path).unwrap();
+    let cutoff = entry_offset(&data, 2);
+    data.truncate(cutoff);
+    std::fs::write(&log_path, &data).unwrap();
+
+    let after = vault.verify_tamper_log().unwrap();
+    assert!(
+        !matches!(after.status, ChainStatus::Intact),
+        "a truncated vault audit log must not verify as Intact, got {:?}",
+        after.status
+    );
 }


### PR DESCRIPTION
## Summary

`verify_chain` had two defects (akroasis#213, HIGH severity):

1. **Trailing truncation reported `Intact`.** Once at least one entry had parsed, reaching EOF returned `ChainStatus::Intact` unconditionally — no persisted entry count or sealed end-anchor existed to notice a missing tail. This is the exact attack an adversary with log/host write access uses to erase evidence of an intrusion.
2. **Unkeyed, self-rooted chain.** The chain was `BLAKE3(cbor || prev_hash)` rooted at the public constant `[0u8; 32]`. Anyone holding the plaintext log could recompute a fully valid chain after editing or deleting entries — no secret required.

## Fix

- **Keyed chain.** New `ChainKey` (32-byte, `Zeroize` + `ZeroizeOnDrop`, constant-time `Eq`, redacted `Debug`) in a sibling `crates/koinon/src/tamper_log_seal.rs` module (`#[path]`, same convention the file already used for its test split). The genesis root is `blake3::keyed_hash` over a domain-separated tag instead of the public constant; every per-entry hash uses `blake3::Hasher::new_keyed`. `TamperLog::open`/`::append` now require a `ChainKey`.
- **Truncation seal.** A sidecar `{log}.seal` file (8-byte LE entry count + 32-byte keyed MAC, domain-separated, atomic temp-then-rename write) is refreshed on every open and append. It authenticates the entry count independently of the chain's own tip hash — a hash chain's prefix is always internally self-consistent, so content integrity up to `entries_verified` is already the chain's job; the seal's only job is the count. `verify_chain` cross-checks the streamed count against the authenticated seal and returns a new `ChainStatus::Truncated { sealed_entries }` on any mismatch or unauthenticated seal, including wiping a log to zero bytes (which no longer reads as `Empty` once a seal claims a nonzero count).
- **Closes the laundering gap.** `TamperLog::open` now runs a full keyed `verify_chain` pass on an existing file before resuming, and refuses via a new `TamperLogError::ChainCompromised` unless the result is `Intact` or `Empty` — so a truncated chain can't be silently extended into a shorter-but-internally-consistent one.
- **Key sourcing.** `kryphos::Vault` derives the `ChainKey` from its existing `VaultKey` via a domain-separated `blake3::keyed_hash` (no second secret to generate/store/rotate), and gains `Vault::verify_tamper_log()`. Added `zeroize` + `subtle` to koinon (already workspace deps).

## Tests

New in `koinon`: `removing_final_entry_reports_non_intact`, `wiping_all_entries_is_not_reported_empty`, `open_refuses_to_resume_a_truncated_chain`, `verify_with_wrong_key_rejects_chain`, `forged_unkeyed_chain_rejected_by_keyed_verification`, `forged_seal_without_key_is_not_trusted`, plus unit coverage for the new seal module (key round-trip/redaction, seal write/read/tamper/rename).

New in `kryphos`: `truncated_vault_audit_log_is_detected` integration test (in `vault_tamper_audit.rs`); existing `vault_tamper_audit.rs`/`tamper_log_signing.rs` tests updated for the new `ChainKey`-carrying signatures.

Done-when criteria from #213 are met: removing the final entry from a log file makes `verify_chain` return a non-`Intact` status, and forging a chain (or a seal) that passes verification requires the key.

## Evidence

Full local gate green (fmt, workspace check, clippy `-D warnings`, `cargo nextest` — 793/793 passed, kanon lint 0 errors/0 warnings with 209 pre-existing suppressions unaffected):

```
Gate-Passed: kanon 0.1.10 +stages:fmt,check,clippy,nextest,lint sha:802d419af3989b6dca0c09d53c0d478b7840fbcb
```

`.kanon-lint-baseline.toml`: six pre-existing suppression entries (in `tamper_log.rs`, `tamper_log_tests.rs`, `storage.rs`) shifted line numbers because of the insertions above them — same rule/file/hash, corrected line numbers so they stay suppressed instead of resurfacing as false new violations from an unrelated insertion.

Closes #213
