### PR TITLE
fix(kerykeion): stop starving heartbeat/router-flush behind main recv() lock (#190)

### DIFF
--- a/crates/kerykeion/src/collector.rs
+++ b/crates/kerykeion/src/collector.rs
@@ -409,9 +409,7 @@ impl Collector for MeshCollector { // kanon:ignore ARCHITECTURE/trait-impl-coloc
                     tracing::info!("collector shutdown requested");
                     break;
                 }
-                result = async {
-                    primary_conn.lock().await.recv().await
-                } => {
+                result = recv_yielding(&*primary_conn) => {
                     match result {
                         Ok(from_radio) => {
                             // Update node_db for CLI display.
@@ -461,6 +459,41 @@ impl Collector for MeshCollector { // kanon:ignore ARCHITECTURE/trait-impl-coloc
 
         tracing::info!("collector shutdown complete");
         Ok(())
+    }
+}
+
+/// Bound on how long [`recv_yielding`] holds the connection lock during a
+/// single `recv()` poll before releasing it.
+const RECV_LOCK_YIELD: Duration = Duration::from_millis(250);
+
+/// Awaits the next inbound frame on `conn` without holding its lock for the
+/// full, potentially-indefinite duration of `MeshConnection::recv()`.
+///
+/// akroasis#190: on a quiet mesh `recv()` blocks until the next frame
+/// arrives  -  unbounded. The previous `conn.lock().await.recv().await`
+/// pattern held the `MutexGuard` across that whole wait, starving every
+/// send-only task sharing the same `Arc<Mutex<ConnectionHandle>>`  -  heartbeat,
+/// discovery, and router-flush all only ever need the lock briefly to
+/// `send()`. This polls `recv()` in `RECV_LOCK_YIELD`-bounded windows,
+/// dropping the guard between polls so a waiting sender is guaranteed a
+/// turn (`tokio::sync::Mutex` is FIFO-fair: a task already queued on
+/// `lock()` is served before a fresh, uncontended re-lock from this loop).
+///
+/// # Cancellation safety
+///
+/// Both transports read through a `Framed`, whose internal buffer persists
+/// across a cancelled poll, so a timed-out window loses no already-buffered
+/// bytes  -  the next iteration resumes cleanly.
+async fn recv_yielding<C>(conn: &Mutex<C>) -> Result<FromRadio, Error>
+where
+    C: MeshConnection,
+{
+    loop {
+        let mut guard = conn.lock().await;
+        match tokio::time::timeout(RECV_LOCK_YIELD, guard.recv()).await {
+            Ok(result) => return result,
+            Err(_elapsed) => drop(guard),
+        }
     }
 }
 

--- a/crates/kerykeion/src/collector_tests.rs
+++ b/crates/kerykeion/src/collector_tests.rs
@@ -204,6 +204,73 @@ async fn router_flush_cancels_cleanly() {
     assert!(result.is_ok(), "router flush should cancel cleanly");
 }
 
+// ── akroasis#190: recv_yielding must not starve send-side tasks ──────
+
+/// Mock connection whose `recv()` never resolves, reproducing a quiet mesh.
+struct BlockingRecvConn;
+
+impl crate::connection::MeshConnection for BlockingRecvConn {
+    async fn send(&mut self, _: crate::proto::ToRadio) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn recv(&mut self) -> Result<FromRadio, Error> {
+        std::future::pending().await
+    }
+    fn is_connected(&self) -> bool {
+        true
+    }
+    async fn reconnect(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn recv_yielding_releases_lock_for_waiting_sender() {
+    let conn = Arc::new(Mutex::new(BlockingRecvConn));
+
+    // Main-loop stand-in: parked on the quiet-mesh recv().
+    let recv_conn = Arc::clone(&conn);
+    let recv_handle = tokio::spawn(async move {
+        let _ = recv_yielding(&*recv_conn).await;
+    });
+    tokio::task::yield_now().await;
+
+    // Send-side stand-in (heartbeat / router-flush): queues on the same
+    // lock before the recv loop's poll window elapses.
+    let send_conn = Arc::clone(&conn);
+    let send_handle = tokio::spawn(async move {
+        send_conn
+            .lock()
+            .await
+            .send(crate::proto::ToRadio {
+                payload_variant: None,
+            })
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    // Elapse one poll window: recv_yielding's inner timeout fires and drops
+    // the guard, handing the fair mutex to the already-queued sender.
+    tokio::time::advance(RECV_LOCK_YIELD).await;
+    tokio::task::yield_now().await;
+
+    #[expect(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "test-only: recv_yielding must release the lock within one poll window"
+    )]
+    let send_result = tokio::time::timeout(RECV_LOCK_YIELD, send_handle)
+        .await
+        .expect("send should complete once recv_yielding releases the lock")
+        .unwrap();
+
+    recv_handle.abort();
+    assert!(
+        send_result.is_ok(),
+        "queued send should succeed once the guard is dropped"
+    );
+}
+
 // ── akroasis#235: inbound ACK/NAK reaches DeliveryTracker ────────────
 
 fn make_outbound_packet(id: u32, to: u32) -> crate::proto::MeshPacket {


### PR DESCRIPTION
Fan-lane fix; premise verified against current main before editing. Hosted CI (gate full-gate-build) is the compile+test proof.

Refs #190