### PR TITLE
fix(koinon): score zero-variance baseline deviations as anomalous (#212)

### DIFF
--- a/crates/koinon/src/baseline.rs
+++ b/crates/koinon/src/baseline.rs
@@ -177,8 +177,28 @@ impl Baseline {
         if self.count < config.min_observations {
             return AnomalyScore::InsufficientData;
         }
-        self.z_score(value)
-            .map_or(AnomalyScore::InsufficientData, |z| {
+        // WHY: z_score is None exactly when stddev is not > 0.0 (a zero-variance
+        // baseline), which is not the same as insufficient data — the count gate
+        // above already guarantees min_observations were recorded. Any deviation
+        // FROM a perfectly stable baseline is maximally significant.
+        self.z_score(value).map_or_else(
+            || {
+                let mean = self.mean().unwrap_or(value);
+                // WHY: exact equality is intentional — a zero-variance baseline means
+                // every recorded observation equals `mean` bit-for-bit (Welford), so
+                // this is the precise "no deviation" test, not an approximate one.
+                #[expect(
+                    clippy::float_cmp,
+                    reason = "zero-variance baseline: exact equality to a bit-stable mean is the intended zero-deviation check"
+                )]
+                let at_baseline = value == mean;
+                if at_baseline {
+                    AnomalyScore::Normal
+                } else {
+                    AnomalyScore::Anomalous(f64::INFINITY.copysign(value - mean))
+                }
+            },
+            |z| {
                 let abs_z = z.abs();
                 if abs_z >= config.anomalous_threshold {
                     AnomalyScore::Anomalous(z)
@@ -187,7 +207,8 @@ impl Baseline {
                 } else {
                     AnomalyScore::Normal
                 }
-            })
+            },
+        )
     }
 }
 

--- a/crates/koinon/src/baseline_tests.rs
+++ b/crates/koinon/src/baseline_tests.rs
@@ -326,6 +326,21 @@ fn baseline_mean_of_constant_sequence() {
     );
 }
 
+/// A zero-variance baseline (all identical observations) must still score:
+/// the matching value is `Normal`, any deviation is `Anomalous` — never
+/// `InsufficientData`, since `min_observations` was already satisfied.
+#[test]
+fn score_on_zero_variance_baseline_is_not_insufficient_data() {
+    let mut b = Baseline::new();
+    for _ in 0..20 {
+        b.observe(5.0);
+    }
+    assert_eq!(b.count(), 20);
+    assert_eq!(b.stddev(), Some(0.0));
+    assert_eq!(b.score(5.0), AnomalyScore::Normal);
+    assert!(matches!(b.score(6.0), AnomalyScore::Anomalous(_)));
+}
+
 /// After 100 observations near 50.0 the baseline is stable; a value of 500.0
 /// must score as Anomalous (it is far beyond 3 sigma).
 #[test]


### PR DESCRIPTION
## Fix
Score zero-variance baseline deviations as Anomalous instead of InsufficientData — z_score returns None when stddev==0, which the count gate already distinguishes from genuinely insufficient data

Refs #212