### PR TITLE
style(deps): expand the overlong sphragis inline table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,6 @@ zeroize = { version = "1", features = ["derive"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 subtle = "2"
 
-# Post-quantum hybrid KEM — standalone fleet crate.
-# WHY: extracted from akroasis crates/sphragis to forkwright/sphragis for
-# cross-repo access. preview-pq gated; unaudited until cryptographic review.
-sphragis = { git = "https://github.com/forkwright/sphragis", tag = "v0.1.1", features = ["preview-pq"] }
-
 # Hashing
 blake3 = "1"
 
@@ -135,3 +130,13 @@ tower-http = { version = "0.7", features = ["cors", "trace"] }
 # Testing
 proptest = "1"
 nix = { version = "0.31.2", features = ["pty"] }
+
+# Post-quantum hybrid KEM — standalone fleet crate.
+# WHY: extracted from akroasis crates/sphragis to forkwright/sphragis for
+# cross-repo access. preview-pq gated; unaudited until cryptographic review.
+# WHY the expanded form: the inline table exceeded the 80-column limit
+# (TOML.md#formatting), and a multi-line inline table needs TOML 1.1.
+[workspace.dependencies.sphragis]
+git = "https://github.com/forkwright/sphragis"
+tag = "v0.1.1"
+features = ["preview-pq"]


### PR DESCRIPTION
`[workspace.dependencies] sphragis` was a 108-column inline table,
over the 80-column limit in TOML.md#formatting, so
`TOML/inline-table-too-long` fired on `Cargo.toml:73`. Rewritten to the
expanded `[workspace.dependencies.sphragis]` form (the transformation
`kanon lint --fix` owns; a multi-line inline table would need TOML 1.1,
not available on this toolchain), with the attached WHY comment moved
down to stay with the declaration and a blank-line separator matching
the surrounding sections.

The declaration itself is unchanged — verified by comparing
`tomllib.load` output of both revisions for whole-manifest structural
equality, not just the one key. Repo-wide `kanon lint` open-violation
count drops from 22 to 21 with no new violations introduced.

`ARCH/substrate-dead-dep` still fires on the same declaration (it
proposes removing the post-quantum KEM dependency entirely) — left
alone here since that is cryptographic substance requiring an
operator decision, not a formatting fix.

Verification: representational-only change with no behavioral test;
verified by the `tomllib` structural-equality comparison described
above and by the lint rule itself going from firing to silent.

Refs #261
