### PR TITLE
fix(kerykeion): treat hops_away 0 as direct, matching the sibling path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "akroasis"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "clap",
  "comfy-table",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "akroasis-server"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "akroasis",
  "axum",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "koinon"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "blake3",
  "ciborium",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "kryphos"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "argon2",
  "blake3",
@@ -2162,7 +2162,7 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semaino"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "jiff",
  "koinon",
@@ -2444,7 +2444,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syntonia"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "compact_str",
  "csv",

--- a/crates/kerykeion/src/handshake.rs
+++ b/crates/kerykeion/src/handshake.rs
@@ -205,15 +205,15 @@ pub(crate) fn node_info_to_mesh_node(ni: &crate::proto::NodeInfo) -> MeshNode {
             None
         },
         snr: if ni.snr == 0.0 { None } else { Some(ni.snr) },
+        // WHY: hops_away's valid domain includes 0 (a direct neighbor), unlike
+        // snr/last_heard where 0 IS the proto3 unset sentinel — so it is
+        // always present, matching processor.rs's hop_count == Some(0)
+        // "direct" convention (#201) instead of treating 0 as unknown.
         #[expect(
             clippy::cast_possible_truncation,
             reason = "hops_away is bounded by MAX_HOP_LIMIT (7) in Meshtastic firmware"
         )]
-        hop_count: if ni.hops_away != 0 {
-            Some(ni.hops_away as u8) // SAFETY: Meshtastic hops_away field is 0..255 per protocol; fits u8
-        } else {
-            None
-        },
+        hop_count: Some(ni.hops_away as u8), // SAFETY: Meshtastic hops_away field is 0..255 per protocol; fits u8
     }
 }
 
@@ -430,5 +430,32 @@ mod tests {
         #[expect(clippy::unwrap_used, reason = "test-only")]
         let result = handshake(&mut conn, &mut db).await.unwrap();
         assert_eq!(result.channels.len(), 1);
+    }
+
+    #[test]
+    fn node_info_zero_hops_away_maps_to_direct_hop_count() {
+        // WHY: 0 hops away means "direct neighbor", not "unknown" — must
+        // agree with processor.rs's Some(0)-is-direct convention (#201),
+        // not collapse to None the way it did before #321.
+        let ni = NodeInfo {
+            hops_away: 0,
+            ..Default::default()
+        };
+
+        let node = node_info_to_mesh_node(&ni);
+
+        assert_eq!(node.hop_count, Some(0));
+    }
+
+    #[test]
+    fn node_info_nonzero_hops_away_maps_to_that_hop_count() {
+        let ni = NodeInfo {
+            hops_away: 3,
+            ..Default::default()
+        };
+
+        let node = node_info_to_mesh_node(&ni);
+
+        assert_eq!(node.hop_count, Some(3));
     }
 }


### PR DESCRIPTION
`node_info_to_mesh_node` mapped `hops_away == 0` to `hop_count: None` — "unknown" — while the sibling path at `processor.rs:190` already treats `Some(0)` as "direct neighbour". Two paths disagreeing about the same fact.

The proto settles which is right: `hops_away` is a bare `uint32`, not `optional`, so 0 is a valid in-domain value rather than a presence sentinel. A directly-adjacent node was being reported as being at an unknown distance.

`handshake.rs:212-216` now passes `Some(ni.hops_away as u8)` unconditionally.

## Verification

Two tests asserting the semantics rather than the shape: `hops_away: 0` maps to `Some(0)`, and a non-zero value maps to that value. On the build box: fmt clean, full suite 727/727.

`cargo clippy --workspace` fails on one pre-existing, unrelated error in `crates/syntonia/src/baofeng/variant.rs:8` (`unfulfilled_lint_expectations`, tracked as #264) — reproduced identically on a clean `origin/main` worktree with zero changes, so it is not from this branch. Scoped `--exclude syntonia`: clean.

Also resynced `Cargo.lock`, stale at `0.1.12` against the workspace's `0.1.13` since #278-280.

Refs #321
