### PR TITLE
fix(kerykeion): drive retention and TTL maintenance from the router flush tick

### DIFF
--- a/crates/kerykeion/src/collector.rs
+++ b/crates/kerykeion/src/collector.rs
@@ -536,6 +536,13 @@ where
                 let pending = {
                     let mut r = router.lock().await;
                     r.process_timeouts();
+                    let expired = r.run_maintenance();
+                    if !expired.is_empty() {
+                        tracing::debug!(
+                            count = expired.len(),
+                            "router flush: expired stale delivery records"
+                        );
+                    }
                     let mut packets = Vec::new();
                     while let Some(msg) = r.next_to_send() {
                         let packet = msg.packet.clone();

--- a/crates/kerykeion/src/config.rs
+++ b/crates/kerykeion/src/config.rs
@@ -256,6 +256,14 @@ pub struct OutboundConfig {
     pub ack_timeout_secs: u64,
     /// Default store-and-forward TTL, in seconds.
     pub store_forward_ttl_secs: u64,
+    /// How long a delivery record is retained after it reaches a terminal
+    /// state, and how long an unacknowledged record may stay active before it
+    /// is expired, in seconds.
+    ///
+    /// WHY: without this bound the delivery tracker grows monotonically on a
+    /// long-lived collector — terminal records are never released and records
+    /// for packets that are never acknowledged stay active forever (#244).
+    pub delivery_record_max_age_secs: u64,
 }
 
 impl Default for OutboundConfig {
@@ -265,6 +273,10 @@ impl Default for OutboundConfig {
             max_retries: 5,
             ack_timeout_secs: 30,
             store_forward_ttl_secs: 3600,
+            // WHY: longer than the store-and-forward TTL so a record outlives
+            // the delivery attempt it describes, and still bounded so the
+            // tracker cannot grow without limit.
+            delivery_record_max_age_secs: 7200,
         }
     }
 }
@@ -280,6 +292,12 @@ impl OutboundConfig {
     #[must_use]
     pub const fn store_forward_ttl(&self) -> Duration {
         Duration::from_secs(self.store_forward_ttl_secs)
+    }
+
+    /// Returns the delivery-record retention bound as a [`Duration`].
+    #[must_use]
+    pub const fn delivery_record_max_age(&self) -> Duration {
+        Duration::from_secs(self.delivery_record_max_age_secs)
     }
 }
 
@@ -562,6 +580,7 @@ neighbor_info_enabled = true
                 max_retries: 1,
                 ack_timeout_secs: 7,
                 store_forward_ttl_secs: 11,
+                delivery_record_max_age_secs: 13,
             },
             transport: TransportConfig {
                 tcp_connect_timeout_secs: 8,

--- a/crates/kerykeion/src/delivery.rs
+++ b/crates/kerykeion/src/delivery.rs
@@ -210,6 +210,10 @@ impl DeliveryTracker {
     }
 
     /// Remove completed (acknowledged, failed, expired) records older than `max_age`.
+    ///
+    /// WARNING: this only releases records that already reached a terminal
+    /// state. Call [`Self::expire_stale`] first, or a record for a packet that
+    /// is never acknowledged stays active and is retained forever (#244).
     pub fn prune_completed(&mut self, max_age: std::time::Duration) {
         let now = Instant::now();
         self.records.retain(|_, record| {
@@ -221,6 +225,33 @@ impl DeliveryTracker {
                 DeliveryStatus::Queued | DeliveryStatus::Sent { .. } => true,
             }
         });
+    }
+
+    /// Move records still active after `max_age` into [`DeliveryStatus::Expired`].
+    ///
+    /// Returns the packet ids that were expired.
+    ///
+    /// WHY: a `Queued` or `Sent` record only leaves the active set on an ACK, a
+    /// NAK, or retry exhaustion. A packet whose ACK never arrives and whose
+    /// outbound entry is already gone reaches none of those, so without a
+    /// wall-clock backstop it pins a record for the lifetime of the process
+    /// and `prune_completed` can never release it (#244).
+    pub fn expire_stale(&mut self, max_age: std::time::Duration) -> Vec<PacketId> {
+        let now = Instant::now();
+        let mut expired = Vec::new();
+        for (id, record) in &mut self.records {
+            let active = matches!(
+                record.status,
+                DeliveryStatus::Queued | DeliveryStatus::Sent { .. }
+            );
+            if active && now.duration_since(record.created) >= max_age {
+                record.status = DeliveryStatus::Expired;
+                let stats = self.dest_stats.entry(record.dest).or_default();
+                stats.failed += 1;
+                expired.push(*id);
+            }
+        }
+        expired
     }
 }
 

--- a/crates/kerykeion/src/router.rs
+++ b/crates/kerykeion/src/router.rs
@@ -46,6 +46,8 @@ pub struct MeshRouter {
     ack_timeout: Duration,
     /// Default TTL for store-and-forward messages.
     sf_ttl_secs: u64,
+    /// Retention bound for delivery records, applied by [`MeshRouter::run_maintenance`].
+    record_max_age: Duration,
 }
 
 /// Options for a send operation.
@@ -108,6 +110,7 @@ impl MeshRouter {
             delivery,
             ack_timeout: config.ack_timeout(),
             sf_ttl_secs: config.store_forward_ttl_secs,
+            record_max_age: config.delivery_record_max_age(),
         }
     }
 
@@ -216,6 +219,31 @@ impl MeshRouter {
         }
 
         failed
+    }
+
+    /// Run every retention and TTL maintenance pass the router owns.
+    ///
+    /// Returns the packet ids of delivery records expired by the wall-clock
+    /// backstop.
+    ///
+    /// WHY: the delivery tracker, the store-and-forward queues and the outbound
+    /// queue each bound themselves through a method that nothing in production
+    /// called, so all three grew monotonically on a long-lived collector. One
+    /// entry point driven from the flush tick keeps them from drifting apart
+    /// again — adding a fourth structure means extending this method, not
+    /// remembering to wire another call site (#244).
+    ///
+    /// PERF: called once per flush tick. Each pass is a single retain over its
+    /// own map, so the cost is proportional to what is currently retained.
+    pub fn run_maintenance(&mut self) -> Vec<PacketId> {
+        // WHY: expire first. `prune_completed` only releases records already in
+        // a terminal state, so without this the records for packets that are
+        // never acknowledged would never become eligible.
+        let expired = self.delivery.expire_stale(self.record_max_age);
+        self.delivery.prune_completed(self.record_max_age);
+        self.store_forward.prune_expired(now_ms());
+        self.outbound.drain_expired();
+        expired
     }
 
     /// Flush stored messages for a node that just came online.
@@ -485,6 +513,67 @@ mod tests {
             ),
             "decoded payload must round-trip byte-identical, got {:?}",
             flushed.packet.payload_variant
+        );
+    }
+
+    /// The delivery tracker must not retain a record for a packet that is
+    /// never acknowledged (#244).
+    #[tokio::test(start_paused = true)]
+    async fn run_maintenance_expires_and_releases_unacknowledged_records() {
+        let mut router = make_router();
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(60), true, &SendOptions::default())
+            .unwrap();
+        if let Some(msg) = router.next_to_send() {
+            router.track_sent(msg);
+        }
+        assert_eq!(router.delivery.tracked_count(), 1);
+
+        // Within the retention bound the record is still live and untouched.
+        tokio::time::advance(Duration::from_secs(60)).await;
+        assert!(
+            router.run_maintenance().is_empty(),
+            "a record inside its retention bound must not be expired"
+        );
+        assert_eq!(router.delivery.tracked_count(), 1);
+
+        // Past it, the record expires and is then released. Before the fix it
+        // stayed `Sent` forever, so `prune_completed` could never free it.
+        tokio::time::advance(
+            OutboundConfig::default().delivery_record_max_age() + Duration::from_secs(1),
+        )
+        .await;
+        assert_eq!(
+            router.run_maintenance(),
+            vec![id],
+            "an unacknowledged record past the retention bound must be expired"
+        );
+        assert_eq!(
+            router.delivery.tracked_count(),
+            0,
+            "expired records must be released in the same maintenance pass"
+        );
+    }
+
+    /// Store-and-forward TTL must be enforced without waiting for `drain_for`
+    /// on a destination that may never return (#244).
+    #[test]
+    fn run_maintenance_prunes_store_forward_without_drain_for() {
+        let mut router = make_router();
+        let opts = SendOptions {
+            ttl_secs: 0,
+            ..SendOptions::default()
+        };
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        router.send(make_packet(61), false, &opts).unwrap();
+        assert_eq!(router.store_forward.total_stored(), 1);
+
+        router.run_maintenance();
+        assert_eq!(
+            router.store_forward.total_stored(),
+            0,
+            "an elapsed-TTL message must be pruned by maintenance, not held until drain_for"
         );
     }
 


### PR DESCRIPTION
`DeliveryTracker::prune_completed`, `StoreForward::prune_expired` and `OutboundQueue::drain_expired` each bound one of the router's maps, and none was called from any production path — the only call sites were their own unit tests.

## Re-derived premise

Verified against `origin/main` (273fa9e): grepping all three across `crates/` returns only definitions and test call sites (`store_forward.rs:276`, `router.rs:510/518`, `outbound.rs:433/476` — all inside `mod tests`). `prune_completed` had **zero** callers anywhere.

## Change

`MeshRouter::run_maintenance` becomes the single entry point for all three, called from `run_router_flush` on each tick alongside `process_timeouts`. Adding a fourth bounded structure means extending that method rather than remembering to wire another call site.

## Pruning alone was not enough

`prune_completed` releases only records already in a terminal state, and a `Queued`/`Sent` record leaves the active set only on an ACK, a NAK, or retry exhaustion. A packet whose ACK never arrives and whose outbound entry is already gone reaches none of those — so its record stayed active forever and was never *eligible* for pruning. `DeliveryTracker::expire_stale` adds that wall-clock backstop, and `run_maintenance` expires before it prunes so the two compose.

The store-forward case was the most harmful: because the TTL never fired, a destination that never came back kept its per-destination queue saturated and rejected new inserts — degrading delivery in exactly the conditions store-and-forward exists to handle.

## Config

Retention is configurable as `outbound.delivery_record_max_age_secs`, defaulting to 7200s — longer than the store-and-forward TTL so a record outlives the delivery attempt it describes, and still bounded.

## Verification

`cargo fmt --check` clean; `cargo clippy -p kerykeion --all-targets -- -D warnings` clean; full `kerykeion` suite passes (235 tests).

Both new tests are falsifiable, not merely green — reverting `run_maintenance` to a no-op fails them with the pre-fix values:

    an unacknowledged record past the retention bound must be expired
      left: []  right: [PacketId(60)]

    an elapsed-TTL message must be pruned by maintenance, not held until drain_for
      left: 1   right: 0

Scope note: clippy was run on `kerykeion` rather than the whole workspace because `crates/syntonia` carries a pre-existing unrelated failure tracked in #264. Nothing in this branch touches syntonia.

Refs #244