### PR TITLE
fix(kerykeion): close six correctness and resilience findings from the wave-1 audit

### DIFF
--- a/crates/kerykeion/src/collector.rs
+++ b/crates/kerykeion/src/collector.rs
@@ -19,7 +19,7 @@ use crate::config::MeshConfig;
 use crate::connection::MeshConnection;
 use crate::delivery::DeliveryTracker;
 use crate::discovery::run_discovery;
-use crate::error::Error;
+use crate::error::{Error, HandshakeFailedSnafu};
 use crate::handshake;
 use crate::heartbeat;
 use crate::node_db::NodeDb;
@@ -213,8 +213,10 @@ impl MeshCollector {
 
     /// Connects to all configured transports and performs handshakes.
     ///
-    /// Returns `Ok` with the list of active connections, which may be empty
-    /// if all connections fail.
+    /// # Errors
+    ///
+    /// Returns [`Error::HandshakeFailed`] if connections are configured but
+    /// none of them reached a completed handshake.
     async fn connect_and_handshake(&self) -> Result<Vec<Arc<Mutex<ConnectionHandle>>>, Error> {
         let mut connections: Vec<ConnectionHandle> = Vec::new();
         for conn_cfg in &self.config.connections {
@@ -231,8 +233,15 @@ impl MeshCollector {
 
         let mut active: Vec<Arc<Mutex<ConnectionHandle>>> = Vec::new();
         for mut conn in connections {
-            let mut db = self.node_db.lock().await;
-            match handshake::handshake_with_config(&mut conn, &mut db, &self.config.handshake).await
+            // WHY: the handshake awaits a full config dump from the radio, which
+            // is unbounded network time. Holding the shared node_db across it
+            // stalls every other task that needs the DB for exactly that long.
+            // The handshake only needs somewhere to accumulate, and
+            // `HandshakeResult` already carries everything it wrote, so give it
+            // a scratch DB and merge under a short lock afterwards.
+            let mut scratch = NodeDb::new();
+            match handshake::handshake_with_config(&mut conn, &mut scratch, &self.config.handshake)
+                .await
             {
                 Ok(result) => {
                     tracing::info!(
@@ -241,14 +250,33 @@ impl MeshCollector {
                         channels = result.channels.len(),
                         "handshake complete"
                     );
+                    let mut db = self.node_db.lock().await;
+                    db.set_my_node(result.my_node_num);
+                    for node in result.known_nodes {
+                        db.insert(node);
+                    }
                     drop(db);
                     active.push(Arc::new(Mutex::new(conn)));
                 }
                 Err(e) => {
-                    drop(db);
                     tracing::warn!(error = %e, "handshake failed, skipping connection");
                 }
             }
+        }
+
+        // WHY: with connections configured and none active, every transport or
+        // handshake failed. Returning Ok here spawns the whole background task
+        // set against no radio: the collector then runs indefinitely observing
+        // nothing while reporting success, which is indistinguishable from a
+        // quiet mesh. Fail instead so the caller can retry or surface it.
+        if active.is_empty() && !self.config.connections.is_empty() {
+            return HandshakeFailedSnafu {
+                detail: format!(
+                    "all {} configured connections failed to connect or handshake",
+                    self.config.connections.len()
+                ),
+            }
+            .fail();
         }
 
         Ok(active)
@@ -543,23 +571,29 @@ where
                             "router flush: expired stale delivery records"
                         );
                     }
-                    let mut packets = Vec::new();
+                    let mut msgs = Vec::new();
                     while let Some(msg) = r.next_to_send() {
-                        let packet = msg.packet.clone();
-                        r.track_sent(msg);
-                        packets.push(packet);
+                        msgs.push(msg);
                     }
                     drop(r);
-                    packets
+                    msgs
                 };
 
-                for packet in pending {
+                for msg in pending {
                     let to_radio = ToRadio {
-                        payload_variant: Some(to_radio::PayloadVariant::Packet(packet)),
+                        payload_variant: Some(to_radio::PayloadVariant::Packet(msg.packet.clone())),
                     };
                     if let Err(e) = conn.lock().await.send(to_radio).await {
                         tracing::warn!(error = %e, "router flush: send error");
                     }
+                    // WHY: track_sent starts the inflight ACK timeout. Starting
+                    // it before the transmit charges the radio's send latency
+                    // and any wait on the connection lock against the peer's
+                    // time to ACK, so a slow link retries messages that were
+                    // never actually late. Tracked even after a send error, so
+                    // the existing timeout/retry path owns the failure rather
+                    // than the message being dropped here.
+                    router.lock().await.track_sent(msg);
                 }
             }
         }

--- a/crates/kerykeion/src/collector_tests.rs
+++ b/crates/kerykeion/src/collector_tests.rs
@@ -4,6 +4,7 @@
 use tracing::Instrument as _;
 
 use super::*;
+use crate::SendOptions;
 use crate::config::{ConnectionConfig, MeshConfig, StoreForwardConfig, TopologyConfig};
 
 fn make_config(connections: Vec<ConnectionConfig>) -> MeshConfig {
@@ -448,4 +449,124 @@ async fn dispatch_routing_ignores_non_routing_packet() {
         "non-routing packet must not create a delivery record"
     );
     drop(router);
+}
+
+// ── akroasis#229: total connection failure must be reported, not swallowed ──
+
+#[tokio::test]
+async fn connect_and_handshake_errors_when_every_connection_fails() {
+    // WHY: returning Ok with an empty connection set spawns the whole
+    // background task set against no radio. The collector then runs
+    // indefinitely observing nothing while reporting success, which is
+    // indistinguishable from a mesh that is merely quiet.
+    let c = MeshCollector::new(make_config(vec![ConnectionConfig::Serial {
+        port: "/dev/nonexistent_device_xyz".into(),
+        baud: 115_200,
+    }]));
+
+    let result = c.connect_and_handshake().await;
+
+    assert!(
+        matches!(result, Err(Error::HandshakeFailed { .. })),
+        "all-connections-failed should surface as Error::HandshakeFailed"
+    );
+}
+
+#[tokio::test]
+async fn connect_and_handshake_stays_ok_with_no_connections_configured() {
+    // WHY: an empty connection list is a valid configuration, not a failure  -
+    // this is what `run_exits_with_no_connections` depends on.
+    let c = MeshCollector::new(make_config(vec![]));
+    let result = c.connect_and_handshake().await;
+    assert!(result.is_ok(), "no configured connections is not a failure");
+}
+
+// ── akroasis#229: the inflight ACK timeout starts after the transmit ──────
+
+/// Connection whose `send()` parks until released, so the test can observe
+/// router state during the transmit.
+struct GatedSendConn {
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+impl crate::connection::MeshConnection for GatedSendConn {
+    async fn send(&mut self, _: crate::proto::ToRadio) -> Result<(), Error> {
+        self.entered.notify_one();
+        self.release.notified().await;
+        Ok(())
+    }
+    async fn recv(&mut self) -> Result<FromRadio, Error> {
+        std::future::pending().await
+    }
+    fn is_connected(&self) -> bool {
+        true
+    }
+    async fn reconnect(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn router_flush_starts_ack_timeout_after_transmit() {
+    // WHY: track_sent starts the inflight ACK timeout. Starting it before the
+    // transmit charges the radio's send latency and any wait on the connection
+    // lock against the peer's time to ACK, so a slow link retries messages
+    // that were never actually late.
+    let router = Arc::new(Mutex::new(MeshRouter::new(
+        OutboundQueue::new(),
+        StoreForward::new(StoreForwardConfig::default()),
+        DeliveryTracker::new(),
+    )));
+    #[expect(clippy::unwrap_used, reason = "test-only")]
+    router
+        .lock()
+        .await
+        .send(
+            make_outbound_packet(42, 0x2222),
+            true,
+            &SendOptions::default(),
+        )
+        .unwrap();
+
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let conn = Arc::new(Mutex::new(GatedSendConn {
+        entered: Arc::clone(&entered),
+        release: Arc::clone(&release),
+    }));
+
+    let token = CancellationToken::new();
+    let flush_router = Arc::clone(&router);
+    let task_token = token.clone();
+    let handle = tokio::spawn(async move {
+        run_router_flush(flush_router, conn, Duration::from_millis(10), task_token).await
+    });
+
+    // Park inside send(): the packet has left the queue but is not on air yet.
+    entered.notified().await;
+    assert_eq!(
+        router.lock().await.outbound.inflight_count(),
+        0,
+        "the ACK timeout must not be running while the transmit is still in flight"
+    );
+
+    release.notify_one();
+
+    // The transmit has now returned, so the message becomes inflight.
+    let mut inflight = 0;
+    for _ in 0..100 {
+        inflight = router.lock().await.outbound.inflight_count();
+        if inflight == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        inflight, 1,
+        "message should be inflight once the send returns"
+    );
+
+    token.cancel();
+    handle.abort();
 }

--- a/crates/kerykeion/src/handshake.rs
+++ b/crates/kerykeion/src/handshake.rs
@@ -458,4 +458,47 @@ mod tests {
 
         assert_eq!(node.hop_count, Some(3));
     }
+
+    // ── akroasis#229: HandshakeResult must mirror every node_db write ─────
+
+    #[tokio::test]
+    async fn handshake_result_mirrors_every_node_db_write() {
+        // WHY: the collector runs the handshake against a scratch NodeDb and
+        // merges HandshakeResult into the shared one afterwards, so the shared
+        // lock is not held across the radio's config dump. That is equivalent
+        // only while the result carries everything the handshake writes  -  a
+        // write with no matching result field would be dropped by the merge.
+        let mut direct = NodeDb::new();
+        let mut conn = DynamicMock {
+            my_info_sent: false,
+            node_info_sent: false,
+            config_id: None,
+        };
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let result = handshake(&mut conn, &mut direct).await.unwrap();
+
+        let mut merged = NodeDb::new();
+        merged.set_my_node(result.my_node_num);
+        for node in result.known_nodes {
+            merged.insert(node);
+        }
+
+        assert_eq!(
+            merged.my_node(),
+            direct.my_node(),
+            "merge must reproduce the local node number"
+        );
+        assert_eq!(
+            merged.len(),
+            direct.len(),
+            "merge must reproduce every node the handshake inserted"
+        );
+        for (num, node) in direct.iter() {
+            #[expect(clippy::expect_used, reason = "test-only")]
+            let mirrored = merged.get(*num).expect("node missing from merged DB");
+            assert_eq!(mirrored.num, node.num);
+            assert_eq!(mirrored.hop_count, node.hop_count);
+        }
+    }
 }

--- a/crates/kerykeion/src/processor.rs
+++ b/crates/kerykeion/src/processor.rs
@@ -137,9 +137,15 @@ impl PacketProcessor {
             }
         }
 
-        // WHY: emit GeoSignals for each produced event.
+        // WHY: an event names its own subject, which is not always the packet
+        // sender. NEIGHBORINFO reports carry a reporter id from the payload, so
+        // locating every signal at `from` puts a relayed report at the relay
+        // rather than at the node the report is about.
         for event in &events {
-            let position = self.node_db.get(from).and_then(|n| n.position.as_ref());
+            let position = event
+                .subject()
+                .and_then(|subject| self.node_db.get(subject))
+                .and_then(|n| n.position.as_ref());
             let signal = mesh_event_to_signal(event, position);
             // WHY: broadcast send errors mean no receivers are listening; not fatal.
             let _ = self.tx.send(signal);
@@ -205,11 +211,23 @@ impl PacketProcessor {
             }
         };
 
+        // WHY: hw_model is an i32 on the wire. Collapsing an out-of-range value
+        // to 0 makes a malformed report indistinguishable from UNSET, which is
+        // also what a radio that never declared its model reports.
+        let hw_model = u32::try_from(user_proto.hw_model).unwrap_or_else(|_| {
+            tracing::warn!(
+                from = from.0,
+                hw_model = user_proto.hw_model,
+                "NODEINFO hw_model out of range; recording as UNSET"
+            );
+            0
+        });
+
         let user = UserInfo {
             id: user_proto.id,
             long_name: user_proto.long_name,
             short_name: user_proto.short_name.clone(),
-            hw_model: u32::try_from(user_proto.hw_model).unwrap_or(0),
+            hw_model,
             is_licensed: user_proto.is_licensed,
         };
 

--- a/crates/kerykeion/src/processor_tests.rs
+++ b/crates/kerykeion/src/processor_tests.rs
@@ -416,3 +416,78 @@ fn apply_nak_marks_failed_when_no_inflight() {
         Some(crate::delivery::DeliveryStatus::Failed { .. })
     ));
 }
+
+// ── akroasis#229: a signal is located at its subject, not the packet sender ──
+
+fn node_at(num: u32, latitude: f64, longitude: f64) -> MeshNode {
+    MeshNode {
+        num: NodeNum(num),
+        user: None,
+        position: Some(crate::node_db::NodePosition {
+            latitude,
+            longitude,
+            altitude: None,
+            timestamp: None,
+        }),
+        metrics: None,
+        last_heard: None,
+        snr: None,
+        hop_count: None,
+    }
+}
+
+#[tokio::test]
+async fn neighborinfo_signal_is_located_at_the_reporter_not_the_packet_sender() {
+    // WHY: NEIGHBORINFO carries its reporter id in the payload, so a relayed
+    // report describes links the relay is not an endpoint of. Locating every
+    // signal at the packet sender puts those links at the relay's coordinates.
+    let (tx, mut rx) = broadcast::channel(64);
+    let mut node_db = NodeDb::new();
+    node_db.set_my_node(NodeNum(0xAAAA));
+    node_db.insert(node_at(0x1111, 10.0, 10.0)); // the relay that transmitted
+    node_db.insert(node_at(0x2222, 50.0, 60.0)); // the node the report is about
+    let mut proc = PacketProcessor::new(node_db, MeshTopology::new(), tx);
+
+    let ni = NeighborInfo {
+        node_id: 0x2222,
+        last_sent_by_id: 0,
+        node_broadcast_interval_secs: 0,
+        neighbors: vec![Neighbor {
+            node_id: 0x3333,
+            snr: 4.0,
+        }],
+    };
+    let mut payload = Vec::new();
+    ni.encode(&mut payload).unwrap();
+
+    let packet = make_mesh_packet(0x1111, portnum::NEIGHBORINFO_APP, payload);
+    let events = proc.process_mesh_packet(&packet);
+    assert_eq!(events.len(), 1, "one neighbor should yield one event");
+
+    let signal = rx.recv().await.unwrap();
+    #[expect(clippy::expect_used, reason = "test-only")]
+    let coords = signal
+        .location
+        .expect("topology signal should carry the reporter's position");
+    assert!(
+        (coords.latitude - 50.0).abs() < f64::EPSILON
+            && (coords.longitude - 60.0).abs() < f64::EPSILON,
+        "signal should be located at reporter 0x2222 (50, 60), got ({}, {})",
+        coords.latitude,
+        coords.longitude
+    );
+}
+
+#[tokio::test]
+async fn partition_events_carry_no_subject_and_no_location() {
+    // WHY: the partition events describe a set of nodes rather than one, so
+    // there is no single position to attribute them to.
+    let detected = MeshEvent::PartitionDetected {
+        components: vec![vec![NodeNum(1)], vec![NodeNum(2)]],
+    };
+    let healed = MeshEvent::PartitionHealed {
+        reunited_nodes: vec![NodeNum(1)],
+    };
+    assert!(detected.subject().is_none());
+    assert!(healed.subject().is_none());
+}

--- a/crates/kerykeion/src/signals.rs
+++ b/crates/kerykeion/src/signals.rs
@@ -85,6 +85,29 @@ pub enum MeshEvent {
     },
 }
 
+impl MeshEvent {
+    /// The node this event is about, when it names exactly one.
+    ///
+    /// This is the node whose position locates the emitted signal. It is not
+    /// the packet sender: `NEIGHBORINFO` carries a reporter id in its payload,
+    /// so a relayed report describes links the relay is not an endpoint of.
+    ///
+    /// Returns `None` for the partition events, which describe a set of nodes
+    /// rather than one; their conversions carry no location either.
+    #[must_use]
+    pub const fn subject(&self) -> Option<NodeNum> {
+        match self {
+            Self::NodeDiscovered { node, .. }
+            | Self::NodeOffline { node }
+            | Self::PositionUpdate { node, .. }
+            | Self::GatewayStatusChange { node, .. }
+            | Self::TelemetryUpdate { node, .. } => Some(*node),
+            Self::TopologyChange { from, .. } | Self::LinkDegraded { from, .. } => Some(*from),
+            Self::PartitionDetected { .. } | Self::PartitionHealed { .. } => None,
+        }
+    }
+}
+
 /// Convert a [`MeshEvent`] to a [`GeoSignal`] using the closest matching [`MeshDetail`] variant.
 ///
 /// Events that lack a direct `MeshDetail` mapping use `MeshDetail::NodeSeen` with

--- a/crates/kerykeion/src/topology.rs
+++ b/crates/kerykeion/src/topology.rs
@@ -16,6 +16,18 @@ use crate::types::NodeNum;
 
 // Historical default (30.0) now lives in [`TopologyConfig::default`].
 
+/// Maximum nodes accepted from a persisted topology snapshot.
+///
+// WHY: `load_from_bytes` allocates one graph node per entry from a file that
+// may be truncated, corrupt or attacker-written. A Meshtastic node DB holds low
+// hundreds of nodes, so this ceiling is far above any real mesh while still
+// bounding the allocation. Exceeding it is recoverable: passive learning
+// re-observes live links, so a truncated restore self-heals.
+const MAX_SNAPSHOT_NODES: usize = 4096;
+
+/// Maximum links accepted from a persisted topology snapshot.
+const MAX_SNAPSHOT_LINKS: usize = 16384;
+
 /// Directed edge weight representing radio link quality between two nodes.
 #[derive(Debug, Clone)]
 pub struct LinkQuality {
@@ -365,6 +377,9 @@ impl MeshTopology {
 
     /// Restore topology from a serialized snapshot. All links are marked as observed now.
     ///
+    /// Repeated `(from, to)` pairs are folded into a single edge, and the
+    /// restore is bounded at [`MAX_SNAPSHOT_NODES`] / [`MAX_SNAPSHOT_LINKS`].
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::TopologySnapshot`] if JSON deserialization fails.
@@ -375,22 +390,58 @@ impl MeshTopology {
                 location: snafu::location!(),
             })?;
 
+        // WHY: never truncate silently  -  a restore that dropped half the mesh
+        // without saying so reads as a small mesh rather than a bad snapshot.
+        if snapshot.nodes.len() > MAX_SNAPSHOT_NODES {
+            tracing::warn!(
+                present = snapshot.nodes.len(),
+                cap = MAX_SNAPSHOT_NODES,
+                "topology snapshot exceeds node cap; restoring a prefix"
+            );
+        }
+        if snapshot.links.len() > MAX_SNAPSHOT_LINKS {
+            tracing::warn!(
+                present = snapshot.links.len(),
+                cap = MAX_SNAPSHOT_LINKS,
+                "topology snapshot exceeds link cap; restoring a prefix"
+            );
+        }
+
         let mut topo = Self::new();
-        for node in &snapshot.nodes {
+        for node in snapshot.nodes.iter().take(MAX_SNAPSHOT_NODES) {
             topo.add_node(*node);
         }
-        for link in &snapshot.links {
+        for link in snapshot.links.iter().take(MAX_SNAPSHOT_LINKS) {
             let from_idx = topo.add_node(link.from);
             let to_idx = topo.add_node(link.to);
-            topo.graph.add_edge(
-                from_idx,
-                to_idx,
-                LinkQuality {
-                    snr: link.snr,
-                    last_observed: Instant::now(),
-                    packet_count: link.packet_count,
-                },
-            );
+
+            // WHY: `update_link` keeps at most one edge per ordered pair, and
+            // `to_bytes` re-emits whatever edges exist. Restoring with a bare
+            // `add_edge` admits parallel edges the live path can never create,
+            // and each save/load cycle multiplies them. Fold instead: the last
+            // observation wins, and the counts add.
+            let existing = topo
+                .graph
+                .edges_connecting(from_idx, to_idx)
+                .next()
+                .map(|e| e.id());
+
+            if let Some(edge_id) = existing {
+                if let Some(weight) = topo.graph.edge_weight_mut(edge_id) {
+                    weight.snr = link.snr;
+                    weight.packet_count = weight.packet_count.saturating_add(link.packet_count);
+                }
+            } else {
+                topo.graph.add_edge(
+                    from_idx,
+                    to_idx,
+                    LinkQuality {
+                        snr: link.snr,
+                        last_observed: Instant::now(),
+                        packet_count: link.packet_count,
+                    },
+                );
+            }
         }
         Ok(topo)
     }
@@ -696,6 +747,80 @@ mod tests {
                 .unwrap()
                 .len(),
             2
+        );
+    }
+
+    // ── akroasis#229: snapshot restore must dedup and stay bounded ────────
+
+    fn link(from: u32, to: u32, snr: f32, packet_count: u32) -> LinkSnapshot {
+        LinkSnapshot {
+            from: n(from),
+            to: n(to),
+            snr,
+            packet_count,
+        }
+    }
+
+    #[test]
+    fn load_from_bytes_folds_repeated_link_pairs() {
+        // WHY: `update_link` keeps at most one edge per ordered pair, so a
+        // restore that admits parallel edges produces a graph the live path
+        // could never reach  -  and `to_bytes` re-emits them, compounding.
+        let snapshot = TopologySnapshot {
+            nodes: vec![n(1), n(2)],
+            links: vec![link(1, 2, 5.0, 3), link(1, 2, 7.5, 4)],
+        };
+        let bytes = serde_json::to_vec(&snapshot).unwrap();
+
+        let topo = MeshTopology::load_from_bytes(&bytes).unwrap();
+
+        assert_eq!(topo.edge_count(), 1, "repeated pair must fold to one edge");
+        let neighbors = topo.neighbors(n(1));
+        assert_eq!(neighbors.len(), 1);
+        let (peer, quality) = &neighbors[0];
+        assert_eq!(*peer, n(2));
+        assert!(
+            (quality.snr - 7.5).abs() < f32::EPSILON,
+            "last observation should win, got {}",
+            quality.snr
+        );
+        assert_eq!(quality.packet_count, 7, "counts should add");
+    }
+
+    #[test]
+    fn load_from_bytes_round_trips_without_multiplying_edges() {
+        // WHY: the compounding case  -  save/load/save must be a fixed point.
+        let mut topo = MeshTopology::new();
+        topo.update_link(n(1), n(2), 5.0);
+        topo.update_link(n(2), n(3), 6.0);
+
+        let once = MeshTopology::load_from_bytes(&topo.save_to_bytes().unwrap()).unwrap();
+        let twice = MeshTopology::load_from_bytes(&once.save_to_bytes().unwrap()).unwrap();
+
+        assert_eq!(once.edge_count(), 2);
+        assert_eq!(twice.edge_count(), 2, "reload must not multiply edges");
+    }
+
+    #[test]
+    fn load_from_bytes_caps_nodes_and_links() {
+        let over = MAX_SNAPSHOT_NODES + 10;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "test-only: indices are far below u32::MAX"
+        )]
+        let nodes: Vec<NodeNum> = (0..over as u32).map(n).collect();
+        let snapshot = TopologySnapshot {
+            nodes,
+            links: Vec::new(),
+        };
+        let bytes = serde_json::to_vec(&snapshot).unwrap();
+
+        let topo = MeshTopology::load_from_bytes(&bytes).unwrap();
+
+        assert_eq!(
+            topo.node_count(),
+            MAX_SNAPSHOT_NODES,
+            "restore must stop at the node cap"
         );
     }
 }


### PR DESCRIPTION
## What was wrong

Six of the thirty findings in the wave-1 kerykeion audit batch:

- `connect_and_handshake` held the shared `node_db` mutex across an entire config-dump handshake — unbounded network time — stalling every other task that needed the DB.
- Total connection failure returned `Ok` with an empty connection list, so the collector spawned its full background task set against no radio and ran indefinitely reporting success, indistinguishable from a quiet mesh.
- `run_router_flush` started the inflight ACK timeout (`track_sent`) before the transmit, so the radio's send latency and any connection-lock wait were charged against the peer's time to ACK — a slow link retried messages that were never actually late.
- Every emitted `GeoSignal` was located at the packet sender's position; for NEIGHBORINFO the reporter id comes from the payload rather than the sender, so a relayed report placed another node's links at the relay instead of at the node the report is about.
- An out-of-range `hw_model` was folded to 0 silently, making a malformed report indistinguishable from a radio that never declared its model.
- `load_from_bytes` restored topology snapshots with a bare `add_edge`, while the live path (`update_link`) keeps at most one edge per ordered pair — a snapshot with repeated pairs produced parallel edges the live path can never create, and `save_to_bytes` re-emitted them, so each save/load cycle multiplied them. The restore was also unbounded against a file that may be truncated, corrupt, or attacker-written.

## What this changes

- The handshake now runs against a scratch `NodeDb` and the result is merged into the shared one under a short lock afterward; `HandshakeResult` already carries everything it writes.
- `connect_and_handshake` now fails when connections are configured and none survive; an empty configuration stays `Ok`.
- `track_sent` is called after the transmit returns (including after a send error), so the existing retry path still owns the failure.
- `MeshEvent::subject` resolves the node an event is actually about, rather than defaulting to the sender.
- The `hw_model` collapse is now logged rather than silent; the recorded value is unchanged.
- Snapshot restore folds repeated pairs (last observation wins, counts add) and is capped at 4096 nodes / 16384 links, with truncation logged rather than silent.

## Verification

Verified with the gate-attestation stage commands: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo nextest run --workspace` at 859/859.

Refs #229
