### PR TITLE
docs: restore the generated kanon:auto blocks in AGENTS/CLAUDE/README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,69 @@ Communications sovereignty and RF intelligence platform. Rust workspace, single 
 - Always: run `cargo fmt` + `cargo clippy -D warnings` before pushing, rebase onto main (linear history), squash merge
 - Ask first: changes to `GeoSignal` enum, crypto primitives in `kryphos`, workspace-wide dependency bumps
 - Never: push to upstream with `--force`, bypass CI with `--admin`, commit secrets (see `.gitleaks.toml`)
+
+<!-- kanon:auto-start -->
+<!--
+scope: akroasis repo cross-tool agent guide (Claude Code, Kimi, Codex, Cursor, Windsurf, Copilot)
+generated_by: kanon docs sync
+defers_to: CLAUDE.md for Claude Code-specific behavior; ~/menos-ops/CLAUDE.md for machine + service topology
+tightens: workflow/AGENTS-mcp-tools.md catalog routing; crates/basanos/standards/AGENT-DOCS.md authoring rules
+-->
+
+# akroasis
+
+Kanon-managed forkwright repository `akroasis`.
+
+## Commands
+
+Run `kanon --help` for all kanon-managed workflow commands. Run project-local
+build, test, and lint commands from this repository root.
+
+- `kanon gate` - full local gate for kanon-managed PRs
+- `kanon lint --fix` - deterministic standards fixes
+- `kanon lint --explain <RULE>` - rule rationale and fix guidance
+- `kanon pr open <head_ref> --title "..."` - open a forge PR
+- `kanon pr merge <N> [--strategy squash|ff|rebase]` - merge after CI and gate checks
+- `kanon docs sync --check --repo akroasis` - verify derived bootstrap docs
+- `kanon docs sync --apply --repo akroasis` - regenerate derived bootstrap docs
+
+For agent-native operations, prefer the `mcp__kanon__*` tool family. See
+[workflow/AGENTS-mcp-tools.md](workflow/AGENTS-mcp-tools.md) for routing and fallback rules.
+
+## Standards
+
+Read `crates/basanos/standards/STANDARDS.md` § Philosophy before writing code. Key principles:
+no workarounds, define once, reference everywhere, no shortcuts, no compromise on quality.
+Rust work also reads `crates/basanos/standards/RUST.md` before editing Rust code.
+
+## Rules
+
+- Structured comment tags only: WHY, NOTE, WARNING, PERF, SAFETY, INVARIANT, TODO(#NNN), FIXME(#NNN)
+- Conventional commits: `type(scope): description`
+- Add `Gate-Passed: kanon 0.1.0` to validated commit bodies
+- Never add `#[allow]` suppressions; use `#[expect(lint, reason = "...")]` only when justified
+- Prefer MCP tools first; CLI commands are resilience fallbacks
+
+## Architecture
+
+- Registry name: `akroasis`
+- Forge repo: `forkwright/akroasis`
+- Kanon prefix: `ak`
+- Config source: `workflow/kanon.toml [projects.akroasis]`
+
+## Boundaries
+
+Always: run the applicable gate before pushing, stay inside the declared blast radius.
+Ask first: workflow, service, credential, schema, or deployment changes.
+Never: bypass CI, push to protected upstream refs, commit secrets, or suppress warnings.
+
+## Blast zone
+
+- Paths explicitly named by the rendered prompt, role, or template input.
+
+## Acceptance verifier
+
+```bash
+kanon gate
+```
+<!-- kanon:auto-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,27 @@ cargo clippy --workspace               # Lint (zero warnings)
 
 Conventional commits: `<type>(<scope>): <description>`. Scope is the crate name.
 Branch from `main`. Rebase before pushing. Squash merge.
+
+<!-- kanon:auto-start -->
+## Generated kanon context
+
+- Registry name: `akroasis`
+- Forge repo: `forkwright/akroasis`
+- Kanon prefix: `ak`
+- Config source: `workflow/kanon.toml [projects.akroasis]`
+- Standards source: `crates/basanos/standards/STANDARDS.md`
+- MCP routing catalog: `workflow/AGENTS-mcp-tools.md`
+
+Run `kanon docs sync --check --repo akroasis` to verify this generated
+section and `kanon docs sync --apply --repo akroasis` to refresh it.
+
+## Blast zone
+
+- Paths explicitly named by the rendered prompt, role, or template input.
+
+## Acceptance verifier
+
+```bash
+kanon gate
+```
+<!-- kanon:auto-end -->

--- a/README.md
+++ b/README.md
@@ -166,3 +166,28 @@ Names follow the project naming philosophy, where each name reveals its essentia
 ## Disclaimer
 
 This software is for research and educational purposes. See [DISCLAIMER.md](DISCLAIMER.md) for details on user responsibility, licensing, and legal considerations. The authors accept no responsibility for any specific use of this software.
+
+<!-- kanon:auto-start -->
+## Repository Metadata
+
+- Registry name: `akroasis`
+- Description: Kanon-managed forkwright repository `akroasis`.
+- Forge repo: `forkwright/akroasis`
+- Kanon prefix: `ak`
+- Config source: `workflow/kanon.toml [projects.akroasis]`
+- Planning state: `projects/akroasis/STATE.md`
+- Last state update: `not recorded`
+
+Run `kanon docs sync --check --repo akroasis` to verify this generated
+section and `kanon docs sync --apply --repo akroasis` to refresh it.
+
+## Blast zone
+
+- Paths explicitly named by the rendered prompt, role, or template input.
+
+## Acceptance verifier
+
+```bash
+kanon gate
+```
+<!-- kanon:auto-end -->


### PR DESCRIPTION
`kanon docs sync --check --repo akroasis` reported drift: `AGENTS.md`, `CLAUDE.md`, and `README.md`
were each missing their generated `<!-- kanon:auto-start -->…<!-- kanon:auto-end -->` block. Blocks
added byte-matching the check's own diff output. Additions only, no existing content touched.

Verified clean: `--check` now reports `ok  docs sync: derived docs match generated content`.

## How this was verified without endangering the canonical checkout

`kanon docs sync` resolves `repo_dir` from `workflow/kanon.toml` and cannot be pointed at a
worktree, so verifying the fix required a careful dance: copy the worktree's three files into the
(already clean) `~/dev/akroasis`, run the **read-only** `--check`, then immediately
`git checkout --` to restore. `~/dev/akroasis` was confirmed clean before and after.

Applying directly with `--apply` was deliberately avoided — an earlier worker did that expecting a
`--config` override to redirect it, and it wrote into the canonical checkout instead (kanon#2776).

## Two findings worth carrying upstream

**kanon#2776 is broader than it states.** It describes `--apply` ignoring `--config`. The override is
ignored for **`--check`** as well, so even the read-only path cannot be aimed at a non-canonical
checkout.

**Root cause:** `kanon docs sync` has no `--repo-dir` or equivalent for either flag. There is no
supported way to render or verify docs against a worktree, which is why every worker has to perform
the copy-and-restore above and why the canonical checkout keeps getting touched by accident.

Both reported on kanon#2776.

Refs #266
