### PR TITLE
fix(koinon): validate deserialized values and stop the writer emitting unverifiable log entries

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -342,31 +342,31 @@ hash = "635566a5376aca1bf92ec855cbe96b69003a02f89b19a6dbdc822d59e580ed34"
 [[baseline.entry]]
 rule = "RUST/config-deny-unknown-fields"
 file = "crates/koinon/src/tamper_log.rs"
-line = 64
+line = 69
 hash = "ab6fa7ce2a569a6a8354104318c49f7ae1f5b147a2c0685363a8b09356549fe2"
 
 [[baseline.entry]]
 rule = "RUST/no-debug-derive-on-public-types"
 file = "crates/koinon/src/tamper_log.rs"
-line = 150
+line = 155
 hash = "50d045131e1a2f659ef9b7d91f23499570d3c0ff047998ea759d704128bf5265"
 
 [[baseline.entry]]
 rule = "RUST/no-result-unwrap-or-default"
 file = "crates/koinon/src/tamper_log.rs"
-line = 273
+line = 293
 hash = "8c45bee0afc5b671fa5c4e4691d11d232504f3a410456c18e3d22e94134777aa"
 
 [[baseline.entry]]
 rule = "TOPOLOGY/shallow-struct"
 file = "crates/koinon/src/tamper_log.rs"
-line = 330
+line = 350
 hash = "3a82e225fc3e3091c19d16433c344bc468c91f63799cc74461cdecc11ca44675"
 
 [[baseline.entry]]
 rule = "RUST/no-result-unwrap-or-default"
 file = "crates/koinon/src/tamper_log.rs"
-line = 384
+line = 404
 hash = "8c45bee0afc5b671fa5c4e4691d11d232504f3a410456c18e3d22e94134777aa"
 
 [[baseline.entry]]

--- a/crates/koinon/src/coordinates.rs
+++ b/crates/koinon/src/coordinates.rs
@@ -13,7 +13,12 @@ pub enum Datum {
 }
 
 /// A geographic point with optional altitude.
+// WHY: the fields are pub, so a derived Deserialize rebuilt the struct field by
+// field and skipped new()'s range check entirely — a plan file could carry
+// latitude 900.0 or a NaN altitude straight into haversine_distance_m. Every
+// deserialized value now goes through the same validation as new().
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "CoordinatesRepr")]
 pub struct Coordinates {
     /// Latitude in decimal degrees, range \[-90, 90\].
     pub latitude: f64,
@@ -41,6 +46,36 @@ pub enum CoordinatesError {
         /// The offending value.
         value: f64,
     },
+    /// Altitude was NaN or infinite.
+    #[snafu(display("altitude {value} is not finite"))]
+    AltitudeNotFinite {
+        /// The offending value.
+        value: f64,
+    },
+}
+
+/// Wire form of [`Coordinates`], validated on the way in.
+///
+/// WHY: `try_from` needs a shape serde can build without validation; this is it.
+/// It must stay field-identical to `Coordinates`.
+#[derive(Deserialize)]
+struct CoordinatesRepr {
+    latitude: f64,
+    longitude: f64,
+    #[serde(default)]
+    altitude: Option<f64>,
+    #[serde(default)]
+    datum: Datum,
+}
+
+impl TryFrom<CoordinatesRepr> for Coordinates {
+    type Error = CoordinatesError;
+
+    fn try_from(repr: CoordinatesRepr) -> Result<Self, Self::Error> {
+        let mut coords = Self::new(repr.latitude, repr.longitude, repr.altitude)?;
+        coords.datum = repr.datum;
+        Ok(coords)
+    }
 }
 
 impl Coordinates {
@@ -50,6 +85,10 @@ impl Coordinates {
     ///
     /// Returns [`CoordinatesError::LatitudeOutOfRange`] if `latitude` is not in `[-90, 90]`.
     /// Returns [`CoordinatesError::LongitudeOutOfRange`] if `longitude` is not in `[-180, 180]`.
+    /// Returns [`CoordinatesError::AltitudeNotFinite`] if `altitude` is present and not finite.
+    ///
+    /// NaN latitude or longitude is rejected: `RangeInclusive::contains` is false
+    /// for NaN, so the range checks below fail closed.
     pub fn new(
         latitude: f64,
         longitude: f64,
@@ -60,6 +99,11 @@ impl Coordinates {
         }
         if !(-180.0..=180.0).contains(&longitude) {
             return Err(CoordinatesError::LongitudeOutOfRange { value: longitude });
+        }
+        if let Some(alt) = altitude
+            && !alt.is_finite()
+        {
+            return Err(CoordinatesError::AltitudeNotFinite { value: alt });
         }
         Ok(Self {
             latitude,
@@ -173,5 +217,45 @@ mod tests {
             (a_to_b - b_to_a).abs() < 1e-6,
             "dist(A,B)={a_to_b} ≠ dist(B,A)={b_to_a}"
         );
+    }
+
+    #[test]
+    fn deserializing_coordinates_cannot_bypass_the_range_check() {
+        // WHY: the fields are pub and the derived Deserialize rebuilt the struct
+        // field by field, so a plan file could carry latitude 900 straight into
+        // haversine_distance_m and produce a silently meaningless distance.
+        let bad_lat = serde_json::from_str::<Coordinates>(
+            r#"{"latitude":900.0,"longitude":0.0,"altitude":null,"datum":"Wgs84"}"#,
+        );
+        assert!(bad_lat.is_err(), "latitude 900 deserialized: {bad_lat:?}");
+
+        let bad_lon = serde_json::from_str::<Coordinates>(
+            r#"{"latitude":0.0,"longitude":-400.0,"altitude":null,"datum":"Wgs84"}"#,
+        );
+        assert!(bad_lon.is_err(), "longitude -400 deserialized: {bad_lon:?}");
+    }
+
+    #[test]
+    fn a_valid_coordinate_still_round_trips_through_serde() {
+        // The guard above must not reject legitimate values.
+        let original = Coordinates::new(51.5, -0.12, Some(35.0)).unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        let back: Coordinates = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn a_non_finite_altitude_is_rejected() {
+        assert!(Coordinates::new(0.0, 0.0, Some(f64::NAN)).is_err());
+        assert!(Coordinates::new(0.0, 0.0, Some(f64::INFINITY)).is_err());
+        assert!(Coordinates::new(0.0, 0.0, Some(35.0)).is_ok());
+        assert!(Coordinates::new(0.0, 0.0, None).is_ok());
+    }
+
+    #[test]
+    fn a_nan_latitude_or_longitude_is_rejected() {
+        // RangeInclusive::contains is false for NaN, so the checks fail closed.
+        assert!(Coordinates::new(f64::NAN, 0.0, None).is_err());
+        assert!(Coordinates::new(0.0, f64::NAN, None).is_err());
     }
 }

--- a/crates/koinon/src/frequency.rs
+++ b/crates/koinon/src/frequency.rs
@@ -19,21 +19,45 @@ impl Frequency {
     }
 
     /// Construct FROM kilohertz (1 kHz = 1 000 Hz).
+    ///
+    /// Saturates at [`u64::MAX`] hertz rather than wrapping.
     #[must_use]
     pub const fn khz(value: u64) -> Self {
-        Self(value * 1_000)
+        Self(value.saturating_mul(1_000))
     }
 
     /// Construct FROM megahertz (1 MHz = 1 000 000 Hz).
+    ///
+    /// Saturates at [`u64::MAX`] hertz rather than wrapping.
     #[must_use]
     pub const fn mhz(value: u64) -> Self {
-        Self(value * 1_000_000)
+        Self(value.saturating_mul(1_000_000))
     }
 
     /// Construct FROM gigahertz (1 GHz = 1 000 000 000 Hz).
+    ///
+    /// Saturates at [`u64::MAX`] hertz rather than wrapping.
     #[must_use]
     pub const fn ghz(value: u64) -> Self {
-        Self(value * 1_000_000_000)
+        Self(value.saturating_mul(1_000_000_000))
+    }
+
+    /// Add two frequencies, returning `None` on overflow.
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        match self.0.checked_add(rhs.0) {
+            Some(hz) => Some(Self(hz)),
+            None => None,
+        }
+    }
+
+    /// Subtract `rhs` FROM `self`, returning `None` if the result would be negative.
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        match self.0.checked_sub(rhs.0) {
+            Some(hz) => Some(Self(hz)),
+            None => None,
+        }
     }
 
     /// Return the raw hertz value.
@@ -75,17 +99,22 @@ impl fmt::Display for Frequency {
     }
 }
 
+// WHY: Frequency is Deserialize, so self.0 is attacker-controlled up to u64::MAX.
+// Raw +/- panicked in debug and wrapped in release, turning a malformed plan into
+// a silently plausible frequency ~18 EHz away. Saturating keeps the operators
+// total and monotonic; callers that must detect the boundary use checked_add /
+// checked_sub.
 impl Add for Frequency {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        Self(self.0 + rhs.0)
+        Self(self.0.saturating_add(rhs.0))
     }
 }
 
 impl Sub for Frequency {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        Self(self.0 - rhs.0)
+        Self(self.0.saturating_sub(rhs.0))
     }
 }
 
@@ -190,6 +219,57 @@ mod tests {
         assert!(
             mw_str.contains("GHz"),
             "2 GHz should display with GHz unit, got: {mw_str}"
+        );
+    }
+
+    #[test]
+    fn unit_constructors_saturate_instead_of_wrapping() {
+        // WHY: Frequency is Deserialize, so these took attacker-controlled u64.
+        // `value * 1_000_000` wrapped in release, turning a huge MHz value into a
+        // small, plausible-looking frequency.
+        assert_eq!(Frequency::ghz(u64::MAX).as_hz(), u64::MAX);
+        assert_eq!(Frequency::mhz(u64::MAX).as_hz(), u64::MAX);
+        assert_eq!(Frequency::khz(u64::MAX).as_hz(), u64::MAX);
+        // Ordinary values are unaffected.
+        assert_eq!(Frequency::mhz(146).as_hz(), 146_000_000);
+    }
+
+    #[test]
+    fn addition_saturates_rather_than_wrapping_past_u64_max() {
+        let high = Frequency::hz(u64::MAX);
+        assert_eq!((high + Frequency::hz(1)).as_hz(), u64::MAX);
+    }
+
+    #[test]
+    fn subtraction_saturates_at_zero_rather_than_wrapping_negative() {
+        // Wrapping here produced ~18 EHz from a simple ordering mistake.
+        let low = Frequency::hz(1_000);
+        assert_eq!((low - Frequency::hz(5_000)).as_hz(), 0);
+    }
+
+    #[test]
+    fn checked_arithmetic_reports_the_boundary() {
+        let high = Frequency::hz(u64::MAX);
+        assert!(high.checked_add(Frequency::hz(1)).is_none());
+        assert!(
+            Frequency::hz(1_000)
+                .checked_sub(Frequency::hz(5_000))
+                .is_none()
+        );
+
+        assert_eq!(
+            Frequency::hz(1_000)
+                .checked_add(Frequency::hz(500))
+                .unwrap()
+                .as_hz(),
+            1_500
+        );
+        assert_eq!(
+            Frequency::hz(1_000)
+                .checked_sub(Frequency::hz(400))
+                .unwrap()
+                .as_hz(),
+            600
         );
     }
 }

--- a/crates/koinon/src/signal.rs
+++ b/crates/koinon/src/signal.rs
@@ -263,18 +263,33 @@ pub enum SignalKind {
 /// Values passed to [`Confidence::new`] outside this range are silently
 /// clamped rather than rejected, preventing panics on out-of-range input
 /// from imprecise sensors or computation.
+// WHY: the tuple field is private but Deserialize reconstructed it directly, so
+// a serialized 5.0 or NaN entered the type without passing new()'s clamp. Going
+// through From<f32> makes the clamp the only way in.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(from = "f32")]
 pub struct Confidence(f32);
+
+impl From<f32> for Confidence {
+    fn from(value: f32) -> Self {
+        Self::new(value)
+    }
+}
 
 impl Confidence {
     /// Construct a [`Confidence`], clamping `value` to \[0.0, 1.0\].
     ///
-    /// Values below 0.0 become 0.0; values above 1.0 become 1.0.
+    /// Values below 0.0 become 0.0; values above 1.0 become 1.0. NaN becomes
+    /// 0.0 — an unusable measurement is treated as no confidence, not as
+    /// certainty.
     #[must_use]
     pub const fn new(value: f32) -> Self {
         // WHY: clamp() is a const fn since Rust 1.83; clamping avoids returning
         // an error type for a simple bounds check on a scalar field.
-        let clamped = if value < 0.0 {
+        // WARNING: NaN compares false against BOTH bounds, so the ordered
+        // if/else chain fell through to the `else` arm and stored NaN unclamped.
+        // Test it first, and fail closed at 0.0.
+        let clamped = if value.is_nan() || value < 0.0 {
             0.0_f32
         } else if value > 1.0 {
             1.0_f32

--- a/crates/koinon/src/signal_tests.rs
+++ b/crates/koinon/src/signal_tests.rs
@@ -445,3 +445,35 @@ fn signal_kind_osint_serde_roundtrip() {
     let back: SignalKind = serde_json::from_str(&json).unwrap();
     assert_eq!(kind, back);
 }
+
+#[test]
+fn confidence_maps_nan_to_zero_rather_than_storing_it() {
+    // WHY: NaN compares false against both bounds, so the ordered if/else chain
+    // fell through to the `else` arm and stored NaN unclamped. Every downstream
+    // comparison against that value then silently answered false.
+    let c = Confidence::new(f32::NAN);
+
+    assert!(!c.as_f32().is_nan(), "NaN survived construction");
+    assert!((c.as_f32() - 0.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn confidence_clamps_values_outside_the_unit_interval() {
+    assert!((Confidence::new(-3.0).as_f32() - 0.0).abs() < f32::EPSILON);
+    assert!((Confidence::new(7.5).as_f32() - 1.0).abs() < f32::EPSILON);
+    assert!((Confidence::new(0.25).as_f32() - 0.25).abs() < f32::EPSILON);
+}
+
+#[test]
+fn deserializing_a_confidence_cannot_bypass_the_clamp() {
+    // WHY: the derived Deserialize rebuilt the private tuple field directly, so
+    // a stored 5.0 or NaN entered the type without passing new().
+    let out_of_range: Confidence = serde_json::from_str("5.0").unwrap();
+    assert!((out_of_range.as_f32() - 1.0).abs() < f32::EPSILON);
+
+    let negative: Confidence = serde_json::from_str("-2.0").unwrap();
+    assert!((negative.as_f32() - 0.0).abs() < f32::EPSILON);
+    // NOTE: JSON has no NaN literal, so the NaN path is covered by
+    // confidence_maps_nan_to_zero_rather_than_storing_it against new(), which
+    // #[serde(from = "f32")] now routes every deserialized value through.
+}

--- a/crates/koinon/src/tamper_log.rs
+++ b/crates/koinon/src/tamper_log.rs
@@ -38,6 +38,11 @@ use crate::{EntityId, SignalId};
 #[path = "tamper_log_seal.rs"]
 mod seal;
 
+#[path = "tamper_log_rotation.rs"]
+mod rotation;
+
+use rotation::rotation_path;
+
 pub use seal::{CHAIN_KEY_LEN, ChainKey};
 
 /// Maximum allowed entry payload size (16 MiB).
@@ -223,6 +228,8 @@ pub struct LogEntry {
 /// # Errors
 ///
 /// Returns [`TamperLogError::CborEncode`] if serialization fails.
+/// Returns [`TamperLogError::EntryTooLarge`] if the CBOR payload exceeds
+/// [`MAX_ENTRY_BYTES`], which is the same bound the decoder enforces.
 pub fn encode_entry(
     entry: &LogEntry,
     prev_hash: &[u8; 32],
@@ -231,12 +238,25 @@ pub fn encode_entry(
     let mut cbor_bytes: Vec<u8> = Vec::new();
     ciborium::into_writer(entry, &mut cbor_bytes).context(CborEncodeSnafu)?;
 
+    // WHY: decode_entry and verify_chain both reject payload_len > MAX_ENTRY_BYTES,
+    // but nothing enforced it here — the SAFETY note below asserted a validation
+    // that did not exist. An oversized entry was written happily and then made the
+    // whole log unverifiable; past 4 GiB the `as u32` cast also truncated the
+    // length prefix, corrupting every following entry's framing.
+    let payload_len = cbor_bytes.len() as u64; // SAFETY: usize->u64 is lossless on all supported targets
+    if payload_len > MAX_ENTRY_BYTES {
+        return Err(TamperLogError::EntryTooLarge {
+            size: payload_len,
+            max: MAX_ENTRY_BYTES,
+        });
+    }
+
     let mut hasher = blake3::Hasher::new_keyed(chain_key.as_bytes());
     hasher.update(&cbor_bytes);
     hasher.update(prev_hash);
     let hash: [u8; 32] = hasher.finalize().into();
 
-    let len = cbor_bytes.len() as u32; // SAFETY: CBOR payload size validated <= MAX_ENTRY_BYTES (16 MiB), fits u32
+    let len = cbor_bytes.len() as u32; // SAFETY: checked above against MAX_ENTRY_BYTES (16 MiB), so it fits u32
     let mut wire = Vec::with_capacity(4 + cbor_bytes.len() + 32);
     wire.extend_from_slice(&len.to_le_bytes());
     wire.extend_from_slice(&cbor_bytes);
@@ -710,7 +730,7 @@ impl TamperLog {
     fn rotate(&mut self) -> Result<(), TamperLogError> {
         self.writer.flush().context(IoSnafu { path: &self.path })?;
 
-        let n = Self::next_rotation_number(&self.path);
+        let n = rotation::next_rotation_number(&self.path)?;
         let rotated = rotation_path(&self.path, n);
 
         std::fs::rename(&self.path, &rotated).context(IoSnafu { path: &self.path })?;
@@ -731,52 +751,6 @@ impl TamperLog {
 
         Ok(())
     }
-
-    /// Scans sibling files to find the next rotation number.
-    fn next_rotation_number(path: &Path) -> u32 {
-        let stem = log_stem(path);
-        let dir = path.parent().unwrap_or_else(|| Path::new("."));
-
-        let mut max_n: u32 = 0;
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let name = entry.file_name();
-                let name = name.to_string_lossy();
-                if let Some(n) = parse_rotation_number(&name, &stem) {
-                    if n > max_n {
-                        max_n = n;
-                    }
-                }
-            }
-        }
-        max_n + 1
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Rotation helpers
-// ---------------------------------------------------------------------------
-
-/// Returns the stem of a log path, e.g. `"audit"` FROM `"audit.log"`.
-fn log_stem(path: &Path) -> String {
-    path.file_stem()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default()
-}
-
-/// Builds `{dir}/{stem}.{n}.log`.
-fn rotation_path(path: &Path, n: u32) -> PathBuf {
-    let dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let stem = log_stem(path);
-    dir.join(format!("{stem}.{n}.log"))
-}
-
-/// Parses `{stem}.{n}.log` → `Some(n)`, returns `None` otherwise.
-fn parse_rotation_number(name: &str, stem: &str) -> Option<u32> {
-    let prefix = format!("{stem}.");
-    let suffix = ".log";
-    let inner = name.strip_prefix(&prefix)?.strip_suffix(suffix)?;
-    inner.parse::<u32>().ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -791,3 +765,11 @@ fn parse_rotation_number(name: &str, stem: &str) -> Option<u32> {
 )]
 #[path = "tamper_log_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panics and unwraps acceptable in assertions"
+)]
+#[path = "tamper_log_codec_tests.rs"]
+mod codec_tests;

--- a/crates/koinon/src/tamper_log_codec_tests.rs
+++ b/crates/koinon/src/tamper_log_codec_tests.rs
@@ -1,0 +1,126 @@
+//! Codec and framing tests for [`super`]; split out to keep
+//! `tamper_log_tests.rs` under the RUST/file-too-long 800-line threshold.
+
+use compact_str::CompactString;
+
+use super::*;
+
+fn test_key() -> ChainKey {
+    ChainKey::from_bytes([0x5A; CHAIN_KEY_LEN])
+}
+
+fn config_kind() -> LogEntryKind {
+    LogEntryKind::ConfigChanged {
+        key: CompactString::from("threshold"),
+        old_value: Some(CompactString::from("10")),
+        new_value: CompactString::from("20"),
+    }
+}
+
+#[test]
+fn verify_chain_reports_corrupted_on_an_oversized_length_prefix() {
+    // WHY: decode_entry's MAX_ENTRY_BYTES guard is covered above, but
+    // verify_chain carries its OWN copy of that bound and walks the file
+    // itself. Without this, removing verify_chain's guard is invisible.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("oversized.log");
+
+    let mut log = TamperLog::open(&path, test_key()).unwrap();
+    log.append(config_kind()).unwrap();
+    drop(log);
+
+    // Overwrite the first entry's 4-byte LE length prefix with u32::MAX.
+    let mut data = std::fs::read(&path).unwrap();
+    data.splice(0..4, u32::MAX.to_le_bytes());
+    std::fs::write(&path, &data).unwrap();
+
+    let result = verify_chain(&path, &test_key()).unwrap();
+
+    // WARNING: assert the OFFSET, not just the variant. Without the guard,
+    // verify_chain still reports Corrupted — but only after attempting a 4 GiB
+    // `vec![0u8; payload_len]` and hitting EOF, which reports byte_offset 4.
+    // The guard reports byte_offset 0, so only this distinguishes them.
+    assert!(
+        matches!(result.status, ChainStatus::Corrupted { byte_offset: 0 }),
+        "expected Corrupted at byte_offset 0 (the guard), got {:?}",
+        result.status
+    );
+}
+
+#[test]
+fn decode_entry_reports_corrupted_when_the_payload_is_short() {
+    // A length prefix promising 64 bytes with only 8 present.
+    let mut bytes = 64_u32.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&[0xAA; 8]);
+
+    let result = decode_entry(&bytes);
+
+    assert!(
+        matches!(result, Err(TamperLogError::Corrupted { offset: 4 })),
+        "expected Corrupted at the payload offset, got {result:?}"
+    );
+}
+
+#[test]
+fn decode_entry_reports_corrupted_when_the_hash_is_missing() {
+    // Well-formed length + payload, but the trailing 32-byte hash is absent.
+    let entry = LogEntry {
+        sequence: 0,
+        timestamp_ms: 0,
+        kind: config_kind(),
+    };
+    let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
+    let without_hash = wire.get(..wire.len() - 32).unwrap();
+
+    let result = decode_entry(without_hash);
+
+    assert!(
+        matches!(result, Err(TamperLogError::Corrupted { .. })),
+        "expected Corrupted for a missing hash, got {result:?}"
+    );
+}
+
+#[test]
+fn decode_entry_reports_cbor_decode_on_an_undecodable_payload() {
+    // Correct framing, but the payload is not valid CBOR for a LogEntry.
+    let payload = [0xFFu8; 16];
+    let mut bytes = 16_u32.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&payload);
+    bytes.extend_from_slice(&[0u8; 32]);
+
+    let result = decode_entry(&bytes);
+
+    assert!(
+        matches!(result, Err(TamperLogError::CborDecode { .. })),
+        "expected CborDecode for a non-CBOR payload, got {result:?}"
+    );
+}
+
+#[test]
+fn encode_entry_refuses_a_payload_over_the_decoder_bound() {
+    // WHY: encode_entry's SAFETY note claimed the payload was "validated <=
+    // MAX_ENTRY_BYTES" while nothing checked it, so the writer could emit an
+    // entry that decode_entry and verify_chain then rejected — a log made
+    // permanently unverifiable by its own writer.
+    let oversized = "x".repeat(usize::try_from(MAX_ENTRY_BYTES).unwrap() + 1);
+    let entry = LogEntry {
+        sequence: 0,
+        timestamp_ms: 0,
+        kind: LogEntryKind::AlertRaised {
+            alert_id: CompactString::from("BIG"),
+            severity: CompactString::from("info"),
+            message: CompactString::from(oversized.as_str()),
+        },
+    };
+
+    let result = encode_entry(&entry, &[0u8; 32], &test_key());
+
+    assert!(
+        matches!(
+            result,
+            Err(TamperLogError::EntryTooLarge { max, .. }) if max == MAX_ENTRY_BYTES
+        ),
+        "expected EntryTooLarge, got {:?}",
+        result.map(|(w, _)| w.len())
+    );
+}

--- a/crates/koinon/src/tamper_log_rotation.rs
+++ b/crates/koinon/src/tamper_log_rotation.rs
@@ -1,0 +1,60 @@
+//! Rotation path helpers for [`super`]; split out to keep the parent file under
+//! the RUST/file-too-long 800-line threshold.
+
+use std::path::{Path, PathBuf};
+
+use snafu::ResultExt;
+
+use super::{IoSnafu, TamperLogError};
+
+/// Returns the stem of a log path, e.g. `"audit"` FROM `"audit.log"`.
+pub(super) fn log_stem(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Builds `{dir}/{stem}.{n}.log`.
+pub(super) fn rotation_path(path: &Path, n: u32) -> PathBuf {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = log_stem(path);
+    dir.join(format!("{stem}.{n}.log"))
+}
+
+/// Parses `{stem}.{n}.log` → `Some(n)`, returns `None` otherwise.
+pub(super) fn parse_rotation_number(name: &str, stem: &str) -> Option<u32> {
+    let prefix = format!("{stem}.");
+    let suffix = ".log";
+    let inner = name.strip_prefix(&prefix)?.strip_suffix(suffix)?;
+    inner.parse::<u32>().ok()
+}
+
+/// Scans sibling files to find the next rotation number.
+///
+/// # Errors
+///
+/// Returns [`TamperLogError::Io`] if the log's directory cannot be scanned.
+pub(super) fn next_rotation_number(path: &Path) -> Result<u32, TamperLogError> {
+    let stem = log_stem(path);
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+
+    // WHY: swallowing this error returned rotation number 1, and the caller
+    // renames the live log onto that path — so an unreadable directory silently
+    // overwrote <stem>.1, destroying an already-sealed segment of a
+    // tamper-evident log. Refuse to rotate instead of guessing.
+    let entries = std::fs::read_dir(dir).context(IoSnafu { path: dir })?;
+
+    let mut max_n: u32 = 0;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some(n) = parse_rotation_number(&name, &stem)
+            && n > max_n
+        {
+            max_n = n;
+        }
+    }
+    // WARNING: saturating so an exhausted rotation space reuses the last slot
+    // rather than wrapping to 0 and overwriting the oldest segment.
+    Ok(max_n.saturating_add(1))
+}

--- a/crates/koinon/src/tamper_log_tests.rs
+++ b/crates/koinon/src/tamper_log_tests.rs
@@ -647,17 +647,38 @@ fn large_metadata_no_truncation() {
 }
 
 #[test]
-fn id_types_usable_in_entry_kinds() {
+fn id_types_survive_a_round_trip_through_entry_kinds() {
+    // WHY: this only constructed the two kinds and dropped them with `let _`,
+    // so it asserted nothing and passed even if the ids were silently replaced.
+    // Assert the ids come back out of a full encode/decode instead.
     let sid = SignalId::from_ulid(Ulid::generate());
     let eid = EntityId::from_ulid(Ulid::generate());
-    let _ = LogEntryKind::SignalObserved {
-        signal_id: sid,
-        kind_tag: CompactString::from("t"),
-    };
-    let _ = LogEntryKind::EntityCreated {
-        entity_id: eid,
-        kind_tag: CompactString::from("t"),
-    };
+
+    for (kind, label) in [
+        (
+            LogEntryKind::SignalObserved {
+                signal_id: sid,
+                kind_tag: CompactString::from("t"),
+            },
+            "signal",
+        ),
+        (
+            LogEntryKind::EntityCreated {
+                entity_id: eid,
+                kind_tag: CompactString::from("t"),
+            },
+            "entity",
+        ),
+    ] {
+        let entry = LogEntry {
+            sequence: 0,
+            timestamp_ms: 0,
+            kind,
+        };
+        let (wire, _) = encode_entry(&entry, &[0u8; 32], &test_key()).unwrap();
+        let (decoded, _) = decode_entry(&wire).unwrap();
+        assert_eq!(entry, decoded, "{label} id did not survive the round trip");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What was wrong

Six of the eight wave-1 findings against `crates/koinon`:

- `Coordinates` (pub fields) and `Confidence` (private tuple field) both derived `Deserialize` by rebuilding the value directly, so the constructors' validation only applied to code paths that called them — a stored plan could carry latitude 900.0 into `haversine_distance_m`, or a confidence of 5.0 into a threshold comparison.
- `Confidence::new`'s clamp was an ordered if/else on `< 0.0` / `> 1.0`; NaN compares false against both, fell through to the else arm, and was stored as-is, after which every comparison against it silently answered false.
- `Frequency` deserializes over a raw `u64`, and the unit constructors / `Add`/`Sub` used unchecked arithmetic — `mhz(u64::MAX)` wrapped to a small plausible frequency, and `a - b` with `b > a` wrapped to ~18 EHz.
- `encode_entry` carried a SAFETY comment asserting the payload was "validated <= MAX_ENTRY_BYTES" when nothing validated it; an oversized entry was written happily and made the whole log unverifiable, and past 4 GiB the `as u32` length cast also truncated, corrupting the framing of every following entry.
- `next_rotation_number` swallowed a `read_dir` failure and returned 1, so an unreadable directory silently overwrote (destroyed) an already-sealed `<stem>.1` segment of the tamper-evident log on rotation.

## What this changes

- `Coordinates` and `Confidence` now route deserialization through their constructors (`try_from` / `from = "f32"`), and `Coordinates::new` additionally rejects a non-finite altitude.
- `Confidence::new` now fails NaN closed to 0.0.
- `Frequency` constructors and operators saturate; `checked_add`/`checked_sub` are available where callers must detect the boundary. No workspace caller used the operators previously.
- `encode_entry` now enforces the `MAX_ENTRY_BYTES` bound before encoding rather than only documenting it.
- Rotation now propagates the directory-read I/O error and refuses to rotate rather than silently overwriting a sealed segment; the rotation counter saturates rather than wrapping to 0.
- `.kanon-lint-baseline.toml` line numbers are updated to match the shifted code; the flagged content (hash) is unchanged.

## Left open, with reasoning

`baseline.rs:306` (rebuild statistics incrementally rather than from scratch) is not folded into this batch — removing observations from a running variance is numerically unstable, which is why the current code rebuilds; the rebuild is bounded by `max_observations` and no hot path is measured. That is a design call, not a mechanical fix.

## Verification

Sixteen new tests, including coverage for `verify_chain`'s and `decode_entry`'s previously-untested oversized/truncated/malformed-payload paths, and a fix to `id_types_usable_in_entry_kinds` (previously asserted nothing).

akroasis workspace: 866 tests pass (850 before). `cargo fmt` and `cargo clippy` clean.

Refs #230
