### PR TITLE
fix(semaino): report the baseline the score was computed against

### DIFF
--- a/crates/semaino/src/aggregator.rs
+++ b/crates/semaino/src/aggregator.rs
@@ -183,6 +183,15 @@ impl SignalAggregator {
 
             let score = baseline.score(day_of_week, hour, feature);
 
+            // WHY(#232): the reported statistics must describe the same
+            // baseline the score was computed against. Read after observe(),
+            // they already include the outlier sample, so an operator judging
+            // the anomaly sees numbers the score never used — and the wider
+            // the outlier, the more it flatters its own baseline.
+            let (baseline_mean, baseline_stddev) = baseline
+                .bucket(day_of_week, hour)
+                .map_or((None, None), |bucket| (bucket.mean(), bucket.stddev()));
+
             // Only update the baseline after scoring to avoid contaminating it with
             // the outlier value we just detected.
             baseline.observe(day_of_week, hour, feature);
@@ -193,10 +202,6 @@ impl SignalAggregator {
             );
 
             if is_notable {
-                let (baseline_mean, baseline_stddev) = baseline
-                    .bucket(day_of_week, hour)
-                    .map_or((None, None), |bucket| (bucket.mean(), bucket.stddev()));
-
                 let aggregated = AggregatedSignal {
                     signal,
                     score,
@@ -279,6 +284,21 @@ mod tests {
                 bandwidth: Frequency::khz(25),
             }),
             Timestamp::now(),
+            None,
+        )
+    }
+
+    /// An RF signal stamped at a fixed instant, so every sample lands in one
+    /// temporal bucket regardless of when the test runs.
+    fn rf_signal_at(power_dbm: f64, millis: i64) -> GeoSignal {
+        GeoSignal::new(
+            SignalKind::Rf(RfDetail::Transmission {
+                frequency: Frequency::mhz(146),
+                power: Power::dbm(power_dbm),
+                modulation: "FM".into(),
+                bandwidth: Frequency::khz(25),
+            }),
+            Timestamp::from_unix_millis(millis).unwrap(),
             None,
         )
     }
@@ -481,5 +501,89 @@ mod tests {
             None,
         );
         assert_eq!(SignalAggregator::extract_feature(&sig), None);
+    }
+
+    #[tokio::test]
+    async fn reported_baseline_excludes_the_outlier_being_scored() {
+        // 2023-11-14T22:13:20Z — a fixed instant, so all 21 samples share one
+        // (day, hour) bucket no matter when the suite runs.
+        const BUCKET_MS: i64 = 1_700_000_000_000;
+        // Twenty warm-up samples at -50, -49, -48 repeating: offsets sum to 19
+        // across i in 0..20, so the baseline mean is -50 + 19/20.
+        const EXPECTED_MEAN: f64 = -49.05;
+
+        let (broadcast_tx, broadcast_rx) = broadcast::channel::<GeoSignal>(64);
+        let (agg_tx, mut agg_rx) = mpsc::channel::<AggregatedSignal>(64);
+
+        let mut aggregator = SignalAggregator::new();
+        let handle = tokio::spawn(async move {
+            aggregator.run(broadcast_rx, agg_tx).await;
+        });
+
+        for i in 0..20_i32 {
+            let power = -50.0 + f64::from(i % 3);
+            broadcast_tx.send(rf_signal_at(power, BUCKET_MS)).unwrap();
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await; // kanon:ignore TESTING/sleep-in-test -- synchronises with the spawned aggregator task; a barrier would re-implement the channel's ready signal
+        while agg_rx.try_recv().is_ok() {}
+
+        broadcast_tx.send(rf_signal_at(50.0, BUCKET_MS)).unwrap();
+
+        let timed = tokio::time::timeout(tokio::time::Duration::from_millis(500), agg_rx.recv())
+            .await
+            .ok();
+        assert!(timed.is_some(), "timed out waiting for the anomaly");
+        let aggregated = timed.flatten();
+        assert!(
+            aggregated.is_some(),
+            "aggregator channel closed unexpectedly"
+        );
+        let aggregated = aggregated.unwrap();
+
+        let mean = aggregated.baseline_mean;
+        assert!(mean.is_some(), "the baseline holds 20 samples");
+        let mean = mean.unwrap();
+        // WHY(#232): folding the outlier in first would report
+        // (-49.05 * 20 + 50) / 21 ≈ -44.33 — the number the score was NOT
+        // computed against. The gap between the two is the whole finding.
+        assert!(
+            (mean - EXPECTED_MEAN).abs() < 1e-9,
+            "reported mean must predate the outlier: expected {EXPECTED_MEAN}, got {mean}"
+        );
+
+        drop(broadcast_tx);
+        handle.await.unwrap();
+    }
+
+    #[test]
+    fn day_hour_from_timestamp_maps_known_instants() {
+        // NOTE: the (0, 0) conversion fallback documented on
+        // day_hour_from_timestamp is unreachable through any public path —
+        // `koinon::Timestamp` only ever holds an already-valid jiff timestamp
+        // (`now()`, the validating `from_unix_millis`, or a Deserialize impl
+        // that delegates to jiff's own), so neither `from_millisecond` nor
+        // `in_tz("UTC")` can fail on a value obtained from one. It is
+        // therefore asserted here as the genuine Monday-00:00 bucket it is
+        // indistinguishable from, not as an error path.
+        let cases = [
+            // 2023-11-14T22:13:20Z — Tuesday.
+            (1_700_000_000_000_i64, (1_u8, 22_u8)),
+            // 1970-01-01T00:00:00Z — Thursday, the unix epoch.
+            (0, (3, 0)),
+            // 2024-01-01T00:00:00Z — Monday midnight: a real (0, 0).
+            (1_704_067_200_000, (0, 0)),
+            // 2023-12-31T00:00:00Z — Sunday, the end of the week wrap.
+            (1_703_980_800_000, (6, 0)),
+        ];
+
+        for (millis, expected) in cases {
+            let ts = Timestamp::from_unix_millis(millis).unwrap();
+            assert_eq!(
+                day_hour_from_timestamp(&ts),
+                expected,
+                "wrong bucket for unix millis {millis}"
+            );
+        }
     }
 }

--- a/crates/semaino/src/pipeline.rs
+++ b/crates/semaino/src/pipeline.rs
@@ -199,8 +199,27 @@ impl SemainoPipeline {
             }
         }
 
-        // Drain any remaining aggregated signals.
-        drop(agg_rx);
+        // WHY(#232): this comment used to sit above a bare `drop(agg_rx)`,
+        // which promised a drain and performed a discard. The window is real:
+        // the loop above breaks as soon as signal_rx is closed and empty, and
+        // the fan task feeds inner_tx before signal_tx, so the aggregator can
+        // still be scoring queued signals at that point and emit afterwards.
+        //
+        // NOTE: measured, not assumed — no scenario tried (warm-up depth,
+        // escalating outliers, immediate close, multi-threaded runtime) ever
+        // lost an alert to the old code, because the biased select cannot
+        // break while agg_rx holds items and the aggregator finishes its
+        // backlog first in practice. This is therefore a correctness
+        // hardening that makes the comment true, not a fix for an observed
+        // loss.
+        //
+        // INVARIANT: this terminates. signal_rx closing means the fan task
+        // exited and dropped inner_tx; that closes the aggregator's receiver,
+        // so it returns and drops agg_tx — the only sender — and recv()
+        // yields None once the buffered alerts are drained.
+        while let Some(aggregated) = agg_rx.recv().await {
+            self.handle_aggregated(&aggregated);
+        }
 
         // Wait for background tasks to complete.
         if let Err(e) = fan_task.await {
@@ -425,5 +444,55 @@ mod tests {
 
         let result = classify(&AnomalyScore::Normal, None);
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn immediate_shutdown_still_delivers_every_anomaly() {
+        // WHY(#232): guards the shutdown drain. It does not reproduce a loss
+        // under the old `drop(agg_rx)` — see the NOTE at that site; no
+        // scenario tried did. What it does catch is a regression in the drain
+        // loop itself: the loop awaits a receiver whose only sender lives in a
+        // spawned task, so a future change that keeps an agg_tx clone alive in
+        // this scope would hang shutdown forever, and this test would time out
+        // rather than pass quietly.
+        const OUTLIERS: usize = 6;
+
+        let (tx, rx) = broadcast::channel::<GeoSignal>(1024);
+        let mut pipeline = SemainoPipeline::new(&SemainoConfig {
+            suppression_window_secs: 0, // no suppression: every anomaly must surface
+            min_convergence_domains: 1,
+            ..SemainoConfig::default()
+        });
+
+        let sink = CollectingSink::default();
+        let sink_data = Arc::clone(&sink.0);
+        pipeline.add_sink(sink);
+
+        let handle = tokio::spawn(async move {
+            pipeline.run(rx).await;
+        });
+
+        // Warm the baseline, then close the feed with the outliers still at
+        // the very end of the stream and no settling delay.
+        for i in 0..20_i32 {
+            tx.send(rf_signal(-50.0 + f64::from(i % 3))).unwrap();
+        }
+        // WHY: escalating magnitudes stay beyond 3 sigma as observing each one
+        // widens the baseline, so all six score anomalous rather than the
+        // baseline absorbing them after the first few.
+        let mut magnitude = 50.0_f64;
+        for _ in 0..OUTLIERS {
+            tx.send(rf_signal(magnitude)).unwrap();
+            magnitude *= 4.0;
+        }
+
+        drop(tx);
+        handle.await.unwrap();
+
+        let count = sink_data.lock().unwrap().len();
+        assert_eq!(
+            count, OUTLIERS,
+            "every anomaly must survive an immediate shutdown"
+        );
     }
 }


### PR DESCRIPTION
## What was wrong

Three of the four findings in the semaino wave-1 audit batch:

- `SignalAggregator::run` read the bucket's mean/stddev after calling `observe()`, so an `AggregatedSignal` reported statistics that already included the outlier being scored. The score itself was correct (computed before `observe()`), but the numbers traveling with it were not the ones the score used — and the wider the outlier, the more the reported baseline flattered itself.
- `SemainoPipeline::run` ended with a comment promising to drain remaining aggregated signals above a bare `drop(agg_rx)`, which discarded them instead.
- `day_hour_from_timestamp` had no test coverage, including the Monday-00:00 bucket.

## What this changes

- The baseline mean/stddev read now happens before `observe()`. A twenty-sample warm-up plus one outlier reports the twenty-sample mean (-49.05), not the twenty-one-sample mean (-44.33).
- `SemainoPipeline::run` now actually drains `agg_rx` instead of dropping it. Stated honestly: no scenario tried (varying warm-up depth, escalating outliers, closing the feed with no settling delay, a multi-threaded runtime) ever lost an alert to the old code — the biased `select` cannot break while `agg_rx` holds items, and the aggregator finishes its backlog first in practice. This is correctness hardening that makes the comment true, not a fix for an observed loss; the accompanying test guards against a regression in the drain loop itself (a stray `agg_tx` clone in scope would hang shutdown forever).
- `day_hour_from_timestamp` is now asserted against four known instants. The documented `(0, 0)` conversion fallback is unreachable through any public path (`koinon::Timestamp` only ever holds an already-valid jiff timestamp), so it is asserted as the genuine bucket it is indistinguishable from, not as an error path.

## Left open, with reasoning

The batch's remaining finding — asymmetric backpressure between the aggregator's broadcast feed and the blocking grid feed — is left open; fixing it would change the signature of the public `SignalAggregator::run`, which is a scope call rather than a bug fix.

## Verification

Each behavioral change was verified against a deliberately broken copy: restoring the post-observe read, an off-by-one weekday mapping, and a live `agg_tx` clone each failed exactly its corresponding test.

Refs #232
