### PR TITLE
chore(deps): pin sphragis to tag v0.1.1 (#254)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ subtle = "2"
 # Post-quantum hybrid KEM — standalone fleet crate.
 # WHY: extracted from akroasis crates/sphragis to forkwright/sphragis for
 # cross-repo access. preview-pq gated; unaudited until cryptographic review.
-sphragis = { git = "https://github.com/forkwright/sphragis", features = ["preview-pq"] }
+sphragis = { git = "https://github.com/forkwright/sphragis", tag = "v0.1.1", features = ["preview-pq"] }
 
 # Hashing
 blake3 = "1"


### PR DESCRIPTION
## Fix
Pin the `sphragis` workspace git dependency to `tag = "v0.1.1"` instead of floating to the default-branch HEAD (the tag now exists; it did not when #254 was filed). The dependency is declared in `[workspace.dependencies]` but consumed by no crate yet, so this is a zero-blast-radius metadata change — Cargo.lock has no sphragis entry to update (nothing pulls it into the graph), so only Cargo.toml changes.

Refs #254