### PR TITLE
fix(syntonia): close nine wave-1 audit findings and consolidate detection tables

### DIFF
--- a/crates/syntonia/src/baofeng/codec.rs
+++ b/crates/syntonia/src/baofeng/codec.rs
@@ -332,6 +332,138 @@ mod tests {
         image
     }
 
+    /// Write a raw 16-byte channel record straight into the image.
+    ///
+    /// WHY: `encode_channel` is the inverse of the function under test, so a
+    /// test that builds its fixture with it can only show the two agree — not
+    /// that either matches the EEPROM layout. These tests assert decode
+    /// against hand-built bytes instead.
+    fn write_raw_channel(
+        image: &mut MemoryImage,
+        index: u8,
+        rx_hz: u64,
+        tx_hz: Option<u64>,
+        byte14: u8,
+        byte15: u8,
+    ) {
+        let mut ch = [0xFFu8; 16];
+        ch[0..4].copy_from_slice(&bcd::lbcd4_encode(rx_hz).unwrap());
+        match tx_hz {
+            Some(hz) => ch[4..8].copy_from_slice(&bcd::lbcd4_encode(hz).unwrap()),
+            None => ch[4..8].copy_from_slice(&[0xFF; 4]),
+        }
+        // Tone slots: 0x0000 in both is "no tone".
+        ch[8..12].copy_from_slice(&[0x00; 4]);
+        ch[14] = byte14;
+        ch[15] = byte15;
+        image.write_bytes(CHANNEL_BASE + u16::from(index) * CHANNEL_STRIDE, &ch);
+    }
+
+    /// Byte-15 flag bits, per the UV-5R channel record.
+    const FLAG_WIDE: u8 = 0x40;
+    const FLAG_SCAN_INCLUDE: u8 = 0x04;
+    const FLAG_BUSY_LOCK: u8 = 0x08;
+
+    fn decode_raw(byte14: u8, byte15: u8) -> Channel {
+        let mut image = MemoryImage::new(0x1800);
+        write_raw_channel(
+            &mut image,
+            3,
+            146_520_000,
+            Some(146_520_000),
+            byte14,
+            byte15,
+        );
+        decode_channel(&image, 3).unwrap().unwrap()
+    }
+
+    // ── byte 15: bandwidth, scan, busy lock ──────────────────────────────
+
+    #[test]
+    fn decode_reads_narrow_bandwidth_when_the_wide_bit_is_clear() {
+        assert_eq!(decode_raw(0, 0).bandwidth, Bandwidth::Narrow);
+        assert_eq!(decode_raw(0, FLAG_WIDE).bandwidth, Bandwidth::Wide);
+    }
+
+    #[test]
+    fn decode_reads_skip_scan_when_the_include_bit_is_clear() {
+        assert_eq!(decode_raw(0, 0).scan, ScanMode::Skip);
+        assert_eq!(decode_raw(0, FLAG_SCAN_INCLUDE).scan, ScanMode::Include);
+    }
+
+    #[test]
+    fn decode_reads_busy_lock_from_its_own_bit() {
+        assert!(!decode_raw(0, 0).busy_lock);
+        assert!(decode_raw(0, FLAG_BUSY_LOCK).busy_lock);
+    }
+
+    // WHY: the three flags share byte 15, so a mask that is too wide reads one
+    // as another. Setting all three at once catches that; the tests above,
+    // each setting a single bit, cannot.
+    #[test]
+    fn decode_reads_the_byte_fifteen_flags_independently() {
+        let ch = decode_raw(0, FLAG_WIDE | FLAG_SCAN_INCLUDE | FLAG_BUSY_LOCK);
+        assert_eq!(ch.bandwidth, Bandwidth::Wide);
+        assert_eq!(ch.scan, ScanMode::Include);
+        assert!(ch.busy_lock);
+    }
+
+    // ── byte 14: power ───────────────────────────────────────────────────
+
+    #[test]
+    fn decode_reads_each_power_level_from_byte_fourteen() {
+        assert_eq!(decode_raw(0, FLAG_WIDE).power, PowerLevel::High);
+        assert_eq!(decode_raw(1, FLAG_WIDE).power, PowerLevel::Low);
+        assert_eq!(decode_raw(2, FLAG_WIDE).power, PowerLevel::Mid);
+    }
+
+    // WHY: only the low two bits carry power; the rest of byte 14 is other
+    // per-channel state, so a decoder reading the whole byte misreads every
+    // channel that has any of it set.
+    #[test]
+    fn decode_ignores_the_high_bits_of_byte_fourteen() {
+        assert_eq!(decode_raw(0xFC, FLAG_WIDE).power, PowerLevel::High);
+        assert_eq!(decode_raw(0xFD, FLAG_WIDE).power, PowerLevel::Low);
+        assert_eq!(decode_raw(0xFE, FLAG_WIDE).power, PowerLevel::Mid);
+    }
+
+    // ── TX/RX pair: derived offset ───────────────────────────────────────
+
+    #[test]
+    fn decode_derives_a_minus_offset_when_tx_is_below_rx() {
+        let mut image = MemoryImage::new(0x1800);
+        write_raw_channel(&mut image, 0, 147_060_000, Some(146_460_000), 0, FLAG_WIDE);
+        let ch = decode_channel(&image, 0).unwrap().unwrap();
+        assert_eq!(ch.tx_freq, Some(Frequency::hz(146_460_000)));
+        assert_eq!(ch.offset, FrequencyOffset::Minus(Frequency::hz(600_000)));
+    }
+
+    #[test]
+    fn decode_derives_a_plus_offset_when_tx_is_above_rx() {
+        let mut image = MemoryImage::new(0x1800);
+        write_raw_channel(&mut image, 0, 147_060_000, Some(147_660_000), 0, FLAG_WIDE);
+        let ch = decode_channel(&image, 0).unwrap().unwrap();
+        assert_eq!(ch.offset, FrequencyOffset::Plus(Frequency::hz(600_000)));
+    }
+
+    #[test]
+    fn decode_reports_no_offset_when_tx_equals_rx() {
+        let mut image = MemoryImage::new(0x1800);
+        write_raw_channel(&mut image, 0, 147_060_000, Some(147_060_000), 0, FLAG_WIDE);
+        let ch = decode_channel(&image, 0).unwrap().unwrap();
+        assert_eq!(ch.tx_freq, Some(Frequency::hz(147_060_000)));
+        assert_eq!(ch.offset, FrequencyOffset::None);
+    }
+
+    #[test]
+    fn decode_reports_a_receive_only_channel_when_tx_is_unprogrammed() {
+        let mut image = MemoryImage::new(0x1800);
+        write_raw_channel(&mut image, 0, 147_060_000, None, 0, FLAG_WIDE);
+        let ch = decode_channel(&image, 0).unwrap().unwrap();
+        assert_eq!(ch.tx_freq, None);
+        assert_eq!(ch.offset, FrequencyOffset::None);
+    }
+
     #[test]
     fn decode_simplex_channel() {
         let image = make_test_image();

--- a/crates/syntonia/src/baofeng/detect.rs
+++ b/crates/syntonia/src/baofeng/detect.rs
@@ -7,6 +7,7 @@
 
 use snafu::Snafu;
 
+use super::constants::{ACK, CMD_IDENT};
 use super::ident::RadioIdent;
 use super::variant::{MAGIC_SETS, VariantConfig, VariantError, identify_variant};
 
@@ -59,6 +60,13 @@ pub enum DetectError {
     #[snafu(display("timeout waiting for radio response"))]
     Timeout,
 
+    /// The radio answered the magic sequence with a byte other than `ACK`.
+    #[snafu(display("unexpected handshake byte: expected 0x{ACK:02X}, got 0x{got:02X}"))]
+    UnexpectedAck {
+        /// The byte the radio actually sent.
+        got: u8,
+    },
+
     /// All magic byte sequences failed  -  no radio detected.
     #[snafu(display(
         "no compatible radio detected after trying all magic sequences. \
@@ -91,6 +99,10 @@ pub enum DetectError {
 /// programming mode with each SET. On success, reads the firmware ident
 /// and returns the matched [`VariantConfig`].
 ///
+/// A magic set that times out, or that is answered with a byte other than
+/// [`ACK`], means "not this variant" and the next set is tried. Any other
+/// error aborts the scan.
+///
 /// # Errors
 ///
 /// - [`DetectError::NoRadioDetected`] if all magic sets fail (includes
@@ -105,7 +117,7 @@ pub(crate) fn auto_detect(
     for &magic in MAGIC_SETS {
         match try_magic(port, magic) {
             Ok((ident, config)) => return Ok((ident, config)),
-            Err(DetectError::Timeout) => {}
+            Err(DetectError::Timeout | DetectError::UnexpectedAck { .. }) => {}
             Err(other) => return Err(other),
         }
     }
@@ -122,15 +134,20 @@ fn try_magic(
     port.write_all(&magic)?;
     port.flush()?;
 
-    // Read ACK (single byte: 0x06)
+    // Read ACK (single byte)
     let mut ack = [0u8; 1];
     port.read_exact(&mut ack)?;
-    if ack.get(0).copied().unwrap_or_default() != 0x06 {
-        return TimeoutSnafu.fail();
+    let got = ack.first().copied().unwrap_or_default();
+    if got != ACK {
+        // WHY: a wrong byte is a radio that answered but speaks a different
+        // dialect; a timeout is silence. Both mean "try the next magic set",
+        // but reporting the first as the second sends the operator to the
+        // cable-and-power troubleshooting for a radio that is plainly awake.
+        return UnexpectedAckSnafu { got }.fail();
     }
 
-    // Send identify command (0x02)
-    port.write_all(&[0x02])?;
+    // Send identify command
+    port.write_all(&[CMD_IDENT])?;
     port.flush()?;
 
     // Read ident response: length byte + ident data
@@ -286,6 +303,39 @@ mod tests {
         queue_uv5r_handshake(&mut mock, b"BFB100\x00\x00");
         let (_, config) = auto_detect(&mut mock).unwrap();
         assert_eq!(config.variant, RadioVariant::Uv5r);
+    }
+
+    // WHY: a falsifiable pair. A radio that answers the magic sequence with
+    // the wrong byte is awake; a port that answers nothing is not. Both make
+    // `auto_detect` move to the next magic set, but reporting the first as a
+    // timeout sends the operator to the cable-and-power checklist for a radio
+    // that is plainly responding.
+    #[test]
+    fn wrong_handshake_byte_is_not_reported_as_a_timeout() {
+        let mut mock = MockSerial::new();
+        mock.queue_data(&[0xFF]);
+
+        let err = try_magic(&mut mock, MAGIC_SETS[0]).unwrap_err();
+        assert!(
+            matches!(err, DetectError::UnexpectedAck { got: 0xFF }),
+            "expected UnexpectedAck, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("0xFF"),
+            "the byte should reach the operator, got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_silent_port_is_reported_as_a_timeout() {
+        let mut mock = MockSerial::new();
+        mock.queue_timeout();
+
+        let err = try_magic(&mut mock, MAGIC_SETS[0]).unwrap_err();
+        assert!(
+            matches!(err, DetectError::Timeout),
+            "expected Timeout, got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/syntonia/src/baofeng/protocol.rs
+++ b/crates/syntonia/src/baofeng/protocol.rs
@@ -224,12 +224,19 @@ pub enum ProtocolError {
     },
 
     /// All retry attempts for a block operation have been exhausted.
-    #[snafu(display("block operation at 0x{addr:04X} failed after {attempts} attempts"))]
+    ///
+    /// Carries the error from the final attempt: a transfer that gave up
+    /// because the radio timed out and one that gave up because every reply
+    /// header was wrong need different fixes, and the count alone tells the
+    /// operator neither.
+    #[snafu(display("block operation at 0x{addr:04X} failed after {attempts} attempts: {source}"))]
     RetryExhausted {
         /// The address of the failed block.
         addr: u16,
         /// Number of attempts made.
         attempts: u8,
+        /// The error from the last attempt.
+        source: Box<Self>,
     },
 
     /// The source image is shorter than the ranges this variant would write.
@@ -548,49 +555,47 @@ impl<P: SerialPort> Uv5rProtocol<P> {
 
     /// Read a block with up to `MAX_RETRIES` attempts.
     fn read_block_with_retry(&mut self, addr: u16, len: u8) -> Result<Vec<u8>> {
-        for attempt in 1..=MAX_RETRIES {
+        let mut attempt: u8 = 1;
+        let last_err = loop {
             match self.read_block(addr, len) {
                 Ok(data) => return Ok(data),
-                Err(_) if attempt < MAX_RETRIES => {
+                Err(err) if attempt >= MAX_RETRIES => break err,
+                Err(_) => {
+                    attempt = attempt.saturating_add(1);
                     thread::sleep(POST_ACK_DELAY);
                 }
-                Err(_) => {
-                    return Err(ProtocolError::RetryExhausted {
-                        addr,
-                        attempts: MAX_RETRIES,
-                    });
-                }
             }
-        }
+        };
+
         Err(ProtocolError::RetryExhausted {
             addr,
             attempts: MAX_RETRIES,
+            source: Box::new(last_err),
         })
     }
 
     /// Write a block with up to `MAX_RETRIES` attempts.
     fn write_block_with_retry(&mut self, addr: u16, data: &[u8]) -> Result<()> {
-        for attempt in 1..=MAX_RETRIES {
+        let mut attempt: u8 = 1;
+        let last_err = loop {
             match self.write_block(addr, data) {
                 Ok(()) => return Ok(()),
                 // Forbidden address is not retryable.
                 Err(ProtocolError::ForbiddenAddress { .. }) => {
                     return Err(ProtocolError::ForbiddenAddress { addr });
                 }
-                Err(_) if attempt < MAX_RETRIES => {
+                Err(err) if attempt >= MAX_RETRIES => break err,
+                Err(_) => {
+                    attempt = attempt.saturating_add(1);
                     thread::sleep(POST_ACK_DELAY);
                 }
-                Err(_) => {
-                    return Err(ProtocolError::RetryExhausted {
-                        addr,
-                        attempts: MAX_RETRIES,
-                    });
-                }
             }
-        }
+        };
+
         Err(ProtocolError::RetryExhausted {
             addr,
             attempts: MAX_RETRIES,
+            source: Box::new(last_err),
         })
     }
 
@@ -647,6 +652,7 @@ fn is_forbidden(addr: u16, len: usize) -> bool {
     clippy::expect_used,
     clippy::indexing_slicing,
     clippy::missing_docs_in_private_items,
+    clippy::panic,
     reason = "test code: panics and unwraps acceptable in assertions"
 )]
 #[path = "protocol_tests.rs"]

--- a/crates/syntonia/src/baofeng/protocol_tests.rs
+++ b/crates/syntonia/src/baofeng/protocol_tests.rs
@@ -439,13 +439,62 @@ fn read_block_retry_exhaustion_returns_error() {
 
     let mut proto = make_protocol(mock);
     let err = proto.read_block_with_retry(addr, len).unwrap_err();
-    assert!(matches!(
-        err,
-        ProtocolError::RetryExhausted {
-            addr: 0x0100,
-            attempts: 3
-        }
-    ));
+    let ProtocolError::RetryExhausted {
+        addr: failed_addr,
+        attempts,
+        source,
+    } = err
+    else {
+        panic!("expected RetryExhausted, got: {err:?}");
+    };
+    assert_eq!(failed_addr, 0x0100);
+    assert_eq!(attempts, 3);
+    assert!(
+        matches!(*source, ProtocolError::Timeout),
+        "a silent radio should exhaust retries on Timeout, got: {source:?}"
+    );
+}
+
+// WHY: the falsifying sibling to the test above. Both transfers give up after
+// the same three attempts, and before the cause was carried they produced
+// byte-identical errors — so "the radio never answered" and "the radio
+// answered with the wrong block" were indistinguishable to the operator.
+#[test]
+fn read_block_retry_exhaustion_carries_a_header_mismatch_cause() {
+    let mut mock = MockSerialPort::new();
+    let addr: u16 = 0x0100;
+    let len: u8 = 0x40;
+
+    // Three attempts, each answered with a header for the wrong address.
+    for _ in 0..3 {
+        mock.enqueue_response(&[CMD_READ_RESPONSE, 0xFF, 0xFF, len]);
+    }
+
+    let mut proto = make_protocol(mock);
+    let err = proto.read_block_with_retry(addr, len).unwrap_err();
+    let ProtocolError::RetryExhausted { source, .. } = err else {
+        panic!("expected RetryExhausted, got: {err:?}");
+    };
+    assert!(
+        matches!(*source, ProtocolError::BadResponseHeader { addr: 0x0100 }),
+        "expected the header mismatch to survive the retry loop, got: {source:?}"
+    );
+}
+
+#[test]
+fn write_block_retry_exhaustion_carries_its_cause() {
+    let mock = MockSerialPort::new();
+    let addr: u16 = 0x0100;
+
+    let mut proto = make_protocol(mock);
+    let err = proto.write_block_with_retry(addr, &[0u8; 16]).unwrap_err();
+    let ProtocolError::RetryExhausted { source, .. } = err else {
+        panic!("expected RetryExhausted, got: {err:?}");
+    };
+    assert!(
+        matches!(*source, ProtocolError::Timeout),
+        "expected the underlying timeout, got: {source:?}"
+    );
 }
 
 // -----------------------------------------------------------------------

--- a/crates/syntonia/src/baofeng/variant.rs
+++ b/crates/syntonia/src/baofeng/variant.rs
@@ -31,6 +31,17 @@ pub const MAGIC_BF_F8HP: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x14, 0x04, 0x13];
 /// All magic byte sequences to try during auto-detection, in priority order.
 pub const MAGIC_SETS: &[[u8; 7]] = &[MAGIC_UV5R_291, MAGIC_BF_F8HP, MAGIC_UV5R_ORIG];
 
+/// Magic bytes `hardware::detect` sends when probing a serial port.
+///
+/// WARNING: this disagrees with [`MAGIC_UV5R_291`] in its last two bytes —
+/// `07 25` against `04 11` — and the two detection paths have always sent
+/// different sequences. Which one a UV-5R answers cannot be settled without
+/// the radio in hand, so both are recorded here, under the single owner
+/// `baofeng::constants` names, rather than left in two modules where the
+/// disagreement is invisible. Adjudicating them is kanon-external hardware
+/// work tracked on akroasis#233.
+pub(crate) const MAGIC_UV5R_PROBE: [u8; 7] = [0x50, 0xBB, 0xFF, 0x20, 0x12, 0x07, 0x25];
+
 // ── RadioVariant ─────────────────────────────────────────────────────────────
 
 /// Baofeng UV-5R family radio variant.
@@ -252,10 +263,27 @@ pub enum VariantError {
 // ── Firmware prefix matching ─────────────────────────────────────────────────
 
 /// Known firmware prefixes for the standard UV-5R.
-const UV5R_PREFIXES: &[&str] = &["BFB", "BFS", "N5R-2", "N5R2", "N5RV", "BTS", "D5R2", "B5R2"];
+pub(crate) const UV5R_PREFIXES: &[&str] =
+    &["BFB", "BFS", "N5R-2", "N5R2", "N5RV", "BTS", "D5R2", "B5R2"];
 
 /// Known firmware prefixes for the BF-F8HP.
-const BF_F8HP_PREFIXES: &[&str] = &["BFP3V3 F", "N5R-3", "N5R3", "F5R3", "BFT"];
+///
+/// WHY: `BFF` came from the second prefix table that `hardware::detect` used
+/// to carry. The two tables had drifted — this one never listed `BFF`, that
+/// one never listed `BFP3V3 F` — so a real BF-F8HP was unidentifiable to one
+/// path and a `BFF` radio to the other. This is the union, under the single
+/// owner named in `baofeng::constants`.
+pub(crate) const BF_F8HP_PREFIXES: &[&str] = &["BFP3V3 F", "N5R-3", "N5R3", "F5R3", "BFT", "BFF"];
+
+/// Known firmware prefixes for the UV-5RM Plus.
+///
+/// WARNING: [`identify_variant`] deliberately does not consult this table.
+/// The UV-5RM Plus may speak `UV17Pro` rather than the UV-5R clone protocol
+/// (see [`RadioVariant::Uv5rmPlus`]), so claiming the variant would hand a
+/// caller a [`VariantConfig`] it must not drive the radio with. It exists so
+/// `hardware::detect`, which only reports the model, has one owner to read
+/// from instead of a private copy.
+pub(crate) const UV5RM_PLUS_PREFIXES: &[&str] = &["BFU"];
 
 /// Identify the radio variant from its firmware ident bytes.
 ///

--- a/crates/syntonia/src/export/csv.rs
+++ b/crates/syntonia/src/export/csv.rs
@@ -226,6 +226,185 @@ mod tests {
         }
     }
 
+    /// Column indices in the CHIRP record produced by `channel_to_record`.
+    const COL_DUPLEX: usize = 3;
+    const COL_OFFSET: usize = 4;
+    const COL_TONE_MODE: usize = 5;
+    const COL_DTCS_CODE: usize = 8;
+    const COL_DTCS_POL: usize = 9;
+    const COL_MODE: usize = 10;
+    const COL_SKIP: usize = 12;
+    const COL_POWER: usize = 13;
+
+    fn channel_with(offset: FrequencyOffset, tx_freq: Option<Frequency>) -> Channel {
+        Channel {
+            index: 7,
+            name: "TEST".to_string(),
+            rx_freq: Frequency::hz(146_520_000),
+            tx_freq,
+            offset,
+            tone: ToneMode::None,
+            power: PowerLevel::High,
+            bandwidth: Bandwidth::Wide,
+            scan: ScanMode::Include,
+            busy_lock: false,
+        }
+    }
+
+    // ── Duplex/offset column ─────────────────────────────────────────────
+
+    #[test]
+    fn export_writes_minus_duplex_with_the_offset_magnitude() {
+        let ch = channel_with(
+            FrequencyOffset::Minus(Frequency::hz(600_000)),
+            Some(Frequency::hz(145_920_000)),
+        );
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_DUPLEX], "-");
+        assert_eq!(record[COL_OFFSET], "0.600000");
+    }
+
+    // WHY: the falsifying sibling — Plus must not also render as "-", and the
+    // offset column carries the same magnitude for both signs.
+    #[test]
+    fn export_writes_plus_duplex_with_the_offset_magnitude() {
+        let ch = channel_with(
+            FrequencyOffset::Plus(Frequency::hz(600_000)),
+            Some(Frequency::hz(147_120_000)),
+        );
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_DUPLEX], "+");
+        assert_eq!(record[COL_OFFSET], "0.600000");
+    }
+
+    // WHY: CHIRP's "split" duplex puts the absolute TX frequency in the
+    // offset column, not a delta — a split channel exported as a delta
+    // retunes the radio to the wrong transmit frequency on re-import.
+    #[test]
+    fn export_writes_split_duplex_with_the_absolute_tx_frequency() {
+        let tx = Frequency::hz(431_100_000);
+        let ch = channel_with(FrequencyOffset::Split(tx), Some(tx));
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_DUPLEX], "split");
+        assert_eq!(record[COL_OFFSET], "431.100000");
+    }
+
+    #[test]
+    fn export_writes_off_duplex_only_when_there_is_no_tx_frequency() {
+        let receive_only = channel_with(FrequencyOffset::None, None);
+        assert_eq!(channel_to_record(&receive_only)[COL_DUPLEX], "off");
+
+        // Simplex: no offset, but the radio does transmit — the duplex column
+        // is empty rather than "off".
+        let simplex = channel_with(FrequencyOffset::None, Some(Frequency::hz(146_520_000)));
+        assert_eq!(channel_to_record(&simplex)[COL_DUPLEX], "");
+    }
+
+    // ── Tone columns ─────────────────────────────────────────────────────
+
+    #[test]
+    fn export_writes_inverted_dcs_polarity() {
+        let mut ch = channel_with(FrequencyOffset::None, Some(Frequency::hz(146_520_000)));
+        ch.tone = ToneMode::Dcs(
+            crate::tone::DcsCode::new(23).unwrap(),
+            crate::tone::DcsPolarity::Inverted,
+        );
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_TONE_MODE], "DTCS");
+        assert_eq!(record[COL_DTCS_CODE], "023");
+        assert_eq!(record[COL_DTCS_POL], "RN");
+    }
+
+    #[test]
+    fn export_writes_normal_dcs_polarity() {
+        let mut ch = channel_with(FrequencyOffset::None, Some(Frequency::hz(146_520_000)));
+        ch.tone = ToneMode::Dcs(
+            crate::tone::DcsCode::new(754).unwrap(),
+            crate::tone::DcsPolarity::Normal,
+        );
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_TONE_MODE], "DTCS");
+        assert_eq!(record[COL_DTCS_CODE], "754");
+        assert_eq!(record[COL_DTCS_POL], "NN");
+    }
+
+    // ── Power, bandwidth, scan columns ───────────────────────────────────
+
+    #[test]
+    fn export_writes_each_power_level_distinctly() {
+        let mut ch = channel_with(FrequencyOffset::None, Some(Frequency::hz(146_520_000)));
+
+        ch.power = PowerLevel::Mid;
+        assert_eq!(channel_to_record(&ch)[COL_POWER], "Mid");
+
+        ch.power = PowerLevel::Low;
+        assert_eq!(channel_to_record(&ch)[COL_POWER], "Low");
+
+        ch.power = PowerLevel::High;
+        assert_eq!(channel_to_record(&ch)[COL_POWER], "High");
+    }
+
+    #[test]
+    fn export_writes_narrow_bandwidth_and_skip_scan() {
+        let mut ch = channel_with(FrequencyOffset::None, Some(Frequency::hz(146_520_000)));
+        ch.bandwidth = Bandwidth::Narrow;
+        ch.scan = ScanMode::Skip;
+
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_MODE], "NFM");
+        assert_eq!(record[COL_SKIP], "S");
+
+        ch.bandwidth = Bandwidth::Wide;
+        ch.scan = ScanMode::Include;
+        let record = channel_to_record(&ch);
+        assert_eq!(record[COL_MODE], "FM");
+        assert_eq!(record[COL_SKIP], "");
+    }
+
+    // WHY: the export columns above are only worth pinning if the importer
+    // reads them back to the same channel. `roundtrip_csv_import_export_import`
+    // covers the plan in `make_test_plan`, which carries no Minus, no Split,
+    // no receive-only and no Mid-power channel.
+    #[test]
+    fn roundtrip_preserves_minus_split_off_and_mid_power() {
+        let mut minus = channel_with(
+            FrequencyOffset::Minus(Frequency::hz(600_000)),
+            Some(Frequency::hz(145_920_000)),
+        );
+        minus.index = 0;
+        minus.name = "MINUS".to_string();
+        minus.power = PowerLevel::Mid;
+
+        let mut split = channel_with(
+            FrequencyOffset::Split(Frequency::hz(431_100_000)),
+            Some(Frequency::hz(431_100_000)),
+        );
+        split.index = 1;
+        split.name = "SPLIT".to_string();
+
+        let mut receive_only = channel_with(FrequencyOffset::None, None);
+        receive_only.index = 2;
+        receive_only.name = "RXONLY".to_string();
+
+        let plan = FrequencyPlan {
+            name: String::new(),
+            radio_model: None,
+            channels: vec![minus, split, receive_only],
+            created: None,
+        };
+
+        let mut buf = Vec::new();
+        export_chirp_csv(&plan, &mut buf).unwrap();
+        let (reimported, _) = import_chirp_csv_reader(buf.as_slice()).unwrap();
+
+        assert_eq!(reimported.channel_count(), 3);
+        for (before, after) in plan.channels.iter().zip(reimported.channels.iter()) {
+            assert_eq!(before.offset, after.offset, "offset for {}", before.name);
+            assert_eq!(before.tx_freq, after.tx_freq, "tx_freq for {}", before.name);
+            assert_eq!(before.power, after.power, "power for {}", before.name);
+        }
+    }
+
     #[test]
     fn export_produces_valid_csv() {
         let plan = make_test_plan();

--- a/crates/syntonia/src/hardware/detect.rs
+++ b/crates/syntonia/src/hardware/detect.rs
@@ -1,11 +1,14 @@
 //! Radio detection via serial port probing.
 
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::time::Duration;
 
 use koinon::RadioKind;
 use snafu::{ResultExt, Snafu};
 
+use crate::baofeng::variant::{
+    BF_F8HP_PREFIXES, MAGIC_UV5R_PROBE, UV5R_PREFIXES, UV5RM_PLUS_PREFIXES,
+};
 use crate::hardware::cables::{CableChip, classify_cable};
 use crate::hardware::usb::{ScanError, UsbCable, scan_usb_cables};
 
@@ -106,29 +109,42 @@ struct MagicSequence {
 // WHY: Baofeng radios enter programming mode via a specific magic byte handshake.
 // Different radio families use different magic sequences.
 const MAGIC_SEQUENCES: &[MagicSequence] = &[MagicSequence {
-    magic: &[0x50, 0xBB, 0xFF, 0x20, 0x12, 0x07, 0x25],
+    magic: &MAGIC_UV5R_PROBE,
     parse: parse_uv5r_ident,
 }];
 
 fn parse_uv5r_ident(ident: &[u8]) -> Option<VariantConfig> {
-    let prefix = ident.get(..3)?;
-    match prefix {
-        b"BFB" => Some(VariantConfig {
-            kind: RadioKind::BaofengUv5r,
-            baud_rate: BAUD_RATE,
-            memory_size: 0x1808,
-        }),
-        b"BFF" => Some(VariantConfig {
-            kind: RadioKind::BaofengBfF8hp,
-            baud_rate: BAUD_RATE,
-            memory_size: 0x1808,
-        }),
-        b"BFU" => Some(VariantConfig {
-            kind: RadioKind::BaofengUv5rmPlus,
-            baud_rate: BAUD_RATE,
-            memory_size: 0x1808,
-        }),
-        _ => None,
+    // WHY: the firmware-prefix tables are owned by `baofeng::variant`. This
+    // module used to keep a private three-letter copy which had drifted from
+    // it, so a BF-F8HP answering `BFP3V3 F` — the prefix the owning table
+    // lists first — was reported as no radio at all.
+    let kind = classify_ident(ident)?;
+    Some(VariantConfig {
+        kind,
+        baud_rate: BAUD_RATE,
+        memory_size: 0x1808,
+    })
+}
+
+/// Match an ident response against the owning prefix tables, most specific
+/// family first.
+fn classify_ident(ident: &[u8]) -> Option<RadioKind> {
+    let matches = |table: &[&str]| {
+        table
+            .iter()
+            .any(|prefix| ident.starts_with(prefix.as_bytes()))
+    };
+
+    // WHY: ordered as `baofeng::variant::identify_variant` orders them, so the
+    // two paths cannot disagree about a prefix listed in more than one table.
+    if matches(BF_F8HP_PREFIXES) {
+        Some(RadioKind::BaofengBfF8hp)
+    } else if matches(UV5R_PREFIXES) {
+        Some(RadioKind::BaofengUv5r)
+    } else if matches(UV5RM_PLUS_PREFIXES) {
+        Some(RadioKind::BaofengUv5rmPlus)
+    } else {
+        None
     }
 }
 
@@ -157,35 +173,76 @@ impl RadioProber for DefaultProber {
                 port: port_path.to_string(),
             })?;
 
-        for seq in MAGIC_SEQUENCES {
-            if let Some(result) = try_magic_sequence(&mut *port, seq) {
-                return Ok(Some(result));
-            }
-        }
-        Ok(None)
+        probe_port(&mut *port, port_path)
     }
 }
 
+/// Try every magic sequence against an already-open port.
+///
+/// # Errors
+///
+/// Returns [`DetectError::SerialIo`] if the port itself fails; a port that
+/// merely stays silent yields `Ok(None)`.
+fn probe_port(
+    port: &mut (impl Read + Write + ?Sized),
+    port_path: &str,
+) -> Result<Option<(VariantConfig, RadioIdent)>, DetectError> {
+    for seq in MAGIC_SEQUENCES {
+        match try_magic_sequence(&mut *port, seq) {
+            Ok(Some(result)) => return Ok(Some(result)),
+            Ok(None) => {}
+            Err(err) if is_silence(&err) => {}
+            Err(err) => {
+                return Err(err).context(SerialIoSnafu {
+                    port: port_path.to_string(),
+                });
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Whether an I/O error means the radio said nothing, as opposed to the port
+/// itself failing.
+///
+/// WHY: a probe that swallows every I/O error reports a permission-denied or
+/// disconnected port as "no radio on this cable", which sends the operator
+/// looking for a radio fault. Only silence — a read that times out, or a port
+/// that closes mid-handshake — means "not this variant, try the next".
+fn is_silence(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::TimedOut | io::ErrorKind::UnexpectedEof | io::ErrorKind::WouldBlock
+    )
+}
+
+/// Run one magic-sequence handshake.
+///
+/// `Ok(None)` means the radio answered but is not this variant; `Err` is a
+/// port-level I/O failure, which the caller separates from silence via
+/// [`is_silence`].
 fn try_magic_sequence(
     port: &mut (impl Read + Write + ?Sized),
     seq: &MagicSequence,
-) -> Option<(VariantConfig, RadioIdent)> {
-    port.write_all(seq.magic).ok()?;
+) -> io::Result<Option<(VariantConfig, RadioIdent)>> {
+    port.write_all(seq.magic)?;
 
     let mut ack = [0u8; 1];
-    port.read_exact(&mut ack).ok()?;
+    port.read_exact(&mut ack)?;
     if ack.first().copied().unwrap_or_default() != ACK {
-        return None;
+        return Ok(None);
     }
 
-    port.write_all(&[IDENT_REQUEST]).ok()?;
+    port.write_all(&[IDENT_REQUEST])?;
 
     let mut ident_buf = [0u8; IDENT_LENGTH];
-    port.read_exact(&mut ident_buf).ok()?;
+    port.read_exact(&mut ident_buf)?;
 
     let _ = port.write_all(&[ACK]);
 
-    let variant = (seq.parse)(&ident_buf)?;
+    let Some(variant) = (seq.parse)(&ident_buf) else {
+        return Ok(None);
+    };
     let firmware = String::from_utf8_lossy(&ident_buf)
         .trim_end_matches('\0')
         .to_string();
@@ -193,7 +250,7 @@ fn try_magic_sequence(
         firmware,
         raw_response: ident_buf.to_vec(),
     };
-    Some((variant, ident))
+    Ok(Some((variant, ident)))
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────
@@ -388,12 +445,32 @@ mod tests {
 
     // ── Magic sequence tests ─────────────────────────────────────────────
 
+    /// Serial port that fails every read with a fixed error kind.
+    struct FailingSerial {
+        kind: std::io::ErrorKind,
+    }
+
+    impl Read for FailingSerial {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(self.kind, "mock port failure"))
+        }
+    }
+
+    impl Write for FailingSerial {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn try_magic_returns_variant_on_valid_uv5r_response() {
         let response = [&[ACK][..], b"BFB297\x00\x00"].concat();
         let mut port = MockSerial::new(response);
 
-        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap());
+        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).unwrap();
         assert!(result.is_some());
 
         let (variant, ident) = result.unwrap();
@@ -406,7 +483,7 @@ mod tests {
         let response = [&[ACK][..], b"BFF800\x00\x00"].concat();
         let mut port = MockSerial::new(response);
 
-        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap());
+        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().0.kind, RadioKind::BaofengBfF8hp);
     }
@@ -415,20 +492,65 @@ mod tests {
     fn try_magic_returns_none_on_no_ack() {
         let response = vec![0xFF]; // Not an ACK
         let mut port = MockSerial::new(response);
-        assert!(try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).is_none());
+        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).unwrap();
+        assert!(result.is_none());
     }
 
     #[test]
-    fn try_magic_returns_none_on_empty_response() {
+    fn try_magic_treats_empty_response_as_silence() {
         let mut port = MockSerial::new(vec![]);
-        assert!(try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).is_none());
+        let err = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).unwrap_err();
+        assert!(
+            is_silence(&err),
+            "empty read should read as silence: {err:?}"
+        );
     }
 
     #[test]
     fn try_magic_returns_none_for_unrecognized_ident() {
         let response = [&[ACK][..], b"ZZZ999\x00\x00"].concat();
         let mut port = MockSerial::new(response);
-        assert!(try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).is_none());
+        let result = try_magic_sequence(&mut port, MAGIC_SEQUENCES.first().unwrap()).unwrap();
+        assert!(result.is_none());
+    }
+
+    // ── Prefix-table alignment ───────────────────────────────────────────
+
+    // WHY: `BFP3V3 F` is the prefix `baofeng::variant::BF_F8HP_PREFIXES` lists
+    // first for the BF-F8HP. The private three-letter table this module used
+    // to carry did not contain it, so a real F8HP probed as no radio at all.
+    #[test]
+    fn f8hp_ident_from_the_owning_table_is_classified() {
+        assert_eq!(
+            classify_ident(b"BFP3V3 F").unwrap(),
+            RadioKind::BaofengBfF8hp
+        );
+        assert_eq!(
+            classify_ident(b"N5R-3\x00\x00\x00").unwrap(),
+            RadioKind::BaofengBfF8hp
+        );
+        assert_eq!(
+            classify_ident(b"BFT297\x00\x00").unwrap(),
+            RadioKind::BaofengBfF8hp
+        );
+    }
+
+    // WHY: the falsifying sibling — a UV-5R prefix must not be swept into the
+    // F8HP arm by the wider table.
+    #[test]
+    fn uv5r_idents_from_the_owning_table_stay_uv5r() {
+        assert_eq!(
+            classify_ident(b"BFB297\x00\x00").unwrap(),
+            RadioKind::BaofengUv5r
+        );
+        assert_eq!(
+            classify_ident(b"BTS123\x00\x00").unwrap(),
+            RadioKind::BaofengUv5r
+        );
+        assert_eq!(
+            classify_ident(b"N5R-2\x00\x00\x00").unwrap(),
+            RadioKind::BaofengUv5r
+        );
     }
 
     #[test]
@@ -439,6 +561,40 @@ mod tests {
         assert!(parse_uv5r_ident(b"ZZZ000\x00\x00").is_none());
         assert!(parse_uv5r_ident(b"BF").is_none());
         assert!(parse_uv5r_ident(b"").is_none());
+    }
+
+    // ── Probe failure classification ─────────────────────────────────────
+
+    // WHY: the pair. A port that fails to read is a port fault and must
+    // surface; a port that stays silent is a cable with no radio on it and
+    // must not. Before this split both arrived as `None`.
+    #[test]
+    fn probe_reports_a_port_level_io_failure() {
+        let mut port = FailingSerial {
+            kind: std::io::ErrorKind::PermissionDenied,
+        };
+        let err = probe_port(&mut port, "/dev/ttyUSB0").unwrap_err();
+        assert!(
+            matches!(err, DetectError::SerialIo { .. }),
+            "expected SerialIo, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn probe_reports_a_silent_port_as_no_radio() {
+        let mut port = FailingSerial {
+            kind: std::io::ErrorKind::TimedOut,
+        };
+        let result = probe_port(&mut port, "/dev/ttyUSB0").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn probe_returns_the_radio_when_one_answers() {
+        let response = [&[ACK][..], b"BFP3V3 F"].concat();
+        let mut port = MockSerial::new(response);
+        let (variant, _) = probe_port(&mut port, "/dev/ttyUSB0").unwrap().unwrap();
+        assert_eq!(variant.kind, RadioKind::BaofengBfF8hp);
     }
 
     // ── Detection integration tests (mocked) ────────────────────────────

--- a/crates/syntonia/src/import/csv.rs
+++ b/crates/syntonia/src/import/csv.rs
@@ -24,12 +24,26 @@ pub enum ImportWarning {
         /// Field value.
         value: String,
     },
-    /// Frequency could not be parsed.
+    /// Frequency could not be parsed, or is outside the representable range.
     InvalidFrequency {
         /// CSV row number.
         row: usize,
         /// The invalid frequency string.
         freq: String,
+    },
+    /// Duplex offset could not be parsed, or is outside the representable range.
+    InvalidOffset {
+        /// CSV row number.
+        row: usize,
+        /// The invalid offset string.
+        offset: String,
+    },
+    /// Memory location (channel index) could not be parsed.
+    InvalidLocation {
+        /// CSV row number.
+        row: usize,
+        /// The invalid location string.
+        value: String,
     },
     /// Unrecognized tone mode string.
     UnknownToneMode {
@@ -122,14 +136,59 @@ fn col(record: &csv::StringRecord, idx: usize) -> &str {
     record.get(idx).unwrap_or("").trim()
 }
 
+/// Upper bound, in MHz, on a frequency or duplex offset accepted from CSV.
+///
+/// WHY: `mhz_to_hz` casts `mhz * 1_000_000` to `u64`, and an `as` cast
+/// saturates rather than wrapping — so an unbounded `1e300` in the Frequency
+/// column becomes `u64::MAX`, and the `rx + offset` addition in
+/// [`parse_duplex`] then overflows. 10 GHz is far above any amateur band the
+/// UV-5R family covers and is the bound `mhz_to_hz` already documents.
+const MAX_FREQ_MHZ: f64 = 10_000.0;
+
 fn mhz_to_hz(mhz: f64) -> u64 {
     #[expect(
         clippy::cast_sign_loss,
         clippy::cast_possible_truncation,
-        reason = "caller ensures mhz > 0 and mhz * 1_000_000 fits in u64 (far below 2^64 Hz)"
+        reason = "callers screen against MAX_FREQ_MHZ, so mhz * 1_000_000 fits in u64"
     )]
-    let hz = (mhz * 1_000_000.0) as u64; // SAFETY: caller ensures mhz>0 and <10GHz; *1e6 fits u64
+    // INVARIANT: every caller screens its input against `MAX_FREQ_MHZ` before
+    // calling, so `mhz * 1e6` is at most 1e10 and the cast is exact.
+    let hz = (mhz * 1_000_000.0) as u64;
     hz
+}
+
+/// Parse the Location column, warning rather than silently defaulting.
+///
+/// WHY: an unparseable Location used to become channel 0 with no trace, so a
+/// CSV whose first column had drifted imported every row onto the same slot.
+fn parse_location(location_str: &str, row: usize, warnings: &mut Vec<ImportWarning>) -> u16 {
+    location_str.parse().unwrap_or_else(|_| {
+        warnings.push(ImportWarning::InvalidLocation {
+            row,
+            value: location_str.to_string(),
+        });
+        0
+    })
+}
+
+/// Parse the Offset column into Hz, screening it against [`MAX_FREQ_MHZ`].
+///
+/// An empty column is the normal simplex case and yields zero silently.
+fn parse_offset_hz(offset_str: &str, row: usize, warnings: &mut Vec<ImportWarning>) -> u64 {
+    if offset_str.is_empty() {
+        return 0;
+    }
+
+    match offset_str.parse::<f64>() {
+        Ok(offset) if offset.abs() <= MAX_FREQ_MHZ => mhz_to_hz(offset.abs()),
+        _ => {
+            warnings.push(ImportWarning::InvalidOffset {
+                row,
+                offset: offset_str.to_string(),
+            });
+            0
+        }
+    }
 }
 
 fn parse_record(
@@ -144,7 +203,7 @@ fn parse_record(
     }
 
     let freq_mhz: f64 = match freq_str.parse() {
-        Ok(f) if f > 0.0 => f,
+        Ok(f) if f > 0.0 && f <= MAX_FREQ_MHZ => f,
         _ => {
             warnings.push(ImportWarning::InvalidFrequency {
                 row,
@@ -156,12 +215,11 @@ fn parse_record(
 
     let rx_freq = Frequency::hz(mhz_to_hz(freq_mhz));
 
-    let location: u16 = col(record, 0).parse().unwrap_or(0);
+    let location = parse_location(col(record, 0), row, warnings);
     let name = col(record, 1).to_string();
 
     let duplex = col(record, 3);
-    let offset_val: f64 = col(record, 4).parse().unwrap_or(0.0);
-    let offset_hz = mhz_to_hz(offset_val.abs());
+    let offset_hz = parse_offset_hz(col(record, 4), row, warnings);
 
     let (tx_freq, offset) = parse_duplex(duplex, rx_freq, offset_hz);
 
@@ -243,7 +301,10 @@ fn parse_duplex(
 ) -> (Option<Frequency>, FrequencyOffset) {
     match duplex {
         "+" => {
-            let tx = Frequency::hz(rx_freq.as_hz() + offset_hz);
+            // WHY: `MAX_FREQ_MHZ` already bounds both operands well below the
+            // u64 range, so this cannot saturate in practice — it is here so
+            // the arithmetic stays total if that bound is ever widened.
+            let tx = Frequency::hz(rx_freq.as_hz().saturating_add(offset_hz));
             (Some(tx), FrequencyOffset::Plus(Frequency::hz(offset_hz)))
         }
         "-" => {
@@ -371,6 +432,109 @@ Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPola
 5,TSQL,146.520000,,0.000000,TSQL,88.5,100.0,023,NN,FM,5.00,,High,,,,,,
 6,MINUS,147.360000,-,0.600000,Tone,100.0,100.0,023,NN,FM,5.00,,High,,,,,,
 ";
+
+    /// A single data row with the given Location, Frequency and Offset.
+    fn one_row(location: &str, freq: &str, duplex: &str, offset: &str) -> String {
+        format!(
+            "Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,\
+             DtcsPolarity,Mode,TStep,Skip,Power,Comment,URCALL,RPT1CALL,RPT2CALL,DVCODE\n\
+             {location},CH,{freq},{duplex},{offset},,88.5,88.5,023,NN,FM,5.00,,High,,,,,,\n"
+        )
+    }
+
+    // ── Bounded frequency and offset ─────────────────────────────────────
+
+    // WHY: `mhz_to_hz` casts through `as u64`, which saturates rather than
+    // wrapping, so an unbounded frequency reached `parse_duplex` as
+    // `u64::MAX` and the `rx + offset` addition overflowed — a panic on a
+    // debug build, a wrong TX frequency on a release one.
+    #[test]
+    fn an_out_of_range_frequency_is_rejected_rather_than_saturating() {
+        let csv = one_row("0", "1e300", "+", "0.600000");
+        let (plan, warnings) = import_chirp_csv_reader(csv.as_bytes()).unwrap();
+
+        assert_eq!(plan.channel_count(), 0, "the row must not become a channel");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, ImportWarning::InvalidFrequency { row: 2, .. })),
+            "expected an InvalidFrequency warning, got: {warnings:?}"
+        );
+    }
+
+    // WHY: the falsifying sibling — a frequency at the top of the accepted
+    // band must still import, so the bound rejects the impossible rather than
+    // the merely high.
+    #[test]
+    fn a_frequency_at_the_upper_bound_is_accepted() {
+        let csv = one_row("0", "10000.000000", "", "0.000000");
+        let (plan, warnings) = import_chirp_csv_reader(csv.as_bytes()).unwrap();
+
+        assert_eq!(plan.channel_count(), 1);
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ImportWarning::InvalidFrequency { .. })),
+            "unexpected warning: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn an_out_of_range_offset_is_reported_and_dropped() {
+        let csv = one_row("0", "146.520000", "+", "1e300");
+        let (plan, warnings) = import_chirp_csv_reader(csv.as_bytes()).unwrap();
+
+        assert_eq!(
+            plan.channel_count(),
+            1,
+            "the channel itself is still usable"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| matches!(w, ImportWarning::InvalidOffset { row: 2, .. })),
+            "expected an InvalidOffset warning, got: {warnings:?}"
+        );
+
+        let channel = plan.channels.first().unwrap();
+        assert_eq!(channel.offset, FrequencyOffset::Plus(Frequency::hz(0)));
+        assert_eq!(channel.tx_freq, Some(Frequency::hz(146_520_000)));
+    }
+
+    // ── Location column ──────────────────────────────────────────────────
+
+    // WHY: an unparseable Location silently became channel 0, so a CSV whose
+    // first column had drifted imported every row on top of the same slot and
+    // the plan came back one channel long with no indication why.
+    #[test]
+    fn an_unparseable_location_is_reported_rather_than_defaulted_silently() {
+        let csv = one_row("not-a-number", "146.520000", "", "0.000000");
+        let (plan, warnings) = import_chirp_csv_reader(csv.as_bytes()).unwrap();
+
+        assert_eq!(plan.channel_count(), 1);
+        assert_eq!(plan.channels.first().unwrap().index, 0);
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                ImportWarning::InvalidLocation { row: 2, value } if value == "not-a-number"
+            )),
+            "expected an InvalidLocation warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn a_valid_location_produces_no_warning() {
+        let csv = one_row("12", "146.520000", "", "0.000000");
+        let (plan, warnings) = import_chirp_csv_reader(csv.as_bytes()).unwrap();
+
+        assert_eq!(plan.channels.first().unwrap().index, 12);
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ImportWarning::InvalidLocation { .. })),
+            "unexpected warning: {warnings:?}"
+        );
+    }
 
     #[test]
     fn parse_fixture_csv() {

--- a/crates/syntonia/src/import/img.rs
+++ b/crates/syntonia/src/import/img.rs
@@ -54,6 +54,21 @@ pub enum ImgImportError {
 /// Returns `ImgImportError` if the file cannot be read, has an unsupported
 /// size, or contains invalid channel data.
 pub fn import_img(path: &Path) -> Result<FrequencyPlan, ImgImportError> {
+    // WHY: reject by size from the directory entry before allocating. A `.img`
+    // is a fixed-size EEPROM dump of a few kilobytes, so reading first and
+    // checking after let any file the user pointed at — a disk image, a core
+    // dump — be pulled into memory in full only to be rejected.
+    let metadata = std::fs::metadata(path).context(ReadFileSnafu {
+        path: path.to_path_buf(),
+    })?;
+    let size = usize::try_from(metadata.len()).unwrap_or(usize::MAX);
+    if size != UV5R_STANDARD_SIZE && size != UV5R_AUX_SIZE {
+        return Err(ImgImportError::UnsupportedImageSize { size });
+    }
+
+    // NOTE: `import_img_bytes` re-checks the length, so a file that changes
+    // size between the stat above and the read below is still rejected.
+
     let data = std::fs::read(path).context(ReadFileSnafu {
         path: path.to_path_buf(),
     })?;
@@ -128,6 +143,54 @@ mod tests {
         let mut data = vec![0u8; IDENT_HEADER_LEN];
         data.extend_from_slice(image.as_slice());
         data
+    }
+
+    // WHY: `import_img` used to read the file in full and check its length
+    // afterwards, so pointing it at a disk image or a core dump pulled the
+    // whole thing into memory only to reject it. The size now comes from the
+    // directory entry. A 64 MiB sparse file is large enough to be an obvious
+    // mistake and costs no disk to create; the property being fixed is that
+    // nothing of it is read, which the error alone cannot show — see the
+    // commit message for the differential.
+    #[test]
+    fn an_oversized_file_is_rejected_by_its_size_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.img");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(64 * 1024 * 1024).unwrap();
+        drop(file);
+
+        let err = import_img(&path).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ImgImportError::UnsupportedImageSize { size: 67_108_864 }
+            ),
+            "expected UnsupportedImageSize with the on-disk length, got: {err:?}"
+        );
+    }
+
+    // WHY: the falsifying sibling — a file of a supported size must still be
+    // read and decoded, so the stat is a gate rather than a refusal.
+    #[test]
+    fn a_supported_size_is_still_read_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("uv5r.img");
+        std::fs::write(&path, make_img_bytes(0x1800)).unwrap();
+
+        let plan = import_img(&path).unwrap();
+        assert_eq!(plan.radio_model.as_deref(), Some("UV-5R"));
+        assert_eq!(plan.channel_count(), 1);
+    }
+
+    #[test]
+    fn a_missing_file_is_reported_as_a_read_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = import_img(&dir.path().join("absent.img")).unwrap_err();
+        assert!(
+            matches!(err, ImgImportError::ReadFile { .. }),
+            "expected ReadFile, got: {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Nine of the thirteen wave-1 audit findings against syntonia (issue #233): an
importer that read a whole file into memory before checking its size, an
unbounded CSV frequency/offset that could overflow on duplex addition, a
silently-mis-imported CSV Location, a firmware-prefix table that missed a
real BF-F8HP response, port I/O errors reported as "no radio" instead of
surfacing, retry-exhaustion errors that discarded their underlying cause, a
wrong-ACK byte misreported as a timeout, and missing coverage for several
CHIRP CSV export and channel-codec cases.

Closes each with either a behavioral fix or new pinning tests; see the
commit message for the specific before/after per finding. Three findings
from the same batch (CSV formula-injection, the orphaned baofeng::detect
module, and one already-satisfied test item) are intentionally left for the
issue rather than folded in here.

Verification: `cargo fmt --all --check` clean; `cargo clippy --workspace
--all-targets -- -D warnings` exit 0; `cargo nextest run --workspace`
877/877 pass (850/850 on main pre-change).

Refs #233
