### PR TITLE
fix(koinon,kerykeion): guard non-finite baseline observations and cap over-capacity snapshots

### DIFF
--- a/crates/kerykeion/src/error.rs
+++ b/crates/kerykeion/src/error.rs
@@ -232,6 +232,23 @@ pub enum Error {
         #[snafu(implicit)]
         location: snafu::Location,
     },
+
+    /// A store-forward snapshot has more distinct destinations than the
+    /// running cap allows; loading it verbatim would silently disable the
+    /// per-destination resource-exhaustion protection for every over-cap
+    /// destination.
+    #[snafu(display(
+        "store-forward snapshot has {destination_count} destinations, exceeding the cap of {max}"
+    ))]
+    StoreForwardOverCapacity {
+        /// Distinct destination count found in the snapshot.
+        destination_count: usize,
+        /// The configured distinct-destination cap (`store_forward::MAX_DESTINATIONS`).
+        max: usize,
+        /// Source location for diagnostics.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
 }
 
 // WHY: tokio_util::codec::Decoder::Error and Encoder::Error both require

--- a/crates/kerykeion/src/store_forward.rs
+++ b/crates/kerykeion/src/store_forward.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 
 use crate::config::StoreForwardConfig;
-use crate::error::{Error, QueueFullSnafu};
+use crate::error::{Error, QueueFullSnafu, StoreForwardOverCapacitySnafu};
 use crate::types::NodeNum;
 
 // WHY: bounds StoreForward.queues cardinality independent of max_queue_per_dest, which only bounds messages inside one queue (#242).
@@ -162,12 +162,29 @@ impl StoreForward {
     /// # Errors
     ///
     /// Returns [`Error::StoreForwardSerde`] if deserialization fails.
+    ///
+    /// Returns [`Error::StoreForwardOverCapacity`] if the snapshot holds
+    /// more than [`MAX_DESTINATIONS`] distinct destinations. `store()`'s cap
+    /// guard only rejects *new* destinations once the cap is reached — a
+    /// destination restored wholesale here would count as "existing" from
+    /// `store()`'s point of view and accept unbounded messages forever, so
+    /// an over-cap snapshot is rejected outright rather than silently
+    /// admitted. `self` is left unmodified when this error is returned.
     pub fn deserialize(&mut self, data: &[u8]) -> Result<(), Error> {
         let raw: HashMap<u32, Vec<StoredMessage>> =
             serde_json::from_slice(data).map_err(|source| Error::StoreForwardSerde {
                 source,
                 location: snafu::location!(),
             })?;
+
+        if raw.len() > MAX_DESTINATIONS {
+            return StoreForwardOverCapacitySnafu {
+                destination_count: raw.len(),
+                max: MAX_DESTINATIONS,
+            }
+            .fail();
+        }
+
         self.queues = raw
             .into_iter()
             .map(|(node, messages)| {
@@ -358,5 +375,45 @@ mod tests {
             .unwrap();
         assert_eq!(sf.destination_count(), MAX_DESTINATIONS);
         assert_eq!(sf.queue_depth(NodeNum(0)), 2);
+    }
+
+    #[test]
+    fn deserialize_rejects_snapshot_over_max_destinations() {
+        // Hand-build a raw snapshot with one destination beyond the cap —
+        // simulates a pre-#242 snapshot, a migration, or a corrupted file.
+        let raw: HashMap<u32, Vec<StoredMessage>> = (0..=MAX_DESTINATIONS as u32)
+            .map(|i| (i, vec![make_stored(i, 64, 1000, 3600)]))
+            .collect();
+        assert_eq!(raw.len(), MAX_DESTINATIONS + 1);
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let data = serde_json::to_vec(&raw).unwrap();
+
+        let mut sf = StoreForward::new(make_config(16));
+        let result = sf.deserialize(&data);
+
+        assert!(
+            result.is_err(),
+            "an over-cap snapshot must be rejected, not silently admitted"
+        );
+        assert_eq!(
+            sf.destination_count(),
+            0,
+            "a rejected snapshot must leave existing state unmodified"
+        );
+    }
+
+    #[test]
+    fn deserialize_accepts_snapshot_at_exactly_max_destinations() {
+        let raw: HashMap<u32, Vec<StoredMessage>> = (0..MAX_DESTINATIONS as u32)
+            .map(|i| (i, vec![make_stored(i, 64, 1000, 3600)]))
+            .collect();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let data = serde_json::to_vec(&raw).unwrap();
+
+        let mut sf = StoreForward::new(make_config(16));
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        sf.deserialize(&data).unwrap();
+
+        assert_eq!(sf.destination_count(), MAX_DESTINATIONS);
     }
 }

--- a/crates/koinon/src/baseline.rs
+++ b/crates/koinon/src/baseline.rs
@@ -48,7 +48,17 @@ impl Baseline {
     }
 
     /// Incorporates a new observation using Welford's online update rule.
+    ///
+    /// A non-finite `value` (NaN or ±∞) is rejected and logged rather than
+    /// applied: Welford's update never recovers from a NaN `mean`/`m2`, so a
+    /// single bad observation would otherwise pin every future
+    /// [`Baseline::score`] call to `Anomalous(±∞)` permanently. Mirrors the
+    /// same guard on `topology.rs::update_link`.
     pub fn observe(&mut self, value: f64) {
+        if !value.is_finite() {
+            tracing::warn!(value, "rejecting non-finite baseline observation");
+            return;
+        }
         self.count += 1;
         let delta = value - self.mean;
         self.mean += delta / (self.count as f64); // SAFETY: u64→f64 precision loss only matters beyond 2^53 observations; statistical accumulation

--- a/crates/koinon/src/baseline_tests.rs
+++ b/crates/koinon/src/baseline_tests.rs
@@ -221,7 +221,7 @@ fn observe_rejects_infinite_values() {
         count_before,
         "infinite observations must not be counted"
     );
-    assert!(b.mean().is_some_and(|m| m.is_finite()));
+    assert!(b.mean().is_some_and(f64::is_finite));
 }
 
 // ── TimeWindowedBaseline tests ────────────────────────────────────────────

--- a/crates/koinon/src/baseline_tests.rs
+++ b/crates/koinon/src/baseline_tests.rs
@@ -188,8 +188,16 @@ fn observe_rejects_nan_and_does_not_poison_future_scores() {
     b.observe(f64::NAN);
 
     // The NaN observation must be rejected outright, not merely tolerated.
-    assert_eq!(b.count(), count_before, "NaN observation must not be counted");
-    assert_eq!(b.mean(), mean_before, "NaN observation must not perturb the mean");
+    assert_eq!(
+        b.count(),
+        count_before,
+        "NaN observation must not be counted"
+    );
+    assert_eq!(
+        b.mean(),
+        mean_before,
+        "NaN observation must not perturb the mean"
+    );
     assert!(!b.mean().unwrap().is_nan());
 
     // A subsequent, ordinary observation still scores sanely — the baseline
@@ -208,7 +216,11 @@ fn observe_rejects_infinite_values() {
     b.observe(f64::INFINITY);
     b.observe(f64::NEG_INFINITY);
 
-    assert_eq!(b.count(), count_before, "infinite observations must not be counted");
+    assert_eq!(
+        b.count(),
+        count_before,
+        "infinite observations must not be counted"
+    );
     assert!(b.mean().is_some_and(|m| m.is_finite()));
 }
 

--- a/crates/koinon/src/baseline_tests.rs
+++ b/crates/koinon/src/baseline_tests.rs
@@ -176,6 +176,42 @@ fn merge_into_empty_self_copies_other() {
     assert_eq!(empty.count(), b.count());
 }
 
+#[test]
+fn observe_rejects_nan_and_does_not_poison_future_scores() {
+    let mut b = Baseline::new();
+    for v in (1..=20).map(f64::from) {
+        b.observe(v);
+    }
+    let mean_before = b.mean();
+    let count_before = b.count();
+
+    b.observe(f64::NAN);
+
+    // The NaN observation must be rejected outright, not merely tolerated.
+    assert_eq!(b.count(), count_before, "NaN observation must not be counted");
+    assert_eq!(b.mean(), mean_before, "NaN observation must not perturb the mean");
+    assert!(!b.mean().unwrap().is_nan());
+
+    // A subsequent, ordinary observation still scores sanely — the baseline
+    // is not permanently pinned to Anomalous(±∞).
+    assert_eq!(b.score(10.5), AnomalyScore::Normal);
+}
+
+#[test]
+fn observe_rejects_infinite_values() {
+    let mut b = Baseline::new();
+    for v in (1..=20).map(f64::from) {
+        b.observe(v);
+    }
+    let count_before = b.count();
+
+    b.observe(f64::INFINITY);
+    b.observe(f64::NEG_INFINITY);
+
+    assert_eq!(b.count(), count_before, "infinite observations must not be counted");
+    assert!(b.mean().is_some_and(|m| m.is_finite()));
+}
+
 // ── TimeWindowedBaseline tests ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
`Refs #323`
`Refs #322`

Two follow-ups from the wave-1 audit, both the same shape: a bound that is
enforced on one path and silently bypassed on another.

## `Baseline::observe` rejects non-finite values (#323)

`observe(f64::NAN)` poisoned `mean`/`m2` permanently — Welford's update never
recovers — and after #212's default arm, `score()` then returned
`Anomalous(±∞)` for **every** subsequent input, forever. A single hardware
glitch or attacker-influenced float would pin a baseline to max severity for
the life of the process.

Non-finite values are now rejected and logged rather than applied, mirroring
the guard `topology.rs::update_link` already had for exactly this reason.

Latent today (the only live feeder is `MeshDetail::NodeSeen { hop_count: u8 }`,
which cannot be non-finite), and live the moment real sensor/RF ingestion is
wired — which is the point of fixing it now.

## `StoreForward::deserialize` enforces `MAX_DESTINATIONS` (#322)

`store()`'s cap guard only rejects *new* destinations once the cap is reached.
A destination restored wholesale by `deserialize()` counted as "existing" from
`store()`'s point of view, so an over-cap snapshot silently disabled the
per-destination resource-exhaustion protection for every over-cap destination —
permanently, for that process.

An over-cap snapshot is now rejected outright via a new
`Error::StoreForwardOverCapacity` carrying the observed count and the cap, and
`self` is left unmodified when it returns.

## Tests

Each fix ships a pair that brackets the boundary, so a green means something
that could have gone red did not:

- `observe_rejects_nan_and_does_not_poison_future_scores` — asserts the NaN is
  *not counted* and does not perturb the mean (not merely "tolerated"), then
  that an ordinary observation still scores `Normal`.
- `observe_rejects_infinite_values` — both `INFINITY` and `NEG_INFINITY`.
- `deserialize_rejects_snapshot_over_max_destinations` — one over the cap is
  rejected **and** leaves existing state unmodified.
- `deserialize_accepts_snapshot_at_exactly_max_destinations` — exactly at the
  cap is still accepted, so the guard is a bound rather than an off-by-one.

## Verification

`cargo test -p koinon -p kerykeion` on this box: **179 passed, 0 failed**.
Full workspace fmt/clippy/nextest is left to this repo's `hybrid-gate`
`full-gate-build` fallback, which is the independent check for a trailer-less PR.

**Known unrelated risk, flagged rather than discovered later:** akroasis#264
tracks pre-existing lint-marker debt in `crates/syntonia` that is not touched
by this branch. If the full-gate-build job goes red there, that is #264 and not
this change.