### PR TITLE
fix(syntonia): make EEPROM download/upload respect the variant's aux block

### DIFF
--- a/crates/akroasis/src/radio/serial_hardware.rs
+++ b/crates/akroasis/src/radio/serial_hardware.rs
@@ -166,12 +166,12 @@ impl Session for BaofengProtocolSession {
         // WHY: UV-5R main memory is 0x0000–0x1800 in 64-byte blocks = 96 blocks.
         // With aux block (BF-F8HP) adds ~32 more blocks. We emit progress in 64-byte
         // increments; the caller's progress bar expects (done, total) block counts.
-        let mem_image = self
-            .protocol
-            .download_image()
-            .map_err(|e| RadioError::SerialTimeout {
-                port: format!("download failed: {e}"),
-            })?;
+        let mem_image =
+            self.protocol
+                .download_image(&self.config)
+                .map_err(|e| RadioError::SerialTimeout {
+                    port: format!("download failed: {e}"),
+                })?;
 
         // Signal completion to progress bar.
         on_block(128, 128);
@@ -181,7 +181,7 @@ impl Session for BaofengProtocolSession {
     fn upload_image(&mut self, data: &[u8], on_block: &dyn Fn(u16, u16)) -> Result<(), RadioError> {
         let image = MemoryImage::from_bytes(data.to_vec());
         self.protocol
-            .upload_image(&image, &mut |done, total| {
+            .upload_image(&self.config, &image, &mut |done, total| {
                 on_block(
                     u16::try_from(done).unwrap_or(u16::MAX),
                     u16::try_from(total).unwrap_or(u16::MAX),

--- a/crates/syntonia/src/baofeng/protocol.rs
+++ b/crates/syntonia/src/baofeng/protocol.rs
@@ -231,6 +231,15 @@ pub enum ProtocolError {
         /// Number of attempts made.
         attempts: u8,
     },
+
+    /// The source image is shorter than the ranges this variant would write.
+    #[snafu(display("image covers {actual} bytes but this variant writes up to 0x{required:04X}"))]
+    ImageTooShort {
+        /// End of the highest range the variant would write.
+        required: usize,
+        /// Actual length of the supplied image.
+        actual: usize,
+    },
 }
 
 /// Specialized result type for protocol operations.
@@ -402,15 +411,28 @@ impl<P: SerialPort> Uv5rProtocol<P> {
 
     /// Download the full EEPROM image FROM the radio.
     ///
-    /// Reads the main block (0x0000–0x1800) in 64-byte chunks and the
-    /// auxiliary block (0x1E80–0x2000) in 16-byte chunks. A warm-up read at
-    /// 0x1E80 primes the aux region.
+    /// Reads the main block (0x0000–0x1800) in 64-byte chunks. Variants
+    /// declaring [`VariantConfig::has_aux_block`] additionally read the
+    /// auxiliary block (0x1E80–0x2000) in 16-byte chunks, preceded by a
+    /// warm-up read at 0x1E80 when [`VariantConfig::needs_aux_warmup`] is set.
+    ///
+    /// The returned image is sized to the region actually read, so a variant
+    /// without an aux block yields a 0x1800 image rather than one with a
+    /// zero-filled tail that reads as real EEPROM content.
     ///
     /// # Errors
     /// Returns [`ProtocolError::RetryExhausted`] if a block fails after all
     /// retries, or any underlying serial/protocol error.
-    pub fn download_image(&mut self) -> Result<MemoryImage> {
-        let image_size = usize::from(AUX_BLOCK_END);
+    pub fn download_image(&mut self, config: &VariantConfig) -> Result<MemoryImage> {
+        // WHY: mirrors `download_plan`, which is the variant-aware description
+        // of this same transfer. The driver reading a region the planner
+        // excludes means a plain UV-5R is issued aux reads its firmware does
+        // not answer, so the transfer fails or returns garbage.
+        let image_size = if config.has_aux_block {
+            usize::from(AUX_BLOCK_END)
+        } else {
+            usize::from(MAIN_BLOCK_END)
+        };
         let mut image = MemoryImage::new(image_size);
 
         // Main block: 64-byte reads.
@@ -421,12 +443,19 @@ impl<P: SerialPort> Uv5rProtocol<P> {
             addr = addr.wrapping_add(u16::from(READ_BLOCK_SIZE));
         }
 
+        if !config.has_aux_block {
+            return Ok(image);
+        }
+
         // Auxiliary block: 16-byte reads.
         // First read at AUX_BLOCK_START is a warm-up (data still stored).
-        let warmup = self.read_block_with_retry(AUX_BLOCK_START, AUX_READ_BLOCK_SIZE)?;
-        image.write_bytes(AUX_BLOCK_START, &warmup);
+        addr = AUX_BLOCK_START;
+        if config.needs_aux_warmup {
+            let warmup = self.read_block_with_retry(AUX_BLOCK_START, AUX_READ_BLOCK_SIZE)?;
+            image.write_bytes(AUX_BLOCK_START, &warmup);
+            addr = AUX_BLOCK_START + u16::from(AUX_READ_BLOCK_SIZE);
+        }
 
-        addr = AUX_BLOCK_START + u16::from(AUX_READ_BLOCK_SIZE);
         while addr < AUX_BLOCK_END {
             let data = self.read_block_with_retry(addr, AUX_READ_BLOCK_SIZE)?;
             image.write_bytes(addr, &data);
@@ -439,22 +468,47 @@ impl<P: SerialPort> Uv5rProtocol<P> {
     /// Upload an EEPROM image to the radio.
     ///
     /// Only writes to safe address ranges (skipping forbidden calibration
-    /// data). Writes in 16-byte blocks. Calls `progress(current, total)`
-    /// after each block.
+    /// data). Variants declaring [`VariantConfig::has_aux_block`] additionally
+    /// write the safe auxiliary ranges. Writes in 16-byte blocks. Calls
+    /// `progress(current, total)` after each block.
     ///
     /// # Errors
-    /// Returns [`ProtocolError::RetryExhausted`] if a block fails after all
-    /// retries, or any underlying serial/protocol error.
+    /// Returns [`ProtocolError::ImageTooShort`] if `image` does not cover every
+    /// range this variant would write, [`ProtocolError::RetryExhausted`] if a
+    /// block fails after all retries, or any underlying serial/protocol error.
     pub fn upload_image(
         &mut self,
+        config: &VariantConfig,
         image: &MemoryImage,
         progress: &mut dyn FnMut(usize, usize),
     ) -> Result<()> {
-        let ranges: Vec<(u16, u16)> = UPLOAD_RANGES_MAIN
+        // WHY: mirrors `upload_plan`. Writing the aux ranges on a variant with
+        // no aux block flashes a region the radio does not have.
+        let ranges: Vec<(u16, u16)> = if config.has_aux_block {
+            UPLOAD_RANGES_MAIN
+                .iter()
+                .chain(UPLOAD_RANGES_AUX.iter())
+                .copied()
+                .collect()
+        } else {
+            UPLOAD_RANGES_MAIN.to_vec()
+        };
+
+        // WHY: `MemoryImage::read_bytes` slices without a bounds check, so a
+        // short source image — a standard 0x1800 `.img` import is one — would
+        // panic mid-transfer with the radio already half-written. Refuse the
+        // whole upload up front instead, before any block is sent.
+        let required = ranges
             .iter()
-            .chain(UPLOAD_RANGES_AUX.iter())
-            .copied()
-            .collect();
+            .map(|&(_, end)| usize::from(end))
+            .max()
+            .unwrap_or(0);
+        if image.len() < required {
+            return Err(ProtocolError::ImageTooShort {
+                required,
+                actual: image.len(),
+            });
+        }
 
         // Count total blocks for progress reporting.
         let total_blocks: usize = ranges

--- a/crates/syntonia/src/baofeng/protocol_tests.rs
+++ b/crates/syntonia/src/baofeng/protocol_tests.rs
@@ -32,7 +32,10 @@ fn uv5r_download_covers_full_main_region() {
         plan.len(),
         usize::try_from(expected_blocks).unwrap_or_default()
     );
-    assert_eq!(plan.get(0).copied().unwrap_or_default().addr, MAIN_START);
+    assert_eq!(
+        plan.first().expect("download plan is non-empty").addr,
+        MAIN_START
+    );
     let last = plan.last().unwrap();
     assert_eq!(last.addr + last.size, MAIN_END);
 }
@@ -44,7 +47,7 @@ fn f8hp_download_includes_aux_warmup() {
     let warmup_ops: Vec<_> = plan.iter().filter(|op| op.is_warmup).collect();
     assert_eq!(warmup_ops.len(), 1);
     assert_eq!(
-        warmup_ops.get(0).copied().unwrap_or_default().addr,
+        warmup_ops.first().expect("exactly one warm-up op").addr,
         AUX_WARMUP_ADDR
     );
 }
@@ -470,7 +473,7 @@ fn download_image_reads_correct_address_sequence() {
     }
 
     let mut proto = make_protocol(mock);
-    let image = proto.download_image().unwrap();
+    let image = proto.download_image(&bf_f8hp_config()).unwrap();
 
     assert_eq!(image.len(), usize::from(AUX_BLOCK_END));
     // First main block byte.
@@ -504,7 +507,7 @@ fn upload_only_writes_safe_ranges() {
     let mut proto = make_protocol(mock);
 
     proto
-        .upload_image(&image, &mut |current, total| {
+        .upload_image(&bf_f8hp_config(), &image, &mut |current, total| {
             progress_calls.push((current, total));
         })
         .unwrap();
@@ -532,7 +535,7 @@ fn upload_calls_progress_callback() {
     let mut proto = make_protocol(mock);
 
     proto
-        .upload_image(&image, &mut |_current, _total| {
+        .upload_image(&bf_f8hp_config(), &image, &mut |_current, _total| {
             called = true;
         })
         .unwrap();
@@ -633,4 +636,97 @@ fn radio_ident_firmware_prefix_from_ascii() {
 #[test]
 fn radio_ident_rejects_odd_length() {
     assert!(RadioIdent::from_raw(&[1, 2, 3]).is_none());
+}
+
+// -----------------------------------------------------------------------
+// Variant-aware live-driver I/O (#225)
+// -----------------------------------------------------------------------
+
+/// Script exactly the main-block reads a UV-5R download should issue.
+fn enqueue_main_block_reads(mock: &mut MockSerialPort) {
+    let mut addr = MAIN_BLOCK_START;
+    while addr < MAIN_BLOCK_END {
+        let data = vec![0u8; usize::from(READ_BLOCK_SIZE)];
+        mock.enqueue_response(&read_response_packet(addr, &data));
+        addr += u16::from(READ_BLOCK_SIZE);
+    }
+}
+
+#[test]
+fn download_skips_aux_block_for_variant_without_one() {
+    // WARNING: the mock is scripted with main-block reads ONLY. If the driver
+    // issues the aux warm-up the way it did before #225, the queue is empty by
+    // then and the read fails — which is what makes this assertion able to go
+    // red rather than merely describing current behaviour.
+    let mut mock = MockSerialPort::new();
+    enqueue_main_block_reads(&mut mock);
+
+    let mut proto = make_protocol(mock);
+    let image = proto
+        .download_image(&uv5r_config())
+        .expect("plain UV-5R download must not touch the aux block");
+
+    assert_eq!(image.len(), usize::from(MAIN_BLOCK_END));
+}
+
+#[test]
+fn download_still_reads_aux_block_for_f8hp() {
+    let mut mock = MockSerialPort::new();
+    enqueue_main_block_reads(&mut mock);
+    let aux_blocks = (AUX_BLOCK_END - AUX_BLOCK_START) / u16::from(AUX_READ_BLOCK_SIZE);
+    for i in 0..=aux_blocks {
+        let addr = AUX_BLOCK_START + i * u16::from(AUX_READ_BLOCK_SIZE);
+        let data = vec![0u8; usize::from(AUX_READ_BLOCK_SIZE)];
+        mock.enqueue_response(&read_response_packet(addr, &data));
+    }
+
+    let mut proto = make_protocol(mock);
+    let image = proto
+        .download_image(&bf_f8hp_config())
+        .expect("F8HP download covers the aux block");
+
+    assert_eq!(image.len(), usize::from(AUX_BLOCK_END));
+}
+
+#[test]
+fn upload_skips_aux_ranges_for_variant_without_one() {
+    let main_blocks: usize = UPLOAD_RANGES_MAIN
+        .iter()
+        .map(|(s, e)| usize::from(e - s) / usize::from(WRITE_BLOCK_SIZE))
+        .sum();
+
+    // Only enough ACKs for the main ranges: an aux write would run the mock dry.
+    let mut mock = MockSerialPort::new();
+    for _ in 0..main_blocks {
+        mock.enqueue_response(&[ACK]);
+    }
+
+    let image = MemoryImage::new(usize::from(MAIN_BLOCK_END));
+    let mut progress_calls = Vec::new();
+    let mut proto = make_protocol(mock);
+
+    proto
+        .upload_image(&uv5r_config(), &image, &mut |current, total| {
+            progress_calls.push((current, total));
+        })
+        .expect("plain UV-5R upload must not write the aux ranges");
+
+    assert_eq!(progress_calls.len(), main_blocks);
+    assert_eq!(progress_calls.last(), Some(&(main_blocks, main_blocks)));
+}
+
+#[test]
+fn upload_refuses_an_image_shorter_than_the_ranges_it_would_write() {
+    let mut proto = make_protocol(MockSerialPort::new());
+    // A standard `.img` import is 0x1800 — short of the aux ranges an F8HP writes.
+    let image = MemoryImage::new(usize::from(MAIN_BLOCK_END));
+
+    let err = proto
+        .upload_image(&bf_f8hp_config(), &image, &mut |_, _| {})
+        .expect_err("a short image must be refused, not panic mid-transfer");
+
+    assert!(
+        matches!(err, ProtocolError::ImageTooShort { .. }),
+        "expected ImageTooShort, got {err:?}"
+    );
 }


### PR DESCRIPTION
`download_image` / `upload_image` took no `VariantConfig` and always processed the auxiliary block (0x1E80–0x2000), contradicting `download_plan` / `upload_plan`, which gate that region on `config.has_aux_block`. Plain UV-5R and UV-5R-original have `has_aux_block: false`, so the live driver issued aux I/O their firmware does not answer.

## Changes

- Both methods take `&VariantConfig` and mirror the planners.
- `download_image` also honours `needs_aux_warmup`, which `download_plan` gates separately (`protocol.rs:92-99`) and the driver ignored outright.
- `download_image` sizes the returned image to the region it actually read, so a no-aux variant yields `0x1800` rather than a zero-filled tail indistinguishable from real EEPROM content.
- `upload_image` refuses a source image shorter than the ranges it would write. `MemoryImage::read_bytes` slices without a bounds check (`image.rs:34`), so a standard `0x1800` `.img` import panicked partway through an F8HP upload **with the radio already half-written**. New `ProtocolError::ImageTooShort` refuses before any block is sent.
- `BaofengProtocolSession` already held a `config: VariantConfig`, so the call sites just pass it.

Also repairs two pre-existing compile errors in `protocol_tests.rs` that depended on a `Default` impl `BlockOp` does not have. Deriving `Default` was the wrong direction — a zero `BlockOp` is a plausible-looking "address 0" operation — so the assertions now name what they expect.

## ⚠️ CI does not verify this change

`baofeng::protocol` sits behind the `hardware-serial` feature (`baofeng/mod.rs:12-14`), which **no gate stage enables** — `.kanon-ci.toml` and `gate-attestation.yml` both run bare `cargo check/clippy/nextest --workspace --all-targets`. So `protocol.rs`, `detect.rs`, and the entire `protocol_tests.rs` suite are invisible to fmt, check, clippy, and nextest.

Consequence: `protocol_tests.rs` **did not compile on `main`** and nobody could have known. Confirmed on a pristine `origin/main` worktree:

```
$ cargo check -p syntonia --features hardware-serial --all-targets
error[E0277]: the trait bound `BlockOp: Default` is not satisfied
error[E0277]: the trait bound `&BlockOp: Default` is not satisfied
error: could not compile `syntonia` (lib test) due to 2 previous errors
```

A green check on this PR therefore attests nothing about it. Filed as a separate issue.

## Verification (local, `--features hardware-serial`)

`cargo nextest run -p syntonia --features hardware-serial` → **202 passed, 0 failed**. That suite had never run.

Falsified rather than observed green: with the variant gating reverted but the signatures kept, 3 of the 4 new tests fail, and the panic the issue predicted reproduces exactly —

```
FAIL upload_skips_aux_ranges_for_variant_without_one
  panicked at image.rs:34: range start index 7904 out of range for slice of length 6144
FAIL download_skips_aux_block_for_variant_without_one
FAIL upload_refuses_an_image_shorter_than_the_ranges_it_would_write
PASS download_still_reads_aux_block_for_f8hp     <- behaviour-preservation control
```

The no-aux tests script the mock with **only** the main-block reads/ACKs, so an aux access runs the queue dry — that is what makes them able to go red rather than merely describe current behaviour.

`cargo fmt --all --check` clean. `cargo clippy -p syntonia --features hardware-serial --all-targets` reports 13 lib warnings plus errors — **all pre-existing** in the never-linted feature-gated code (`detect.rs`, `constants.rs`, `protocol.rs:317/320/357/607/610/649`, `protocol_tests.rs:72/125/337/561/570`). I checked each against my diff; none are in code this PR wrote. Not fixed here — that is the separate coverage issue's scope, not this fix's.

Refs #225