### PR TITLE
fix(syntonia): remove duplicate baofeng magic-byte constants (#237)

### DIFF
--- a/crates/syntonia/src/baofeng/constants.rs
+++ b/crates/syntonia/src/baofeng/constants.rs
@@ -36,18 +36,10 @@ pub(crate) const CMD_WRITE: u8 = 0x58;
 /// Terminator byte in the identification response.
 pub(crate) const IDENT_TERMINATOR: u8 = 0xDD;
 
-// ---------------------------------------------------------------------------
-// Magic byte sequences for entering programming mode (variant-specific)
-// ---------------------------------------------------------------------------
-
-/// UV-5R firmware BFB291 and later.
-pub(crate) const MAGIC_UV5R_291: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x12, 0x07, 0x25];
-
-/// UV-5R original firmware.
-pub(crate) const MAGIC_UV5R_ORIG: [u8; 7] = [0x50, 0xBB, 0xFF, 0x01, 0x25, 0x98, 0x4D];
-
-/// BF-F8HP / BF-A58 variants.
-pub(crate) const MAGIC_BF_F8HP: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x14, 0x04, 0x13];
+// NOTE: magic byte sequences for entering programming mode live in
+// `variant.rs` (`MAGIC_UV5R_291`, `MAGIC_UV5R_ORIG`, `MAGIC_BF_F8HP`,
+// `MAGIC_SETS`) — that is the sole authoritative source; do not redefine
+// them here (#237).
 
 // ---------------------------------------------------------------------------
 // EEPROM memory layout

--- a/crates/syntonia/src/baofeng/protocol_tests.rs
+++ b/crates/syntonia/src/baofeng/protocol_tests.rs
@@ -2,7 +2,7 @@
 //! RUST/file-too-long 800-line threshold.
 
 use super::*;
-use crate::baofeng::variant::{bf_f8hp_config, uv5r_config, uv5rm_plus_config};
+use crate::baofeng::variant::{MAGIC_UV5R_291, bf_f8hp_config, uv5r_config, uv5rm_plus_config};
 use crate::serial::mock::MockSerialPort;
 
 // -----------------------------------------------------------------------
@@ -176,15 +176,10 @@ fn enter_programming_mode_sends_magic_bytes() {
     mock.enqueue_response(&[ACK]);
 
     let mut proto = make_protocol(mock);
-    proto
-        .enter_programming_mode(&super::super::constants::MAGIC_UV5R_291)
-        .unwrap();
+    proto.enter_programming_mode(&MAGIC_UV5R_291).unwrap();
 
     // All 7 magic bytes should have been written.
-    assert_eq!(
-        &proto.port.written[..7],
-        &super::super::constants::MAGIC_UV5R_291
-    );
+    assert_eq!(&proto.port.written[..7], &MAGIC_UV5R_291);
 }
 
 #[test]
@@ -193,9 +188,7 @@ fn enter_programming_mode_bad_ack_returns_error() {
     mock.enqueue_response(&[0xFF]);
 
     let mut proto = make_protocol(mock);
-    let err = proto
-        .enter_programming_mode(&super::super::constants::MAGIC_UV5R_291)
-        .unwrap_err();
+    let err = proto.enter_programming_mode(&MAGIC_UV5R_291).unwrap_err();
 
     assert!(matches!(
         err,
@@ -210,9 +203,7 @@ fn enter_programming_mode_bad_ack_returns_error() {
 fn enter_programming_mode_timeout_returns_error() {
     let mock = MockSerialPort::new();
     let mut proto = make_protocol(mock);
-    let err = proto
-        .enter_programming_mode(&super::super::constants::MAGIC_UV5R_291)
-        .unwrap_err();
+    let err = proto.enter_programming_mode(&MAGIC_UV5R_291).unwrap_err();
 
     assert!(matches!(err, ProtocolError::Timeout));
 }


### PR DESCRIPTION
Fan-lane fix; premise verified against current main before editing. Hosted CI (gate full-gate-build) is the compile+test proof.

Refs #237