### PR TITLE
test(syntonia): un-gate variant.rs tests from hardware-serial feature (#251)

### DIFF
--- a/crates/syntonia/src/baofeng/variant.rs
+++ b/crates/syntonia/src/baofeng/variant.rs
@@ -299,7 +299,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-#[cfg(all(test, feature = "hardware-serial"))] // kanon:ignore RUST/feature-gate-check -- declared in syntonia/Cargo.toml [features]
+#[cfg(test)]
 #[expect(
     clippy::unwrap_used,
     clippy::indexing_slicing,


### PR DESCRIPTION
## Fix
Un-gate variant.rs tests from the hardware-serial feature (they use no hardware I/O) so identify_variant/VariantConfig gain default-CI coverage

Refs #251