### PR TITLE
docs(vault): document AKROASIS_VAULT_PATH override (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 
 ---
 
+## Environment Variables
+
+Akroasis reads these environment variables at runtime; unset variables fall back to the defaults below.
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `AKROASIS_VAULT_PATH` | Overrides the credential vault's storage directory. | `~/.local/share/akroasis/vault` |
+
+---
+
 ## Documentation
 
 - [standards/](standards/): Pointer to canonical kanon standards (STANDARDS.md, GNOMON.md, etc.)


### PR DESCRIPTION
## Fix
Add an "## Environment Variables" section to README.md documenting `AKROASIS_VAULT_PATH` (read by `default_vault_path()` in crates/akroasis/src/vault/mod.rs, default `~/.local/share/akroasis/vault`) — it was read at runtime but documented nowhere.

Refs #253