### PR TITLE
fix(release): keep Cargo.lock in lockstep with the workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "akroasis"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "clap",
  "comfy-table",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "akroasis-server"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "akroasis",
  "axum",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "kerykeion"
-version = "0.1.0"
+version = "0.1.14"
 dependencies = [
  "aes",
  "bytes",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "koinon"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "blake3",
  "ciborium",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "kryphos"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "argon2",
  "blake3",
@@ -2162,7 +2162,7 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semaino"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "jiff",
  "koinon",
@@ -2455,7 +2455,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syntonia"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "compact_str",
  "csv",

--- a/crates/kerykeion/Cargo.toml
+++ b/crates/kerykeion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kerykeion"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,11 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(!@.source)].version"
         }
       ]
     }


### PR DESCRIPTION
Closes the drift measured in #327.

## Before

At `origin/main` (`477cb94`, release 0.1.14):

```
workspace.package.version = 0.1.14

lock: akroasis 0.1.13   akroasis-server 0.1.13   koinon 0.1.13
     kryphos 0.1.13     semaino 0.1.13           syntonia 0.1.13
     kerykeion 0.1.0
```

`release-please-config.json` carried one `extra-files` entry, `$.workspace.package.version`. Nothing targeted `Cargo.lock`.

## Changes

1. **`crates/kerykeion/Cargo.toml`** — `version = "0.1.0"` → `version.workspace = true`.
2. **`release-please-config.json`** — adds the fleet-standard lock entry:
   ```json
   { "type": "toml", "path": "Cargo.lock", "jsonpath": "$.package[?(!@.source)].version" }
   ```
3. **`Cargo.lock`** — regenerated via `cargo update --workspace`.

## Why (1) is a prerequisite, not scope creep

The `!@.source` filter selects *every* workspace-local package. That is correct only where all members inherit `version.workspace = true`. Six of the seven do; kerykeion kept the scaffold default from #52. Adding the entry alone would have rewritten kerykeion's **lock** version to 0.1.14 while its **manifest** still read 0.1.0 — trading drift for a contradiction.

Nothing depends on kerykeion by version — it is consumed only as `{ path = "../kerykeion" }` with no version requirement — so joining workspace versioning is inert at the dependency graph.

## Verification

`cargo update --workspace` moved exactly the seven workspace members and left all 86 registry dependencies unchanged; the `Cargo.lock` diff is seven version lines and nothing else.

Note the config change on its own is unfalsifiable until the next release cut, which is why the lock is regenerated here — that part is checkable now:

```
$ python3 -c "…"   # after
akroasis 0.1.14  akroasis-server 0.1.14  kerykeion 0.1.14  koinon 0.1.14
kryphos 0.1.14   semaino 0.1.14          syntonia 0.1.14
```

The next release is the real falsifier: it should patch the lock with no hand-editing, as thumos's 0.1.14 cut did after the equivalent change.

Refs #327