### PR TITLE
fix(syntonia): add assertion messages and clear the dead bare-assert baseline family

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -718,262 +718,76 @@ line = 318
 hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 319
-hash = "8a40d5727b684435291907633696a452ba80ca083a800b6733134ac112ef6ec9"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 326
+line = 330
 hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 327
-hash = "8a40d5727b684435291907633696a452ba80ca083a800b6733134ac112ef6ec9"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 335
+line = 343
 hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 336
-hash = "8a40d5727b684435291907633696a452ba80ca083a800b6733134ac112ef6ec9"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 345
+line = 357
 hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 346
-hash = "7e74063cc42d1a76680e2ccd4d06ef81cde1650c2a8cefe4a13cfff33fd24c0b"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 354
+line = 370
 hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 355
-hash = "7e74063cc42d1a76680e2ccd4d06ef81cde1650c2a8cefe4a13cfff33fd24c0b"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 362
+line = 382
 hash = "c094aaf595475108e5824f55ddd24c0e8afe4ec5f9c00a9650fcf4e1627b0f10"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 363
-hash = "7e74063cc42d1a76680e2ccd4d06ef81cde1650c2a8cefe4a13cfff33fd24c0b"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 383
-hash = "82e2d02602b541a81f7204320c75e300f1fb6f39d5ad7563874b098876e92f87"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 384
-hash = "0d4e5f305d5037c921999f90a079868e4cde916f76303aae87d83bf68f7ab5a9"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 386
-hash = "f0c4c923f192332c2eb321f715419ea1c9d746438ed7983212dcef5bc9ab6c85"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 392
-hash = "82e2d02602b541a81f7204320c75e300f1fb6f39d5ad7563874b098876e92f87"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 393
-hash = "0d4e5f305d5037c921999f90a079868e4cde916f76303aae87d83bf68f7ab5a9"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 394
-hash = "623acb6bae40a087d60a38c5fa6dc9cdc8ef96d68d2d351c6c3f0a5a5d7b067f"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 400
+line = 448
 hash = "38e9ab1ef1c4c968a33c6d58f8bf43fb6db8a12b934b60ba833877db2a2ad385"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 401
-hash = "7ba330c5dc67ec0d1c2a5b9e50c59f594308ff07f0423ddc32f8c86d099bf543"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 402
+line = 454
 hash = "231bf6514a8e0f85b0c8066d0286a9b910e67ebe40a909f251d7a415779d01ce"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 403
-hash = "49cdeb321eb086bf1e93ba7bbbb9a5eceab49cbe793e4aabe7f4677e21f6a949"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 410
+line = 466
 hash = "41c2164cbb32013c1ca3612dad96f68abff893b36751851009cecd8769abba8a"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 411
-hash = "b57494707a3a1e2c2722980a4ca7a92f44e9abf9e1781948f610a9a5893ea96d"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 418
-hash = "0ba4f2348046839d346a79f9a564c9d702e7600fb113bf72142d82d81053fdcc"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 419
-hash = "594907db99377fa6032e504fd2036558b14f3a26ab5fc05210022e1dd3d48aec"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 425
-hash = "2a14c3f17396e825d34f4adc97ebab46d47816903d89418b33baf6035fa5f7d5"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 426
-hash = "52f1e7cbafea09bffd78f0989f585651d5457794d9acd9585a1f723866698314"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 432
-hash = "0ba4f2348046839d346a79f9a564c9d702e7600fb113bf72142d82d81053fdcc"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 433
-hash = "594907db99377fa6032e504fd2036558b14f3a26ab5fc05210022e1dd3d48aec"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 434
-hash = "2b4aacec45ed139a2d69cd3fcf3d903832f3b39ae933e59e0c13eac35c4b42aa"
-
-[[baseline.entry]]
 rule = "RUST/unwrap"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 440
+line = 518
 hash = "768ddb73b8a45e552aab286432b1359f724bd84afa0d7730d4c7f96fb81b1729"
 
 [[baseline.entry]]
-rule = "RUST/bare-assert"
+rule = "RUST/indexing-slicing"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 441
-hash = "bb62c3e119c9d2c7ea589c560edc932de96a4a5e5828d5b7a3c2687359175934"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 458
-hash = "0626f20170f347be01920b5925e64f33884c186e9f9ae83bc7eebe5b11f3f689"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 459
-hash = "00626b7ea54b9ae26341f77da74be0109e696a71de72d00c52a7b435332c92ad"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 464
-hash = "8e8d7f935dab7cdc4d1a1c8d336eb7ab59cba4d9db446ca8300bcf9b1e7aece4"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 465
-hash = "0c7e704838ba3fb9a457184230be426be022401aae87f85e6cbc73c0dd66f43e"
+line = 559
+hash = "9004ad6f4ded6281c812fb843769186fab164301e0aa880e79e3ae32683bf79f"
 
 [[baseline.entry]]
 rule = "RUST/indexing-slicing"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 465
-hash = "0c7e704838ba3fb9a457184230be426be022401aae87f85e6cbc73c0dd66f43e"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 466
-hash = "f42b2cb757ae1e2643e0e397afc86d2371f6e953de554a13cbe9d7e311c6c694"
+line = 563
+hash = "ee55d690a5df013a28a7926eb2fd9e93c643acccb51c7b8a0e02162e6c338551"
 
 [[baseline.entry]]
 rule = "RUST/indexing-slicing"
 file = "crates/syntonia/src/baofeng/variant.rs"
-line = 466
-hash = "f42b2cb757ae1e2643e0e397afc86d2371f6e953de554a13cbe9d7e311c6c694"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 467
-hash = "80d16f04190b8ea1927bb2a127d41ace988c6bb5282d51e01a58098f03308937"
-
-[[baseline.entry]]
-rule = "RUST/indexing-slicing"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 467
-hash = "80d16f04190b8ea1927bb2a127d41ace988c6bb5282d51e01a58098f03308937"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 478
-hash = "71335c3733396048bcd74191f9cd71084d4900d6fcd26e3ca06a81f281355ed6"
-
-[[baseline.entry]]
-rule = "RUST/bare-assert"
-file = "crates/syntonia/src/baofeng/variant.rs"
-line = 490
-hash = "60f47864faae784f0e41fbde70f1a1defc1596257ecde0bdf82de546d1404e71"
+line = 567
+hash = "4fc108ef055cdd08e2914f0128cae15715986c51b0d55ebc7dabc640175ec0ec"
 
 [[baseline.entry]]
 rule = "RUST/config-deny-unknown-fields"

--- a/crates/syntonia/src/baofeng/variant.rs
+++ b/crates/syntonia/src/baofeng/variant.rs
@@ -316,7 +316,11 @@ mod tests {
     fn identify_bfb_firmware_as_uv5r() -> Result<(), &'static str> {
         let ident = RadioIdent::from_raw(b"BFB297\x00\x00").ok_or("8-byte literal must parse")?;
         let config = identify_variant(&ident).unwrap();
-        assert_eq!(config.variant, RadioVariant::Uv5r);
+        assert_eq!(
+            config.variant,
+            RadioVariant::Uv5r,
+            "BFB-prefixed firmware idents must resolve to the Uv5r variant"
+        );
         Ok(())
     }
 
@@ -324,7 +328,11 @@ mod tests {
     fn identify_bfs_firmware_as_uv5r() -> Result<(), &'static str> {
         let ident = RadioIdent::from_raw(b"BFS300\x00\x00").ok_or("8-byte literal must parse")?;
         let config = identify_variant(&ident).unwrap();
-        assert_eq!(config.variant, RadioVariant::Uv5r);
+        assert_eq!(
+            config.variant,
+            RadioVariant::Uv5r,
+            "BFS-prefixed firmware idents must resolve to the Uv5r variant"
+        );
         Ok(())
     }
 
@@ -333,7 +341,11 @@ mod tests {
         let ident =
             RadioIdent::from_raw(b"N5R-2\x00\x00\x00").ok_or("8-byte literal must parse")?;
         let config = identify_variant(&ident).unwrap();
-        assert_eq!(config.variant, RadioVariant::Uv5r);
+        assert_eq!(
+            config.variant,
+            RadioVariant::Uv5r,
+            "N5R-2 firmware idents must resolve to the Uv5r variant"
+        );
         Ok(())
     }
 
@@ -343,7 +355,11 @@ mod tests {
         // the full normalized ident, not the 6-char firmware_prefix field.
         let ident = RadioIdent::from_raw(b"BFP3V3 F").ok_or("8-byte literal must parse")?;
         let config = identify_variant(&ident).unwrap();
-        assert_eq!(config.variant, RadioVariant::BfF8hp);
+        assert_eq!(
+            config.variant,
+            RadioVariant::BfF8hp,
+            "BFP3V3 F firmware idents must resolve to the BfF8hp variant"
+        );
         Ok(())
     }
 
@@ -352,7 +368,11 @@ mod tests {
         let ident =
             RadioIdent::from_raw(b"N5R-3\x00\x00\x00").ok_or("8-byte literal must parse")?;
         let config = identify_variant(&ident).unwrap();
-        assert_eq!(config.variant, RadioVariant::BfF8hp);
+        assert_eq!(
+            config.variant,
+            RadioVariant::BfF8hp,
+            "N5R-3 firmware idents must resolve to the BfF8hp variant"
+        );
         Ok(())
     }
 
@@ -360,7 +380,11 @@ mod tests {
     fn identify_bft_firmware_as_f8hp() -> Result<(), &'static str> {
         let ident = RadioIdent::from_raw(b"BFT123\x00\x00").ok_or("8-byte literal must parse")?;
         let config = identify_variant(&ident).unwrap();
-        assert_eq!(config.variant, RadioVariant::BfF8hp);
+        assert_eq!(
+            config.variant,
+            RadioVariant::BfF8hp,
+            "BFT-prefixed firmware idents must resolve to the BfF8hp variant"
+        );
         Ok(())
     }
 
@@ -380,27 +404,59 @@ mod tests {
     #[test]
     fn uv5r_has_two_logical_power_levels() {
         let config = uv5r_config();
-        assert_eq!(config.power_from_bits(0), Some(PowerLevel::High));
-        assert_eq!(config.power_from_bits(1), Some(PowerLevel::Low));
+        assert_eq!(
+            config.power_from_bits(0),
+            Some(PowerLevel::High),
+            "UV-5R power bit 0 must decode to High"
+        );
+        assert_eq!(
+            config.power_from_bits(1),
+            Some(PowerLevel::Low),
+            "UV-5R power bit 1 must decode to Low"
+        );
         // WHY: bit 2 (Mid) maps to High — UV-5R has no mid setting
-        assert_eq!(config.power_from_bits(2), Some(PowerLevel::High));
+        assert_eq!(
+            config.power_from_bits(2),
+            Some(PowerLevel::High),
+            "UV-5R has no Mid setting, so power bit 2 must also decode to High"
+        );
     }
 
     #[test]
     fn f8hp_has_three_power_levels() {
         let config = bf_f8hp_config();
-        assert_eq!(config.power_from_bits(0), Some(PowerLevel::High));
-        assert_eq!(config.power_from_bits(1), Some(PowerLevel::Low));
-        assert_eq!(config.power_from_bits(2), Some(PowerLevel::Mid));
+        assert_eq!(
+            config.power_from_bits(0),
+            Some(PowerLevel::High),
+            "F8HP power bit 0 must decode to High"
+        );
+        assert_eq!(
+            config.power_from_bits(1),
+            Some(PowerLevel::Low),
+            "F8HP power bit 1 must decode to Low"
+        );
+        assert_eq!(
+            config.power_from_bits(2),
+            Some(PowerLevel::Mid),
+            "F8HP power bit 2 must decode to Mid, unlike the UV-5R which has no Mid setting"
+        );
     }
 
     #[test]
     fn uv5r_bits_from_power_roundtrips() {
         let config = uv5r_config();
         let bits = config.bits_from_power(PowerLevel::High).unwrap();
-        assert_eq!(config.power_from_bits(bits), Some(PowerLevel::High));
+        assert_eq!(
+            config.power_from_bits(bits),
+            Some(PowerLevel::High),
+            "encoding UV-5R High power to bits and decoding it back must yield High"
+        );
         let bits = config.bits_from_power(PowerLevel::Low).unwrap();
-        assert_eq!(config.power_from_bits(bits), Some(PowerLevel::Low));
+        assert_eq!(
+            config.power_from_bits(bits),
+            Some(PowerLevel::Low),
+            "encoding UV-5R Low power to bits and decoding it back must yield Low"
+        );
     }
 
     #[test]
@@ -408,37 +464,62 @@ mod tests {
         let config = bf_f8hp_config();
         for level in [PowerLevel::High, PowerLevel::Mid, PowerLevel::Low] {
             let bits = config.bits_from_power(level).unwrap();
-            assert_eq!(config.power_from_bits(bits), Some(level));
+            assert_eq!(
+                config.power_from_bits(bits),
+                Some(level),
+                "encoding F8HP {level:?} power to bits and decoding it back must yield {level:?}"
+            );
         }
     }
 
     #[test]
     fn f8hp_has_aux_block_and_warmup() {
         let config = bf_f8hp_config();
-        assert!(config.has_aux_block);
-        assert!(config.needs_aux_warmup);
+        assert!(config.has_aux_block, "F8HP variant must have an aux block");
+        assert!(
+            config.needs_aux_warmup,
+            "F8HP variant must require aux warmup"
+        );
     }
 
     #[test]
     fn uv5r_has_no_aux_block() {
         let config = uv5r_config();
-        assert!(!config.has_aux_block);
-        assert!(!config.needs_aux_warmup);
+        assert!(
+            !config.has_aux_block,
+            "UV-5R variant must not have an aux block"
+        );
+        assert!(
+            !config.needs_aux_warmup,
+            "UV-5R variant must not require aux warmup"
+        );
     }
 
     #[test]
     fn uv5rm_plus_assumed_same_as_f8hp_layout() {
         let config = uv5rm_plus_config();
-        assert!(config.has_aux_block);
-        assert!(config.needs_aux_warmup);
-        assert_eq!(config.magic, MAGIC_BF_F8HP);
+        assert!(
+            config.has_aux_block,
+            "UV-5RM Plus is assumed to share the F8HP's aux block"
+        );
+        assert!(
+            config.needs_aux_warmup,
+            "UV-5RM Plus is assumed to share the F8HP's aux warmup requirement"
+        );
+        assert_eq!(
+            config.magic, MAGIC_BF_F8HP,
+            "UV-5RM Plus is assumed to share the F8HP's magic bytes"
+        );
         // Higher wattage than F8HP
         let high = config
             .power_levels
             .iter()
             .find(|m| m.level == PowerLevel::High)
             .unwrap();
-        assert!((high.watts - 10.0).abs() < f32::EPSILON);
+        assert!(
+            (high.watts - 10.0).abs() < f32::EPSILON,
+            "UV-5RM Plus High power level must be 10 watts"
+        );
     }
 
     #[test]
@@ -455,16 +536,37 @@ mod tests {
     #[test]
     fn unknown_bits_returns_none() {
         let config = uv5r_config();
-        assert_eq!(config.power_from_bits(3), None);
-        assert_eq!(config.power_from_bits(255), None);
+        assert_eq!(
+            config.power_from_bits(3),
+            None,
+            "power bit pattern 3 is undefined and must decode to None"
+        );
+        assert_eq!(
+            config.power_from_bits(255),
+            None,
+            "power bit pattern 255 is undefined and must decode to None"
+        );
     }
 
     #[test]
     fn magic_sets_contains_all_three() {
-        assert_eq!(MAGIC_SETS.len(), 3);
-        assert_eq!(MAGIC_SETS[0], MAGIC_UV5R_291);
-        assert_eq!(MAGIC_SETS[1], MAGIC_BF_F8HP);
-        assert_eq!(MAGIC_SETS[2], MAGIC_UV5R_ORIG);
+        assert_eq!(
+            MAGIC_SETS.len(),
+            3,
+            "MAGIC_SETS must list exactly the three known magic byte sequences"
+        );
+        assert_eq!(
+            MAGIC_SETS[0], MAGIC_UV5R_291,
+            "MAGIC_SETS[0] must be the UV-5R 291 magic sequence"
+        );
+        assert_eq!(
+            MAGIC_SETS[1], MAGIC_BF_F8HP,
+            "MAGIC_SETS[1] must be the BF-F8HP magic sequence"
+        );
+        assert_eq!(
+            MAGIC_SETS[2], MAGIC_UV5R_ORIG,
+            "MAGIC_SETS[2] must be the original UV-5R magic sequence"
+        );
     }
 
     #[test]
@@ -475,7 +577,10 @@ mod tests {
             bf_f8hp_config(),
             uv5rm_plus_config(),
         ] {
-            assert_eq!(config.channel_count, 128);
+            assert_eq!(
+                config.channel_count, 128,
+                "every variant must report 128 channels"
+            );
         }
     }
 
@@ -487,7 +592,10 @@ mod tests {
             bf_f8hp_config(),
             uv5rm_plus_config(),
         ] {
-            assert_eq!(config.baud_rate, 9_600);
+            assert_eq!(
+                config.baud_rate, 9_600,
+                "every variant must communicate at 9600 baud"
+            );
         }
     }
 }


### PR DESCRIPTION
Clears the largest single family from `.kanon-lint-baseline.toml`, which carries
`remove_after = "2026-08-13"`. An expired non-empty baseline makes `kanon lint` return an error and
stop linting entirely (`basanos/src/baseline.rs:143`), so every entry removed before that date is
one fewer reason the gate blocks.

## What the 31 entries turned out to be

All 31 `RUST/bare-assert` entries sat inside `#[cfg(test)] mod tests` in
`crates/syntonia/src/baofeng/variant.rs`. The rule sets `skip_in_test: true` and stops scanning at
the `#[cfg(test)]` boundary, so **none of them was suppressing a live violation** — confirmed with
`kanon lint --strict` and `--show-suppressions-only`, both of which reported zero bare-assert hits
before any edit. They were dead weight counting toward an expiry deadline.

The assertion messages were written anyway, because `RUST.md#assertions` states the message
requirement with no test-code exception, and a bare `assert_eq!` failing in CI tells you two values
differed but not which invariant broke. Each message names what should have been true in the
radio domain's terms:

```rust
assert_eq!(config.power_from_bits(2), Some(PowerLevel::High),
    "UV-5R has no Mid setting, so power bit 2 must also decode to High");
```

No assertion's operands or logic changed — only the message and the formatting needed to fit it.

## Sibling baseline entries were re-anchored, not left to rot

Expanding 31 assertions to multi-line shifted every later line in the file, which moves the `line:`
anchor of 10 `RUST/unwrap` and 3 `RUST/indexing-slicing` entries belonging to *other* families in
the same file. Those anchors were corrected to the new positions of the same unchanged code — the
content hashes are untouched because the code did not change, only its position. Leaving them would
have silently broken three other families' suppressions as a side effect of this one.

## Verification

Compared against this branch's own base (`010c9c5`), not against a moved `main`:

| | base `010c9c5` | branch `6aea274` |
|---|---|---|
| Total violations | 24 | 24 |
| suppressed by baseline | 112 | 112 |
| strict equivalent | 152 | 152 |

Identical — no new violations, no broken suppressions. Baseline drops from 197 entries to 166.

`cargo test -p syntonia`: 117 passed, 0 failed, including all 19 tests in `baofeng::variant::tests`.

## Follow-up this surfaced

84 of the remaining 197 entries suppress nothing at all (197 recorded, 113 actively suppressing).
Baseline entries can be recorded against code a rule structurally never scans, and
`--detect-stale-suppressions` does not flag them. Tracked separately.

Refs #261
