### PR TITLE
test(kerykeion): cover the thirteen untested branches from the wave-1 audit

### DIFF
--- a/crates/kerykeion/src/bridge.rs
+++ b/crates/kerykeion/src/bridge.rs
@@ -707,4 +707,79 @@ mod tests {
         let bridge = GatewayBridge::with_config(cfg);
         assert_eq!(bridge.config().failover_cooldown_secs, 7);
     }
+
+    /// Drives the bridge to the one state in which `ensure_active` actually
+    /// consults the cooldown: no active gateway, a healthy candidate
+    /// available, and `last_failover` freshly stamped.
+    ///
+    /// WHY: `record_health_failure` calls `failover()` directly when the
+    /// ACTIVE gateway drops, bypassing the cooldown entirely — so a
+    /// two-gateway setup never reaches the guard. Taking the sole gateway
+    /// offline instead drives `active` to `None` and stamps `last_failover`;
+    /// the replacement is only registered afterwards.
+    fn bridge_needing_reselection(cfg: BridgeConfig) -> GatewayBridge {
+        let mut bridge = GatewayBridge::with_config(cfg);
+        bridge.add_gateway(NodeNum(1), 1);
+
+        bridge.ensure_active();
+        assert_eq!(
+            bridge.active(),
+            Some(NodeNum(1)),
+            "the only healthy gateway must be chosen first"
+        );
+
+        for _ in 0..bridge.config().offline_check_threshold {
+            bridge.record_health_failure(NodeNum(1));
+        }
+        assert_eq!(
+            bridge.active(),
+            None,
+            "losing the sole gateway must leave the bridge with none active"
+        );
+
+        bridge.add_gateway(NodeNum(2), 2);
+        let _ = bridge.drain_events();
+        bridge
+    }
+
+    #[test]
+    fn ensure_active_suppresses_a_second_failover_inside_the_cooldown() {
+        // WHY(#229): the cooldown exists to stop a flapping gateway from
+        // driving continuous failover churn. last_failover was stamped when
+        // the sole gateway dropped, so adopting the replacement must wait even
+        // though a healthy candidate is now available.
+        let mut bridge = bridge_needing_reselection(BridgeConfig::default());
+
+        bridge.ensure_active();
+
+        assert_eq!(
+            bridge.active(),
+            None,
+            "inside the cooldown no new gateway may be adopted"
+        );
+        assert!(
+            bridge.drain_events().is_empty(),
+            "a suppressed failover must emit no event"
+        );
+    }
+
+    #[test]
+    fn ensure_active_fails_over_when_the_cooldown_is_zero() {
+        // WHY(#229): the falsifiable half — same sequence, cooldown of zero.
+        // `elapsed() < 0` can never hold, so the guard falls through and the
+        // failover proceeds. Without this the test above would also pass if
+        // ensure_active simply never adopted a gateway at all.
+        let mut bridge = bridge_needing_reselection(BridgeConfig {
+            failover_cooldown_secs: 0,
+            ..BridgeConfig::default()
+        });
+
+        bridge.ensure_active();
+
+        assert_eq!(
+            bridge.active(),
+            Some(NodeNum(2)),
+            "with no cooldown the bridge must adopt the healthy gateway"
+        );
+    }
 }

--- a/crates/kerykeion/src/collector_tests.rs
+++ b/crates/kerykeion/src/collector_tests.rs
@@ -204,6 +204,100 @@ async fn router_flush_cancels_cleanly() {
     assert!(result.is_ok(), "router flush should cancel cleanly");
 }
 
+#[tokio::test(start_paused = true)]
+async fn router_flush_tick_drains_the_queue_and_sends() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::proto::FromRadio;
+
+    // WHY(#229): counts what reached the radio, so the test observes the
+    // drain/send half of the tick arm rather than only its cancellation
+    // path (which `router_flush_cancels_cleanly` already covers).
+    struct CountingConn(Arc<AtomicUsize>);
+    impl crate::connection::MeshConnection for CountingConn {
+        async fn send(&mut self, _: crate::proto::ToRadio) -> Result<(), Error> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn recv(&mut self) -> Result<FromRadio, Error> {
+            std::future::pending().await
+        }
+        fn is_connected(&self) -> bool {
+            true
+        }
+        async fn reconnect(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    let router = Arc::new(Mutex::new(MeshRouter::new(
+        OutboundQueue::new(),
+        StoreForward::new(StoreForwardConfig::default()),
+        DeliveryTracker::new(),
+    )));
+
+    // Two reachable packets, so the `while let Some(msg)` drain loop has to
+    // run more than once inside a single tick.
+    {
+        let mut r = router.lock().await;
+        for id in [1_u32, 2] {
+            // A reachable send only enqueues, so it cannot fail; the result is
+            // asserted rather than unwrapped.
+            let sent = r.send(
+                crate::proto::MeshPacket {
+                    id,
+                    to: 0xBBBB,
+                    ..Default::default()
+                },
+                true,
+                &crate::router::SendOptions::default(),
+            );
+            assert!(sent.is_ok(), "a reachable send must enqueue");
+        }
+        assert_eq!(r.outbound.pending_count(), 2);
+        drop(r);
+    }
+
+    let sent = Arc::new(AtomicUsize::new(0));
+    let conn = Arc::new(Mutex::new(CountingConn(Arc::clone(&sent))));
+    let token = CancellationToken::new();
+
+    let flush_router = Arc::clone(&router);
+    let task_token = token.clone();
+    let handle = tokio::spawn(
+        async move {
+            run_router_flush(flush_router, conn, Duration::from_millis(100), task_token).await
+        }
+        .instrument(tracing::info_span!("spawned_task")),
+    );
+
+    // The first tick of a tokio interval fires immediately; advance past a
+    // second one so the drain has certainly run.
+    tokio::time::advance(Duration::from_millis(150)).await;
+    tokio::task::yield_now().await;
+
+    token.cancel();
+    #[expect(clippy::unwrap_used, reason = "test-only")]
+    let result = handle.await.unwrap();
+    assert!(result.is_ok(), "router flush should cancel cleanly");
+
+    assert_eq!(
+        sent.load(Ordering::SeqCst),
+        2,
+        "both queued packets must reach the radio"
+    );
+
+    let r = router.lock().await;
+    let (pending, inflight) = (r.outbound.pending_count(), r.outbound.inflight_count());
+    drop(r);
+
+    assert_eq!(pending, 0, "the queue must be drained");
+    assert_eq!(
+        inflight, 2,
+        "drained packets must be tracked as inflight, awaiting ACK"
+    );
+}
+
 // ── akroasis#190: recv_yielding must not starve send-side tasks ──────
 
 /// Mock connection whose `recv()` never resolves, reproducing a quiet mesh.

--- a/crates/kerykeion/src/delivery.rs
+++ b/crates/kerykeion/src/delivery.rs
@@ -484,4 +484,58 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn prune_completed_releases_only_terminal_records() {
+        // WHY(#229): the retention rule is state-keyed, not purely age-keyed.
+        // A zero max_age makes every record "too old", so whatever survives
+        // survives because of its STATE — which is exactly the rule under test.
+        let mut tracker = DeliveryTracker::new();
+
+        let queued = PacketId(1);
+        let sent = PacketId(2);
+        let acked = PacketId(3);
+        let failed = PacketId(4);
+        let expired = PacketId(5);
+        for id in [queued, sent, acked, failed, expired] {
+            tracker.track(id, 0x1234);
+        }
+        tracker.mark_sent(sent);
+        tracker.mark_acknowledged(acked, Some(1));
+        tracker.mark_failed(failed, DeliveryFailure::MaxRetries);
+        tracker.mark_expired(expired);
+
+        tracker.prune_completed(std::time::Duration::ZERO);
+
+        assert!(
+            tracker.delivery_status(queued).is_some(),
+            "a Queued record is still active and must be retained (#244)"
+        );
+        assert!(
+            tracker.delivery_status(sent).is_some(),
+            "a Sent record is still active and must be retained (#244)"
+        );
+        assert!(tracker.delivery_status(acked).is_none());
+        assert!(tracker.delivery_status(failed).is_none());
+        assert!(tracker.delivery_status(expired).is_none());
+        assert_eq!(tracker.tracked_count(), 2);
+    }
+
+    #[test]
+    fn prune_completed_retains_terminal_records_inside_max_age() {
+        // WHY(#229): the falsifiable half — with a max_age no record can have
+        // exceeded, the same terminal records that vanished above all survive,
+        // so the test above proves the age comparison and not merely the match.
+        let mut tracker = DeliveryTracker::new();
+        let acked = PacketId(10);
+        tracker.track(acked, 0x1234);
+        tracker.mark_acknowledged(acked, Some(1));
+
+        tracker.prune_completed(std::time::Duration::from_secs(3600));
+
+        assert!(
+            tracker.delivery_status(acked).is_some(),
+            "a freshly acknowledged record is younger than max_age"
+        );
+    }
 }

--- a/crates/kerykeion/src/handshake.rs
+++ b/crates/kerykeion/src/handshake.rs
@@ -351,6 +351,62 @@ mod tests {
         }
     }
 
+    /// Mock that answers with a WRONG `config_complete_id` before sending the
+    /// `NodeInfo` and then the matching id.
+    struct MismatchMock {
+        step: u32,
+        config_id: Option<u32>,
+    }
+
+    impl MeshConnection for MismatchMock {
+        async fn send(&mut self, packet: ToRadio) -> Result<(), Error> {
+            if let Some(to_radio::PayloadVariant::WantConfigId(id)) = packet.payload_variant {
+                self.config_id = Some(id);
+            }
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Result<FromRadio, Error> {
+            self.step += 1;
+            match self.step {
+                1 => Ok(FromRadio {
+                    id: 1,
+                    payload_variant: Some(from_radio::PayloadVariant::MyInfo(MyNodeInfo {
+                        my_node_num: 0x2222,
+                    })),
+                }),
+                // WHY: a stale id from an earlier config dump — must be ignored.
+                2 => Ok(FromRadio {
+                    id: 2,
+                    payload_variant: Some(from_radio::PayloadVariant::ConfigCompleteId(
+                        self.config_id.unwrap_or(0).wrapping_add(1),
+                    )),
+                }),
+                3 => Ok(FromRadio {
+                    id: 3,
+                    payload_variant: Some(from_radio::PayloadVariant::NodeInfo(NodeInfo {
+                        num: 0x3333,
+                        ..Default::default()
+                    })),
+                }),
+                _ => Ok(FromRadio {
+                    id: 4,
+                    payload_variant: Some(from_radio::PayloadVariant::ConfigCompleteId(
+                        self.config_id.unwrap_or(0),
+                    )),
+                }),
+            }
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        async fn reconnect(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
     // ── Tests ─────────────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -457,5 +513,110 @@ mod tests {
         let node = node_info_to_mesh_node(&ni);
 
         assert_eq!(node.hop_count, Some(3));
+    }
+
+    #[tokio::test]
+    async fn mismatched_config_complete_id_does_not_end_the_handshake() {
+        // WHY(#229): a ConfigCompleteId that does not match want_config_id is a
+        // stale reply from an earlier config dump. The loop must ignore it and
+        // keep reading, not break out with a half-populated result. The mock
+        // sends the wrong id first and the NodeInfo only afterwards, so a
+        // premature break loses that node and the assertion fails.
+        let mut db = NodeDb::new();
+        let mut conn = MismatchMock {
+            step: 0,
+            config_id: None,
+        };
+
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let result = handshake(&mut conn, &mut db).await.unwrap();
+
+        assert_eq!(result.my_node_num.0, 0x2222);
+        assert_eq!(
+            result.known_nodes.len(),
+            1,
+            "the NodeInfo sent after the mismatched id must still be collected"
+        );
+    }
+
+    #[test]
+    fn node_info_converts_position_timestamps_and_snr() {
+        // WHY(#229): covers the scaling and proto3-sentinel rules in
+        // node_info_to_mesh_node together — lat/lon are integer degrees x 1e7,
+        // a zero altitude/last_heard/snr is "unset" rather than a real zero.
+        let ni = NodeInfo {
+            num: 0xABCD,
+            snr: 4.25,
+            last_heard: 1_700_000_000,
+            hops_away: 2,
+            user: Some(crate::proto::User {
+                id: "!abcd".into(),
+                long_name: "Long".into(),
+                short_name: "SHRT".into(),
+                macaddr: vec![],
+                hw_model: 9,
+                is_licensed: true,
+                role: 0,
+            }),
+            position: Some(crate::proto::Position {
+                latitude_i: 515_074_000,
+                longitude_i: -1_278_000,
+                altitude: 42,
+                time: 1_700_000_001,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let node = node_info_to_mesh_node(&ni);
+
+        assert_eq!(node.num.0, 0xABCD);
+        assert_eq!(node.hop_count, Some(2));
+        assert_eq!(node.snr, Some(4.25));
+
+        #[expect(clippy::unwrap_used, reason = "test-only: constructed above")]
+        let position = node.position.unwrap();
+        assert!((position.latitude - 51.507_4).abs() < 1e-9);
+        assert!((position.longitude - -0.127_8).abs() < 1e-9);
+        assert_eq!(position.altitude, Some(42));
+        assert!(position.timestamp.is_some());
+
+        #[expect(clippy::unwrap_used, reason = "test-only: constructed above")]
+        let user = node.user.unwrap();
+        assert_eq!(user.short_name, "SHRT");
+        assert_eq!(user.hw_model, 9);
+        assert!(user.is_licensed);
+
+        #[expect(clippy::unwrap_used, reason = "test-only: nonzero last_heard")]
+        let last_heard = node.last_heard.unwrap();
+        assert_eq!(last_heard.as_second(), 1_700_000_000);
+    }
+
+    #[test]
+    fn node_info_proto3_zero_sentinels_map_to_none() {
+        // WHY(#229): the falsifiable half of the pair above — 0 means "unset"
+        // for snr, last_heard and altitude, so none of them may survive as a
+        // real reading.
+        let ni = NodeInfo {
+            num: 1,
+            snr: 0.0,
+            last_heard: 0,
+            position: Some(crate::proto::Position {
+                latitude_i: 0,
+                longitude_i: 0,
+                altitude: 0,
+                time: 0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let node = node_info_to_mesh_node(&ni);
+
+        assert_eq!(node.snr, None);
+        assert_eq!(node.last_heard, None);
+        #[expect(clippy::unwrap_used, reason = "test-only: constructed above")]
+        let position = node.position.unwrap();
+        assert_eq!(position.altitude, None);
     }
 }

--- a/crates/kerykeion/src/message.rs
+++ b/crates/kerykeion/src/message.rs
@@ -403,4 +403,34 @@ mod tests {
             .unwrap();
         assert_eq!(pkt.id, 0xCAFE);
     }
+
+    #[test]
+    fn build_propagates_an_encryption_failure() {
+        // WHY(#229): a PSK that is neither empty (unencrypted channel) nor a
+        // 1..=10 channel index resolves to itself, so a 3-byte PSK reaches
+        // AES-CTR as an invalid key length. `build` must surface that as
+        // Error::Encryption rather than emitting an unencrypted packet.
+        let result = MessageBuilder::text(DEST, "test").build(FROM_NODE, &[0xAA, 0xBB, 0xCC]);
+
+        assert!(
+            matches!(result, Err(Error::Encryption { .. })),
+            "an invalid PSK length must fail the build, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn build_with_a_valid_psk_encrypts_rather_than_failing() {
+        // WHY(#229): the falsifiable half — a 16-byte PSK is a valid AES key,
+        // so the same path must succeed and produce an Encrypted variant.
+        // Without this the test above would pass even if `build` always failed.
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let pkt = MessageBuilder::text(DEST, "test")
+            .build(FROM_NODE, &[0x11; 16])
+            .unwrap();
+
+        assert!(matches!(
+            pkt.payload_variant,
+            Some(mesh_packet::PayloadVariant::Encrypted(_))
+        ));
+    }
 }

--- a/crates/kerykeion/src/processor_tests.rs
+++ b/crates/kerykeion/src/processor_tests.rs
@@ -2,6 +2,7 @@
 //! RUST/file-too-long 800-line threshold.
 
 use super::*;
+use crate::outbound::PendingMessage;
 use crate::proto::{Data, PortNum, mesh_packet};
 
 fn make_processor() -> PacketProcessor {
@@ -415,4 +416,222 @@ fn apply_nak_marks_failed_when_no_inflight() {
         delivery.delivery_status(id),
         Some(crate::delivery::DeliveryStatus::Failed { .. })
     ));
+}
+
+#[test]
+fn apply_nak_retries_while_the_packet_is_still_inflight() {
+    // WHY(#229): the sibling of apply_nak_marks_failed_when_no_inflight. When
+    // the packet IS inflight with retries remaining, the NAK must re-queue it
+    // and leave the delivery record un-failed — the retry arm of
+    // apply_routing_result, which no existing test reached.
+    let mut delivery = DeliveryTracker::new();
+    let mut outbound = OutboundQueue::new();
+    let id = PacketId(78);
+
+    delivery.track(id, 0x5678);
+    outbound.track_inflight(
+        PendingMessage {
+            packet: crate::proto::MeshPacket {
+                id: id.0,
+                ..Default::default()
+            },
+            created: tokio::time::Instant::now(),
+            ttl: std::time::Duration::from_secs(60),
+            priority: crate::proto::mesh_packet::Priority::Default,
+            retries: 0,
+        },
+        std::time::Duration::from_secs(30),
+    );
+    delivery.mark_sent(id);
+
+    let result = RoutingResult::Nak {
+        request_id: id,
+        error: routing::Error::NoRoute,
+    };
+    RoutingProcessor::apply_routing_result(&result, &mut delivery, &mut outbound);
+
+    assert_eq!(
+        outbound.pending_count(),
+        1,
+        "a retryable NAK must re-queue the packet"
+    );
+    assert_eq!(outbound.inflight_count(), 0);
+    assert!(
+        !matches!(
+            delivery.delivery_status(id),
+            Some(crate::delivery::DeliveryStatus::Failed { .. })
+        ),
+        "a retryable NAK must not mark the delivery failed"
+    );
+}
+
+#[test]
+fn malformed_payloads_are_dropped_without_panicking() {
+    // WHY(#229): every decode site on the OTA path is fed attacker-influenced
+    // bytes. A malformed payload must be logged and skipped, never unwrapped —
+    // so each handler returns no events and leaves the node database clean.
+    let mut proc = make_processor();
+    // A leading tag byte of 0xFF is not a valid protobuf field header, so
+    // prost rejects it for every message type below.
+    let garbage = vec![0xFF_u8, 0xFF, 0xFF, 0xFF];
+
+    for portnum in [
+        portnum::NODEINFO_APP,
+        portnum::POSITION_APP,
+        portnum::TELEMETRY_APP,
+        portnum::NEIGHBORINFO_APP,
+        portnum::TRACEROUTE_APP,
+    ] {
+        let packet = make_mesh_packet(0xBAD0, portnum, garbage.clone());
+        let events = proc.process_mesh_packet(&packet);
+
+        assert!(
+            events.is_empty(),
+            "portnum {portnum} produced events from a malformed payload"
+        );
+    }
+
+    // Passive learning still records the sender; only the decoded payload is
+    // discarded.
+    #[expect(clippy::unwrap_used, reason = "test-only: passive learning inserts it")]
+    let node = proc.node_db().get(NodeNum(0xBAD0)).unwrap();
+    assert!(node.user.is_none(), "no user info may survive a bad decode");
+    assert!(node.position.is_none());
+}
+
+#[test]
+fn repeat_nodeinfo_for_a_known_node_emits_no_rediscovery() {
+    // WHY(#229): NodeDiscovered drives downstream alerting, so a periodic
+    // NODEINFO refresh from an already-known node must not re-announce it.
+    // The is_new test keys on whether user info was already present.
+    let mut proc = make_processor();
+    let user = crate::proto::User {
+        id: "!feedface".into(),
+        long_name: "Repeat Node".into(),
+        short_name: "RPT".into(),
+        macaddr: vec![],
+        hw_model: 9,
+        is_licensed: false,
+        role: 0,
+    };
+    let mut payload = Vec::new();
+    user.encode(&mut payload).unwrap();
+
+    let first = proc.process_mesh_packet(&make_mesh_packet(
+        0xFEED,
+        portnum::NODEINFO_APP,
+        payload.clone(),
+    ));
+    assert!(
+        first
+            .iter()
+            .any(|e| matches!(e, MeshEvent::NodeDiscovered { .. })),
+        "the first NODEINFO must announce the node"
+    );
+
+    let second =
+        proc.process_mesh_packet(&make_mesh_packet(0xFEED, portnum::NODEINFO_APP, payload));
+    assert!(
+        !second
+            .iter()
+            .any(|e| matches!(e, MeshEvent::NodeDiscovered { .. })),
+        "a repeat NODEINFO must not re-announce a known node"
+    );
+}
+
+#[test]
+fn traceroute_inserts_the_reverse_path_links() {
+    // WHY(#229): the `back`/`snr_back` half of handle_traceroute runs only
+    // when `back` is non-empty, and inserts links without emitting events —
+    // so nothing but the topology shows it ran.
+    let mut proc = make_processor();
+    let route = crate::proto::RouteDiscovery {
+        route: vec![0x20],
+        snr_towards: vec![40, 32],
+        back: vec![0x20],
+        snr_back: vec![24, 16],
+    };
+    let mut payload = Vec::new();
+    route.encode(&mut payload).unwrap();
+
+    let mut packet = make_mesh_packet(0x10, portnum::TRACEROUTE_APP, payload);
+    packet.to = 0x30;
+
+    proc.process_mesh_packet(&packet);
+
+    // Links are directed. The forward path lays 0x10 → 0x20 → 0x30; the
+    // reverse path lays 0x30 → 0x20 → 0x10. So the 0x20 → 0x10 edge exists
+    // only if the reverse loop ran, and its SNR comes from snr_back.
+    let topology = proc.topology();
+    assert!(topology.contains_node(NodeNum(0x10)));
+    assert!(topology.contains_node(NodeNum(0x20)));
+    assert!(topology.contains_node(NodeNum(0x30)));
+
+    let neighbours = topology.neighbors(NodeNum(0x20));
+    assert_eq!(
+        neighbours.len(),
+        2,
+        "the middle hop must have an outgoing link on each path"
+    );
+
+    #[expect(clippy::unwrap_used, reason = "test-only: asserted present above")]
+    let to_origin = neighbours
+        .iter()
+        .find(|(n, _)| *n == NodeNum(0x10))
+        .unwrap()
+        .1;
+    // snr_back[1] = 16 is the 0x20 → 0x10 leg of the reverse path.
+    assert!(
+        (to_origin.snr - 16.0).abs() < f32::EPSILON,
+        "the reverse leg must carry its snr_back reading, got {}",
+        to_origin.snr
+    );
+}
+
+#[test]
+fn traceroute_without_a_reverse_path_leaves_the_forward_snr() {
+    // WHY(#229): the falsifiable half — with `back` empty the reverse loop is
+    // skipped, so the forward SNR survives. Without this the assertion above
+    // could pass on any code that merely wrote some SNR.
+    let mut proc = make_processor();
+    let route = crate::proto::RouteDiscovery {
+        route: vec![0x20],
+        snr_towards: vec![40, 32],
+        back: vec![],
+        snr_back: vec![],
+    };
+    let mut payload = Vec::new();
+    route.encode(&mut payload).unwrap();
+
+    let mut packet = make_mesh_packet(0x10, portnum::TRACEROUTE_APP, payload);
+    packet.to = 0x30;
+
+    proc.process_mesh_packet(&packet);
+
+    let neighbours = proc.topology().neighbors(NodeNum(0x20));
+    assert!(
+        !neighbours.iter().any(|(n, _)| *n == NodeNum(0x10)),
+        "with no reverse path the 0x20 → 0x10 edge must not exist"
+    );
+    assert_eq!(
+        neighbours.len(),
+        1,
+        "only the forward 0x20 → 0x30 leg may be present"
+    );
+
+    // The forward path itself is unaffected: 0x10 → 0x20 still carries
+    // snr_towards[0].
+    #[expect(clippy::unwrap_used, reason = "test-only: forward path links it")]
+    let forward = proc
+        .topology()
+        .neighbors(NodeNum(0x10))
+        .iter()
+        .find(|(n, _)| *n == NodeNum(0x20))
+        .unwrap()
+        .1
+        .snr;
+    assert!(
+        (forward - 40.0).abs() < f32::EPSILON,
+        "the forward leg must carry snr_towards, got {forward}"
+    );
 }

--- a/crates/kerykeion/src/router.rs
+++ b/crates/kerykeion/src/router.rs
@@ -291,11 +291,15 @@ mod tests {
     use super::*;
     use crate::config::StoreForwardConfig;
     use crate::delivery::DeliveryStatus;
-    use crate::proto::Data;
+    use crate::proto::{Data, routing};
 
     fn make_router() -> MeshRouter {
+        make_router_with_outbound(OutboundQueue::new())
+    }
+
+    fn make_router_with_outbound(outbound: OutboundQueue) -> MeshRouter {
         MeshRouter::new(
-            OutboundQueue::new(),
+            outbound,
             StoreForward::new(StoreForwardConfig {
                 enabled: true,
                 max_queue_per_dest: 16,
@@ -303,6 +307,14 @@ mod tests {
             }),
             DeliveryTracker::new(),
         )
+    }
+
+    /// Move the head of the pending queue into the inflight set, the way
+    /// `run_router_flush` does on each tick.
+    fn transmit_next(router: &mut MeshRouter) {
+        #[expect(clippy::unwrap_used, reason = "test-only: caller enqueued a message")]
+        let msg = router.next_to_send().unwrap();
+        router.track_sent(msg);
     }
 
     fn make_packet(id: u32) -> MeshPacket {
@@ -683,6 +695,76 @@ mod tests {
                 Some(DeliveryStatus::Failed { .. })
             ),
             "delivery must be marked Failed after retries exhausted"
+        );
+    }
+
+    #[test]
+    fn handle_nak_retries_while_attempts_remain() {
+        // WHY(#229): the retry half of handle_nak's branch. With one retry
+        // allowed, the first NAK must re-enqueue rather than fail — this is
+        // the arm that must NOT fire in the max-retries test below.
+        let mut router = make_router_with_outbound(OutboundQueue::with_config(&OutboundConfig {
+            max_retries: 1,
+            ..OutboundConfig::default()
+        }));
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(70), true, &SendOptions::default())
+            .unwrap();
+        transmit_next(&mut router);
+
+        router.handle_nak(id, routing::Error::NoRoute);
+
+        assert_eq!(
+            router.outbound.pending_count(),
+            1,
+            "a retryable NAK must put the packet back on the pending queue"
+        );
+        assert!(
+            !matches!(
+                router.delivery.delivery_status(id),
+                Some(DeliveryStatus::Failed { .. })
+            ),
+            "a retryable NAK must not mark the delivery failed"
+        );
+    }
+
+    #[test]
+    fn handle_nak_after_max_retries_marks_delivery_failed() {
+        // WHY(#229): once retries are exhausted the NAK must map to
+        // DeliveryFailure::Nak carrying the reported routing error, not to
+        // MaxRetries — the failure reason is what tells an operator whether
+        // the mesh rejected the packet or simply never answered.
+        let mut router = make_router_with_outbound(OutboundQueue::with_config(&OutboundConfig {
+            max_retries: 1,
+            ..OutboundConfig::default()
+        }));
+        #[expect(clippy::unwrap_used, reason = "test-only")]
+        let id = router
+            .send(make_packet(71), true, &SendOptions::default())
+            .unwrap();
+
+        // First NAK consumes the single retry and re-enqueues the packet.
+        transmit_next(&mut router);
+        router.handle_nak(id, routing::Error::NoRoute);
+
+        // Retransmit, then NAK again — now retries == max_retries.
+        transmit_next(&mut router);
+        router.handle_nak(id, routing::Error::NoRoute);
+
+        assert!(
+            matches!(
+                router.delivery.delivery_status(id),
+                Some(DeliveryStatus::Failed {
+                    reason: DeliveryFailure::Nak(routing::Error::NoRoute)
+                })
+            ),
+            "an exhausted NAK must fail with the routing error it reported"
+        );
+        assert_eq!(
+            router.outbound.pending_count(),
+            0,
+            "the packet must not be re-enqueued once retries are exhausted"
         );
     }
 }

--- a/crates/kerykeion/src/signals.rs
+++ b/crates/kerykeion/src/signals.rs
@@ -363,4 +363,117 @@ mod tests {
         let signal = mesh_event_to_signal(&event, None);
         assert!(signal.metadata.contains_key("to_node"));
     }
+
+    #[test]
+    fn invalid_position_falls_back_to_node_seen() {
+        // WHY(#229): a latitude outside [-90, 90] makes `Coordinates::new`
+        // fail, and the fallback arm must still emit a signal rather than
+        // dropping the event. The valid-coordinate case is covered by
+        // `position_update_produces_position_signal`, so this pair fires on
+        // exactly the branch under test.
+        let event = MeshEvent::PositionUpdate {
+            node: NodeNum(7),
+            lat: 91.0,
+            lon: 0.0,
+            alt: None,
+        };
+
+        let signal = mesh_event_to_signal(&event, None);
+
+        assert!(
+            matches!(
+                signal.kind,
+                SignalKind::Mesh(MeshDetail::NodeSeen { node_id: 7, .. })
+            ),
+            "invalid coordinates must fall back to NodeSeen, not Position"
+        );
+        assert_eq!(
+            signal.metadata.get("event"),
+            Some(&serde_json::json!("invalid_position"))
+        );
+        assert!(
+            signal.location.is_none(),
+            "no position was passed, so the signal carries no location"
+        );
+    }
+
+    #[test]
+    fn link_degraded_carries_both_snr_readings() {
+        let event = MeshEvent::LinkDegraded {
+            from: NodeNum(1),
+            to: NodeNum(2),
+            old_snr: 10.0,
+            new_snr: 2.0,
+        };
+
+        let signal = mesh_event_to_signal(&event, None);
+
+        // WHY(#229): the signal reports the DEGRADED (new) SNR; the previous
+        // reading is preserved only as metadata.
+        assert!(matches!(
+            signal.kind,
+            SignalKind::Mesh(MeshDetail::NodeSeen {
+                node_id: 1,
+                snr,
+                ..
+            }) if (snr - 2.0).abs() < f32::EPSILON
+        ));
+        assert_eq!(
+            signal.metadata.get("event"),
+            Some(&serde_json::json!("link_degraded"))
+        );
+        assert_eq!(
+            signal.metadata.get("to_node"),
+            Some(&serde_json::json!(2_u32))
+        );
+        assert_eq!(
+            signal.metadata.get("old_snr"),
+            Some(&serde_json::json!(10.0_f32))
+        );
+    }
+
+    #[test]
+    fn partition_healed_lists_the_reunited_nodes() {
+        let event = MeshEvent::PartitionHealed {
+            reunited_nodes: vec![NodeNum(4), NodeNum(5)],
+        };
+
+        let signal = mesh_event_to_signal(&event, None);
+
+        assert_eq!(
+            signal.metadata.get("event"),
+            Some(&serde_json::json!("partition_healed"))
+        );
+        assert_eq!(
+            signal.metadata.get("reunited_nodes"),
+            Some(&serde_json::json!([4_u32, 5_u32]))
+        );
+        assert!(
+            signal.location.is_none(),
+            "a partition event is not located at a single node"
+        );
+    }
+
+    #[test]
+    fn gateway_status_change_records_the_new_role() {
+        let event = MeshEvent::GatewayStatusChange {
+            node: NodeNum(9),
+            is_gateway: true,
+        };
+
+        let signal = mesh_event_to_signal(&event, None);
+
+        assert!(matches!(
+            signal.kind,
+            SignalKind::Mesh(MeshDetail::NodeSeen { node_id: 9, .. })
+        ));
+        assert_eq!(
+            signal.metadata.get("event"),
+            Some(&serde_json::json!("gateway_status"))
+        );
+        assert_eq!(
+            signal.metadata.get("is_gateway"),
+            Some(&serde_json::json!(true))
+        );
+    }
 }


### PR DESCRIPTION
## What was wrong

Thirteen findings in the `testing` section of the kerykeion wave-1 audit batch: branches and conversions with no test reaching them (handshake config-id mismatch, NodeInfo→MeshNode scaling, NAK retry/exhaustion, delivery-record pruning, gateway failover cooldown, several processor/topology conversion paths, and encryption-failure propagation in `MessageBuilder::build`).

## What this changes

Twenty-one new tests, no production behavior change. Eight of the thirteen findings are covered as falsifiable pairs — one test that fires on the behavior under test and a sibling that holds the opposite input, so a green result cannot come from the assertion simply never being reached. Two test helpers were extracted in `router.rs` to build a queue with a non-default retry budget.

## Verification

Each test was checked against a deliberately broken copy of the code it covers: five mutations (cooldown guard removed, any config id accepted, reverse path skipped, active delivery records pruned, encryption error swallowed) each failed exactly its corresponding test and no other new one.

Refs #229
