### PR TITLE
fix(config): deny unknown fields on operator-authored config types

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -196,24 +196,6 @@ line = 383
 hash = "bf306ffa19e0898259628da1f361f4eb4ae5c88aad26958e332195a046bc5ce6"
 
 [[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/kerykeion/src/config.rs"
-line = 27
-hash = "e23cb6e73a71989c6e9c01170dea62ed7f329b3f8d22654e50dc30eacf552384"
-
-[[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/kerykeion/src/config.rs"
-line = 106
-hash = "78d24d0929797553f0f4f4a45acadd78ffa2105c163aa96a8351f2ba336bc127"
-
-[[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/kerykeion/src/config.rs"
-line = 128
-hash = "248682e91b041336faf78e667ac5da1a548ef9fd2c37de888340ce49ea6b616b"
-
-[[baseline.entry]]
 rule = "RUST/indexing-slicing"
 file = "crates/kerykeion/src/crypto.rs"
 line = 43
@@ -340,12 +322,6 @@ line = 259
 hash = "635566a5376aca1bf92ec855cbe96b69003a02f89b19a6dbdc822d59e580ed34"
 
 [[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/koinon/src/tamper_log.rs"
-line = 64
-hash = "ab6fa7ce2a569a6a8354104318c49f7ae1f5b147a2c0685363a8b09356549fe2"
-
-[[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/koinon/src/tamper_log.rs"
 line = 150
@@ -416,12 +392,6 @@ rule = "TOPOLOGY/shallow-struct"
 file = "crates/semaino/src/alert.rs"
 line = 73
 hash = "4e5ef5104b47dd039767e8e2d6ef6699ade3e36c5770ac0a821dea0561c1c0b2"
-
-[[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/semaino/src/pipeline.rs"
-line = 31
-hash = "262ca345a0b206c9528ef353f9371d7575f0ea817b276dfb2226b0af5b1a6045"
 
 [[baseline.entry]]
 rule = "RUST/no-silent-result-swallow"
@@ -536,24 +506,6 @@ rule = "TOPOLOGY/shallow-struct"
 file = "crates/syntonia/src/baofeng/variant.rs"
 line = 66
 hash = "2df5f344710c8c41cfdc1db5db970823dbe71b1d8257e9ed33213093e61f2cfb"
-
-[[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/syntonia/src/config.rs"
-line = 27
-hash = "410fb7612200122375fc747129a01ede3e4590c80fff90c532f233ee62cc9596"
-
-[[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/syntonia/src/config.rs"
-line = 92
-hash = "25a7ddf94b9a455321aa2e3cead3023ca7a56f8e1a40556160913a7cca11cf4c"
-
-[[baseline.entry]]
-rule = "RUST/config-deny-unknown-fields"
-file = "crates/syntonia/src/config.rs"
-line = 119
-hash = "6c9bedf9cc6694a9f8539534da5451fe5217da127b552849c472e6ea2d81d3d9"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"

--- a/crates/kerykeion/src/config.rs
+++ b/crates/kerykeion/src/config.rs
@@ -24,6 +24,7 @@ use crate::types::ChannelIndex;
 
 /// Top-level kerykeion configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MeshConfig {
     /// Transport connections to Meshtastic radios.
     #[serde(default)]
@@ -102,7 +103,7 @@ pub struct ChannelPsk {
 
 /// Store-and-forward server configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StoreForwardConfig {
     /// Whether the store-and-forward feature is enabled on this node.
     pub enabled: bool,
@@ -124,7 +125,7 @@ impl Default for StoreForwardConfig {
 
 /// Topology maintenance configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TopologyConfig {
     /// How often to request a traceroute, in seconds.
     pub traceroute_interval_secs: u64,

--- a/crates/koinon/src/tamper_log.rs
+++ b/crates/koinon/src/tamper_log.rs
@@ -60,7 +60,7 @@ pub const DEFAULT_MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
 /// Currently controls rotation only; future additions (fsync policy,
 /// compression, retention) will land here.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TamperLogConfig {
     /// Rotation threshold in bytes. When `bytes_written` exceeds this,
     /// the current file is renamed and a fresh log is opened.

--- a/crates/semaino/src/pipeline.rs
+++ b/crates/semaino/src/pipeline.rs
@@ -27,7 +27,7 @@ use crate::{
 /// support + `#[serde(default)]` lets operators and agents override
 /// a subset of fields via TOML without knowing the rest of the schema.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SemainoConfig {
     /// Grid quantization factor. 10 000 ≈ 10 m resolution.
     pub grid_resolution: u32,

--- a/crates/syntonia/src/config.rs
+++ b/crates/syntonia/src/config.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// `#[serde(default)]` lets TOML files specify only the values that
 /// actually need to deviate from the default.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BaofengTimingConfig {
     /// Delay between individual magic bytes during programming-mode entry,
     /// in milliseconds. Too short and some cables drop bytes; too long and
@@ -88,7 +88,7 @@ impl BaofengTimingConfig {
 /// ports are unconnected; higher values are needed for slower cable /
 /// radio combinations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct HardwareProbeConfig {
     /// Timeout applied to the serial port during an individual probe
     /// attempt, in milliseconds.
@@ -116,6 +116,7 @@ impl HardwareProbeConfig {
 /// Aggregates the per-subsystem configs so callers can accept a single
 /// `&SyntoniaConfig` and thread it down.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SyntoniaConfig {
     /// Baofeng programming timing + retries.
     #[serde(default)]


### PR DESCRIPTION
Adds `#[serde(deny_unknown_fields)]` to operator-authored config types
across four crates so a misspelled TOML key fails loudly at load time
instead of being silently defaulted away: `MeshConfig`,
`StoreForwardConfig`, `TopologyConfig` (kerykeion), `TamperLogConfig`
(koinon), `SemainoConfig` (semaino), `BaofengTimingConfig`,
`HardwareProbeConfig`, `SyntoniaConfig` (syntonia). Drops the eight
matching `.kanon-lint-baseline.toml` entries for the
`RUST/config-deny-unknown-fields` family now fixed at source.

Note for the reviewer: the three kerykeion structs here are also
covered, more thoroughly (with dedicated rejection tests), by #343 —
that PR touches all ten kerykeion config structs, this one only the
three. The koinon/semaino/syntonia structs are not covered anywhere
else. Whichever of the two lands first on the kerykeion file, the other
will need a trivial rebase to drop the now-redundant hunk.

Verification: this is a mechanical, single-attribute addition following
the same pattern already used elsewhere in the codebase; no dedicated
tests were added in this branch, so verification here is CI (build +
existing config round-trip tests still passing) only.

Refs #261
