### PR TITLE
fix(radio): honor CSV quoting on import and preserve probe failure causes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ version = "0.1.19"
 dependencies = [
  "clap",
  "comfy-table",
+ "csv",
  "dialoguer",
  "figment",
  "indicatif",

--- a/crates/akroasis/Cargo.toml
+++ b/crates/akroasis/Cargo.toml
@@ -23,6 +23,7 @@ hardware-serial = ["syntonia/hardware-serial"]
 [dependencies]
 clap = { workspace = true }
 comfy-table = "7"
+csv = { workspace = true }
 dialoguer = "0.11"
 figment = { workspace = true }
 indicatif = "0.17"

--- a/crates/akroasis/src/radio/errors.rs
+++ b/crates/akroasis/src/radio/errors.rs
@@ -88,6 +88,12 @@ pub enum RadioError {
         source: syntonia::hardware::DetectError,
     },
 
+    #[cfg(feature = "hardware-serial")] // kanon:ignore RUST/feature-gate-check -- declared in akroasis/Cargo.toml [features]
+    #[snafu(display(
+        "Radio answered on {port} but its firmware ident was not recognized: {message}"
+    ))]
+    UnrecognizedRadio { port: String, message: String },
+
     #[snafu(display("I/O error: {source}"))]
     Io { source: std::io::Error },
 }

--- a/crates/akroasis/src/radio/import.rs
+++ b/crates/akroasis/src/radio/import.rs
@@ -162,59 +162,63 @@ pub(crate) fn import_from_string(
 )]
 pub(crate) fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError> {
     let mut channels = Vec::new();
-    let mut lines = content.lines();
 
-    // Skip header
-    let _header = lines.next();
+    // WHY: CHIRP quotes any field containing a comma, a quote or a newline —
+    // `export::csv_escape` writes exactly that form — so splitting on ','
+    // misaligns every column after a quoted name and silently decodes the wrong
+    // frequency. RFC4180 decoding is the csv crate's job, not this parser's.
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .trim(csv::Trim::All)
+        .from_reader(content.as_bytes());
 
-    for (line_num, line) in lines.enumerate() {
-        if line.trim().is_empty() {
+    for record in reader.records() {
+        // WHY: a quoted field may span newlines, so the record's own position is
+        // the only accurate line number; there is no line index to count.
+        let record = record.map_err(|source| RadioError::CsvParse {
+            line: csv_error_line(&source),
+            message: source.to_string(),
+        })?;
+
+        let line_num = record
+            .position()
+            .map_or(0, |p| usize::try_from(p.line()).unwrap_or(usize::MAX));
+
+        if record.iter().all(str::is_empty) {
             continue;
         }
 
-        let cols: Vec<&str> = line.split(',').collect();
+        let cols = &record;
         if cols.len() < 15 {
             return Err(RadioError::CsvParse {
-                line: line_num + 2,
+                line: line_num,
                 message: format!("expected at least 15 columns, got {}", cols.len()),
             });
         }
 
-        let index: u16 = cols
-            .first()
-            .copied()
-            .unwrap_or_default()
-            .trim()
-            .parse()
-            .map_err(|_| RadioError::CsvParse {
-                line: line_num + 2,
-                message: format!(
-                    "invalid location: '{}'",
-                    cols.first().copied().unwrap_or_default().trim()
-                ),
-            })?;
+        let index: u16 =
+            cols.get(0)
+                .unwrap_or_default()
+                .parse()
+                .map_err(|_| RadioError::CsvParse {
+                    line: line_num,
+                    message: format!("invalid location: '{}'", cols.get(0).unwrap_or_default()),
+                })?;
 
-        let name = cols
-            .get(1)
-            .copied()
-            .unwrap_or_default()
-            .trim()
-            .trim_matches('"')
-            .to_string();
+        // WHY: the reader already removed the surrounding quotes and undoubled
+        // any escaped ones, so trimming '"' here would corrupt a name whose own
+        // first or last character is a quote.
+        let name = cols.get(1).unwrap_or_default().to_string();
 
-        let rx_mhz: f64 = cols
-            .get(2)
-            .copied()
-            .unwrap_or_default()
-            .trim()
-            .parse()
-            .map_err(|_| RadioError::CsvParse {
-                line: line_num + 2,
-                message: format!(
-                    "invalid frequency: '{}'",
-                    cols.get(2).copied().unwrap_or_default().trim()
-                ),
-            })?;
+        let rx_mhz: f64 =
+            cols.get(2)
+                .unwrap_or_default()
+                .parse()
+                .map_err(|_| RadioError::CsvParse {
+                    line: line_num,
+                    message: format!("invalid frequency: '{}'", cols.get(2).unwrap_or_default()),
+                })?;
         #[expect(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
@@ -222,14 +226,8 @@ pub(crate) fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError
         )]
         let rx_freq = Frequency::hz((rx_mhz * 1_000_000.0).round() as u64);
 
-        let duplex = cols.get(3).copied().unwrap_or_default().trim();
-        let offset_mhz: f64 = cols
-            .get(4)
-            .copied()
-            .unwrap_or_default()
-            .trim()
-            .parse()
-            .unwrap_or(0.0);
+        let duplex = cols.get(3).unwrap_or_default();
+        let offset_mhz: f64 = cols.get(4).unwrap_or_default().parse().unwrap_or(0.0);
 
         #[expect(
             clippy::cast_possible_truncation,
@@ -249,7 +247,7 @@ pub(crate) fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError
                 let tx_hz = rx_hz
                     .checked_add(off_hz)
                     .ok_or_else(|| RadioError::CsvParse {
-                        line: line_num + 2,
+                        line: line_num,
                         message: format!("frequency offset overflow: {rx_freq} + {offset_freq}"),
                     })?;
                 (
@@ -261,7 +259,7 @@ pub(crate) fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError
                 let tx_hz = rx_hz
                     .checked_sub(off_hz)
                     .ok_or_else(|| RadioError::CsvParse {
-                        line: line_num + 2,
+                        line: line_num,
                         message: format!("frequency offset underflow: {rx_freq} - {offset_freq}"),
                     })?;
                 (
@@ -277,23 +275,23 @@ pub(crate) fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError
         };
 
         let tone = parse_chirp_tone(
-            cols.get(5).copied().unwrap_or_default().trim(),
-            cols.get(6).copied().unwrap_or_default().trim(),
-            cols.get(8).copied().unwrap_or_default().trim(),
-            cols.get(9).copied().unwrap_or_default().trim(),
+            cols.get(5).unwrap_or_default(),
+            cols.get(6).unwrap_or_default(),
+            cols.get(8).unwrap_or_default(),
+            cols.get(9).unwrap_or_default(),
         );
 
-        let bandwidth = match cols.get(11).map(|s| s.trim()) {
+        let bandwidth = match cols.get(11) {
             Some("NFM") => Bandwidth::Narrow,
             _ => Bandwidth::Wide,
         };
 
-        let scan = match cols.get(13).map(|s| s.trim()) {
+        let scan = match cols.get(13) {
             Some("S") => ScanMode::Skip,
             _ => ScanMode::Include,
         };
 
-        let power = match cols.get(14).map(|s| s.trim()) {
+        let power = match cols.get(14) {
             Some("Low") => PowerLevel::Low,
             Some("Mid") => PowerLevel::Mid,
             _ => PowerLevel::High,
@@ -319,6 +317,15 @@ pub(crate) fn parse_chirp_csv(content: &str) -> Result<FrequencyPlan, RadioError
         channels,
         created: None,
     })
+}
+
+/// Recovers the 1-based source line a CSV reader error occurred on.
+///
+/// Returns 0 when the reader could not attribute the failure to a position
+/// (an I/O fault rather than a malformed record).
+fn csv_error_line(err: &csv::Error) -> usize {
+    err.position()
+        .map_or(0, |p| usize::try_from(p.line()).unwrap_or(usize::MAX))
 }
 
 fn parse_chirp_tone(tone_mode: &str, r_tone: &str, dtcs_code: &str, dtcs_pol: &str) -> ToneMode {
@@ -452,6 +459,102 @@ Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPola
         assert_eq!(imported.channels[0].index, 0);
         assert_eq!(imported.channels[0].name, "TEST");
         assert_eq!(imported.channels[0].rx_freq, plan.channels[0].rx_freq);
+    }
+
+    /// Builds a one-row CHIRP CSV whose Name column is `name`, quoted verbatim.
+    fn chirp_csv_with_quoted_name(name: &str) -> String {
+        format!(
+            "Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,\
+             DtcsPolarity,RxDtcsCode,Mode,TStep,Skip,Power,Comment,URCALL,RPT1CALL,RPT2CALL,DVCODE\n\
+             7,{name},146.520000,,0.000000,,88.5,88.5,023,NN,023,FM,5.00,,Low,,,,,\n"
+        )
+    }
+
+    #[test]
+    fn a_quoted_name_containing_a_comma_keeps_the_later_columns_aligned() {
+        // WHY: splitting on ',' turns this one row into 21 fields, so Frequency
+        // reads " North\"" and every column after it shifts by one.
+        let csv = chirp_csv_with_quoted_name("\"Repeater, North\"");
+
+        let plan = parse_chirp_csv(&csv).unwrap();
+
+        assert_eq!(plan.channels.len(), 1);
+        assert_eq!(plan.channels[0].name, "Repeater, North");
+        assert_eq!(plan.channels[0].rx_freq.as_hz(), 146_520_000);
+        // The Power column sits after the comma, so a shift would misread it.
+        assert_eq!(plan.channels[0].power, PowerLevel::Low);
+    }
+
+    #[test]
+    fn a_doubled_quote_in_a_name_is_undoubled_rather_than_stripped() {
+        // RFC4180 escapes an embedded '"' by doubling it; the old parser used
+        // trim_matches('"'), which neither undoubles nor survives interior quotes.
+        let csv = chirp_csv_with_quoted_name("\"MT \"\"HIGH\"\"\"");
+
+        let plan = parse_chirp_csv(&csv).unwrap();
+
+        assert_eq!(plan.channels[0].name, "MT \"HIGH\"");
+        assert_eq!(plan.channels[0].rx_freq.as_hz(), 146_520_000);
+    }
+
+    #[test]
+    fn exported_names_needing_quotes_reimport_unchanged() {
+        use crate::radio::export::export_chirp_csv;
+
+        // WHY: export::csv_escape already writes RFC4180 quoting, so every name
+        // here is one this crate itself emits — the roundtrip was broken against
+        // akroasis's OWN export, not just against foreign CHIRP files.
+        let tricky = ["Repeater, North", "MT \"HIGH\"", "A,B,C", "plain"];
+
+        let plan = FrequencyPlan {
+            name: "Roundtrip".to_string(),
+            radio_model: None,
+            channels: tricky
+                .iter()
+                .enumerate()
+                .map(|(i, name)| Channel {
+                    index: u16::try_from(i).unwrap(),
+                    name: (*name).to_string(),
+                    rx_freq: Frequency::hz(146_520_000),
+                    tx_freq: None,
+                    offset: syntonia::FrequencyOffset::None,
+                    tone: ToneMode::None,
+                    power: PowerLevel::High,
+                    bandwidth: Bandwidth::Wide,
+                    scan: ScanMode::Include,
+                    busy_lock: false,
+                })
+                .collect(),
+            created: None,
+        };
+
+        let imported = parse_chirp_csv(&export_chirp_csv(&plan)).unwrap();
+
+        assert_eq!(imported.channels.len(), tricky.len());
+        for (got, want) in imported.channels.iter().zip(tricky) {
+            assert_eq!(got.name, want);
+            assert_eq!(got.rx_freq.as_hz(), 146_520_000);
+        }
+    }
+
+    #[test]
+    fn a_quoted_embedded_newline_does_not_desynchronise_the_reported_line() {
+        // The bad row is the 4th physical line; a record counter would say 3.
+        let csv = "\
+Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPolarity,RxDtcsCode,Mode,TStep,Skip,Power,Comment,URCALL,RPT1CALL,RPT2CALL,DVCODE
+0,\"two
+line\",146.520000,,0.000000,,88.5,88.5,023,NN,023,FM,5.00,,High,,,,,
+1,BAD,not-a-frequency,,0.000000,,88.5,88.5,023,NN,023,FM,5.00,,High,,,,,\n";
+
+        let err = parse_chirp_csv(csv).unwrap_err();
+
+        assert!(
+            matches!(err, RadioError::CsvParse { line: 4, .. }),
+            "expected CsvParse on physical line 4, got: {err:?}"
+        );
+        if let RadioError::CsvParse { message, .. } = err {
+            assert!(message.contains("not-a-frequency"), "got: {message}");
+        }
     }
 
     #[test]

--- a/crates/akroasis/src/radio/read.rs
+++ b/crates/akroasis/src/radio/read.rs
@@ -62,7 +62,10 @@ pub(crate) fn print_channel_table(
             .map_or_else(|| ch.rx_freq.to_string(), |tx| format!("{tx}"));
 
         table.add_row(vec![
-            Cell::new(format!("{:03}", ch.index + 1)),
+            // WHY: index comes from untrusted CSV as a full-range u16, so `+ 1`
+            // on u16 panics in debug and wraps to 000 in release at index 65535;
+            // widening first keeps the display exact for every input.
+            Cell::new(format!("{:03}", u32::from(ch.index) + 1)),
             Cell::new(&ch.name),
             Cell::new(ch.rx_freq.to_string()),
             Cell::new(tx_display),
@@ -170,6 +173,24 @@ mod tests {
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("CALL"));
         assert!(s.contains("RPT-IN"));
+    }
+
+    #[test]
+    fn the_maximum_channel_index_displays_without_overflowing() {
+        // WHY: import parses Location straight into u16, so u16::MAX is reachable
+        // from a CSV file. `ch.index + 1` on u16 panicked in debug and wrapped to
+        // "000" in release — a silently wrong channel number.
+        let mut channels = sample_channels();
+        if let Some(first) = channels.first_mut() {
+            first.index = u16::MAX;
+        }
+        let refs: Vec<&Channel> = channels.iter().collect();
+
+        let mut out = Vec::new();
+        print_channel_table(&refs, &mut out).unwrap();
+
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("65536"), "expected the widened index, got:\n{s}");
     }
 
     #[test]

--- a/crates/akroasis/src/radio/serial_hardware.rs
+++ b/crates/akroasis/src/radio/serial_hardware.rs
@@ -105,14 +105,32 @@ impl BaofengProtocolSession {
         // Try every magic sequence in priority order (UV5R-291, BF-F8HP, UV5R-orig).
         let ident = {
             let mut found = None;
-            for magic in MAGIC_SETS {
-                if protocol.enter_programming_mode(magic).is_ok() {
-                    match protocol.identify() {
-                        Ok(id) => {
-                            found = Some(id);
-                            break;
-                        }
-                        Err(_) => continue,
+            for (attempt, magic) in MAGIC_SETS.iter().enumerate() {
+                // WHY: every probe failure here used to be discarded, so a radio
+                // that answered wrongly and a port that never answered produced
+                // the same bare timeout. Trace each rejection so the operator can
+                // tell "wrong magic set" from "nothing on the wire".
+                if let Err(e) = protocol.enter_programming_mode(magic) {
+                    tracing::debug!(
+                        port = port_path,
+                        attempt,
+                        error = %e,
+                        "magic sequence rejected entering programming mode"
+                    );
+                    continue;
+                }
+                match protocol.identify() {
+                    Ok(id) => {
+                        found = Some(id);
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            port = port_path,
+                            attempt,
+                            error = %e,
+                            "radio entered programming mode but did not identify"
+                        );
                     }
                 }
             }
@@ -121,13 +139,21 @@ impl BaofengProtocolSession {
             })?
         };
 
-        // Map the raw ident bytes to a VariantConfig.
-        let config = identify_variant(&ident).map_err(|_| RadioError::WrongBaudRate {
+        // WHY: the radio DID answer to get here, so the baud rate is right. The
+        // ident simply names a variant this build does not know — reporting that
+        // as WrongBaudRate sent the operator to the cable-and-protocol checklist
+        // and threw away the ident bytes needed to add the variant.
+        let config = identify_variant(&ident).map_err(|source| RadioError::UnrecognizedRadio {
             port: port_path.to_string(),
+            message: source.to_string(),
         })?;
 
-        let variant = variant_from_config(&config).ok_or(RadioError::WrongBaudRate {
+        let variant = variant_from_config(&config).ok_or_else(|| RadioError::UnrecognizedRadio {
             port: port_path.to_string(),
+            message: format!(
+                "syntonia identified variant {:?}, which this build does not map to a CLI variant",
+                config.variant
+            ),
         })?;
 
         Ok(Self {


### PR DESCRIPTION
## What was wrong

Four findings from the wave-1 audit batch against `crates/akroasis/src/radio`:

- `parse_chirp_csv` split each CSV line on `,` and stripped quotes from the Name column with `trim_matches('"')`, ignoring RFC4180 quoting. A quoted field containing a comma (e.g. a channel named "Repeater, North") became two columns, shifting Frequency/Mode/Skip/Power one place left and importing the wrong values without an error. This broke against akroasis's own export — `export::csv_escape` already writes RFC4180-quoted output the importer could not read back — and the existing roundtrip test only passed because its test channel happened to be named "TEST".
- Channel index display (`read.rs`) formatted `ch.index + 1` on a `u16`, and import parses Location straight into `u16`, so a CSV with location 65535 panicked in debug / displayed "000" in release.
- A radio that answered the magic handshake but returned an unrecognized firmware ident was classified as `WrongBaudRate`, sending the operator to the cable/protocol checklist for a radio that was awake and talking, and discarding the ident bytes needed to add the variant.
- Probe rejections in the magic-set loop were discarded via `.is_ok()` / `Err(_) => continue`, so "nothing on the wire" and "answered, but to a different magic set" produced the same bare `SerialTimeout` with no diagnostic trail.

## What this changes

- CSV decoding now goes through the workspace `csv` crate reader, which owns quoting, quote-undoubling, and embedded newlines; error line numbers come from the record's own position.
- The channel-index addition widens to `u32` before formatting.
- Both the unrecognized-ident and unmappable-variant cases now return a new `UnrecognizedRadio` variant carrying the cause (`RadioError` is `#[non_exhaustive]`, so this is additive).
- Each magic-set rejection is now traced with the magic-set index and the underlying error; no control flow changed.

## Verification

Five new tests, each failing on the pre-fix code, cover the CSV quoting/undoubling/roundtrip/newline and index-overflow findings. The two `serial_hardware.rs` findings are not covered by a test — `syntonia`'s `MockSerialPort` is `#[cfg(test)]` with `pub(crate)` wire constants, so akroasis cannot script the handshake without duplicating them, and exposing a test-util port from syntonia is scoped as a follow-up rather than folded into this batch.

akroasis: 180 tests pass (170 before). `cargo fmt` and `cargo clippy` clean.

Refs #228
