### PR TITLE
fix(api): split ApiError into client message and server detail

### DIFF
--- a/crates/akroasis-server/src/error.rs
+++ b/crates/akroasis-server/src/error.rs
@@ -4,35 +4,55 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 
+/// Body text returned for any failure whose cause is server-side.
+///
+/// WHY: the underlying `Display` strings name serial device paths, filesystem
+/// paths and raw OS error text. The API is served without authentication, so
+/// that detail goes to the server log and the caller sees only the status.
+const INTERNAL_MESSAGE: &str = "internal server error";
+
 /// A typed API error that serializes to a JSON body with `{ "error": "..." }`.
 #[derive(Debug)]
 pub struct ApiError {
     status: StatusCode,
+    /// Serialized into the response body.
     message: String,
+    /// Recorded in the server log when the response is built. Never serialized.
+    detail: Option<String>,
 }
 
 impl ApiError {
     /// Construct a 500 Internal Server Error.
-    pub fn internal(message: impl Into<String>) -> Self {
+    ///
+    /// `detail` is logged, not returned: the caller receives a fixed message.
+    pub fn internal(detail: impl Into<String>) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
-            message: message.into(),
+            message: INTERNAL_MESSAGE.to_string(),
+            detail: Some(detail.into()),
         }
     }
 
-    /// Construct a 400 Bad Request.
+    /// Construct a 400 Bad Request. `message` is returned to the caller.
     pub fn bad_request(message: impl Into<String>) -> Self {
-        Self {
-            status: StatusCode::BAD_REQUEST,
-            message: message.into(),
-        }
+        Self::client(StatusCode::BAD_REQUEST, message)
     }
 
-    /// Construct a 404 Not Found.
+    /// Construct a 404 Not Found. `message` is returned to the caller.
     pub fn not_found(message: impl Into<String>) -> Self {
+        Self::client(StatusCode::NOT_FOUND, message)
+    }
+
+    /// Construct a client-error response with an explicit status.
+    ///
+    /// INVARIANT: `message` must describe a condition the caller can act on
+    /// without disclosing server-side state. Anything derived from an internal
+    /// error's `Display` belongs in [`ApiError::internal`] instead.
+    pub fn client(status: StatusCode, message: impl Into<String>) -> Self {
         Self {
-            status: StatusCode::NOT_FOUND,
+            status,
             message: message.into(),
+            detail: None,
         }
     }
 }
@@ -44,6 +64,9 @@ struct ErrorBody<'a> {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
+        if let Some(detail) = &self.detail {
+            tracing::error!(status = %self.status, detail = %detail, "api request failed");
+        }
         let body = serde_json::to_string(&ErrorBody {
             error: &self.message,
         })
@@ -54,3 +77,77 @@ impl IntoResponse for ApiError {
 
 /// Convenience alias for route handler results.
 pub type ApiResult<T> = Result<T, ApiError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn parts_of(error: ApiError) -> (StatusCode, String, String) {
+        let response = error.into_response();
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+            Err(err) => format!("<unreadable body: {err}>"),
+        };
+        (status, content_type, body)
+    }
+
+    #[tokio::test]
+    async fn internal_reports_500_without_echoing_the_detail() {
+        let (status, content_type, body) =
+            parts_of(ApiError::internal("open /dev/ttyUSB0: permission denied")).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(content_type, "application/json");
+        assert_eq!(body, r#"{"error":"internal server error"}"#);
+        assert!(!body.contains("/dev/ttyUSB0"));
+        assert!(!body.contains("permission denied"));
+    }
+
+    #[tokio::test]
+    async fn bad_request_reports_400_and_returns_its_message() {
+        let (status, _, body) = parts_of(ApiError::bad_request(
+            "multiple radios detected; specify `port`",
+        ))
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body,
+            r#"{"error":"multiple radios detected; specify `port`"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn not_found_reports_404_and_returns_its_message() {
+        let (status, _, body) = parts_of(ApiError::not_found("no radio detected")).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, r#"{"error":"no radio detected"}"#);
+    }
+
+    #[tokio::test]
+    async fn client_carries_the_status_it_is_given() {
+        let (status, _, body) = parts_of(ApiError::client(
+            StatusCode::FORBIDDEN,
+            "port not accessible",
+        ))
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body, r#"{"error":"port not accessible"}"#);
+    }
+
+    #[tokio::test]
+    async fn a_quote_in_the_message_stays_valid_json() {
+        let (_, _, body) = parts_of(ApiError::bad_request(r#"unsupported format "x""#)).await;
+
+        assert_eq!(body, r#"{"error":"unsupported format \"x\""}"#);
+    }
+}

--- a/crates/akroasis-server/src/mesh.rs
+++ b/crates/akroasis-server/src/mesh.rs
@@ -1,19 +1,37 @@
 //! `/api/v1/mesh/*` route handlers.
 
+use akroasis_lib::mesh::MeshError;
 use axum::Json;
 
 use crate::error::{ApiError, ApiResult};
+
+/// Classify a mesh dispatch failure as a client or server error.
+///
+/// WHY: only `NodeNotFound` names something the caller supplied, so it is the
+/// one variant whose text is safe to return. The rest wrap I/O and
+/// serialization failures whose `Display` carries host filesystem paths and OS
+/// error text, and this API is served without authentication, so they route to
+/// [`ApiError::internal`] which logs the detail instead of returning it.
+fn classify(err: &MeshError) -> ApiError {
+    match err {
+        MeshError::NodeNotFound { identifier } => {
+            ApiError::not_found(format!("node not found: {identifier}"))
+        }
+        _ => ApiError::internal(err.to_string()),
+    }
+}
 
 /// `GET /api/v1/mesh/status` — mesh network status.
 ///
 /// Returns the same JSON schema as `akroasis mesh status --json`.
 ///
 /// # Errors
-/// Returns an HTTP 500 [`ApiError`] if the mesh command fails or JSON parse fails.
+/// Returns 404 if the mesh command names a node that does not exist, and an
+/// HTTP 500 [`ApiError`] if the command otherwise fails or JSON parse fails.
 pub async fn status() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Status { json: true };
-    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| classify(&e))?;
     let value: serde_json::Value =
         serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
@@ -22,11 +40,12 @@ pub async fn status() -> ApiResult<Json<serde_json::Value>> {
 /// `GET /api/v1/mesh/nodes` — list mesh nodes.
 ///
 /// # Errors
-/// Returns an HTTP 500 [`ApiError`] if the mesh command fails or JSON parse fails.
+/// Returns 404 if the mesh command names a node that does not exist, and an
+/// HTTP 500 [`ApiError`] if the command otherwise fails or JSON parse fails.
 pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Nodes { json: true };
-    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| classify(&e))?;
     let value: serde_json::Value =
         serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
@@ -35,12 +54,46 @@ pub async fn nodes() -> ApiResult<Json<serde_json::Value>> {
 /// `GET /api/v1/mesh/topology` — mesh network topology.
 ///
 /// # Errors
-/// Returns an HTTP 500 [`ApiError`] if the mesh command fails or JSON parse fails.
+/// Returns 404 if the mesh command names a node that does not exist, and an
+/// HTTP 500 [`ApiError`] if the command otherwise fails or JSON parse fails.
 pub async fn topology() -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::mesh::MeshCommand::Topology { json: true };
-    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    akroasis_lib::mesh::dispatch(&cmd, &mut out).map_err(|e| classify(&e))?;
     let value: serde_json::Value =
         serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    use super::*;
+
+    #[test]
+    fn a_missing_node_is_a_404() {
+        let err = MeshError::NodeNotFound {
+            identifier: "node-7".to_string(),
+        };
+        let response = classify(&err).into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn an_io_failure_is_a_500_that_does_not_echo_the_os_error() {
+        let err = MeshError::Io {
+            source: std::io::Error::other("/var/lib/akroasis/mesh.db is unreadable"),
+        };
+        let response = classify(&err).into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+            Err(read_err) => format!("<unreadable body: {read_err}>"),
+        };
+        assert_eq!(body, r#"{"error":"internal server error"}"#);
+        assert!(!body.contains("/var/lib/akroasis"));
+    }
 }

--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -4,8 +4,10 @@
 //! the same schema-versioned JSON used by `radio detect --json` / `radio
 //! import --json` etc.
 
+use akroasis_lib::radio::errors::RadioError;
 use axum::Json;
 use axum::extract::Query;
+use axum::http::StatusCode;
 use serde::Deserialize;
 
 use crate::error::{ApiError, ApiResult};
@@ -17,20 +19,100 @@ pub struct DetectQuery {
     pub port: Option<String>,
 }
 
+/// Classify a radio dispatch failure as a client or server error.
+///
+/// WHY: `RadioError` mixes conditions the caller can resolve (no radio
+/// attached, an ambiguous port that `port` would disambiguate) with faults of
+/// the host the server runs on. Reporting the first group as 500 tells the
+/// caller to retry something that will never succeed on its own, and the
+/// blanket 500 also echoed the error's `Display` text, which names the serial
+/// device path. Server-side causes route to [`ApiError::internal`], which logs
+/// the detail instead of returning it.
+fn classify(err: &RadioError) -> ApiError {
+    match err {
+        RadioError::NoRadioDetected => ApiError::not_found(
+            "no radio detected; check that the radio is on and the programming cable is connected",
+        ),
+        RadioError::MultipleRadiosDetected => {
+            ApiError::bad_request("multiple radios detected; set the `port` query parameter")
+        }
+        RadioError::PermissionDenied { .. } => ApiError::client(
+            StatusCode::FORBIDDEN,
+            "the server is not permitted to open the requested serial port",
+        ),
+        RadioError::HardwareNotAvailable => ApiError::client(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "radio hardware support is not available in this build",
+        ),
+        _ => ApiError::internal(err.to_string()),
+    }
+}
+
 /// `GET /api/v1/radio/detect` — detect connected radios.
 ///
 /// Returns the same JSON schema as `akroasis radio detect --json`.
 ///
 /// # Errors
-/// Returns an HTTP 500 [`ApiError`] if detection fails or JSON parse fails.
+/// Returns 404 when no radio is attached, 400 when several are and `port` was
+/// not given, 403 when the port cannot be opened, 503 when the build carries no
+/// hardware support, and 500 for any other detection or JSON parse failure.
 pub async fn detect(Query(params): Query<DetectQuery>) -> ApiResult<Json<serde_json::Value>> {
     let mut out = Vec::new();
     let cmd = akroasis_lib::radio::RadioCommand::Detect {
         port: params.port,
         json: true,
     };
-    akroasis_lib::radio::dispatch(&cmd, &mut out).map_err(|e| ApiError::internal(e.to_string()))?;
+    akroasis_lib::radio::dispatch(&cmd, &mut out).map_err(|e| classify(&e))?;
     let value: serde_json::Value =
         serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
     Ok(Json(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::response::IntoResponse;
+
+    use super::*;
+
+    #[test]
+    fn no_radio_is_a_404() {
+        let response = classify(&RadioError::NoRadioDetected).into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn an_ambiguous_port_is_a_400() {
+        let response = classify(&RadioError::MultipleRadiosDetected).into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn a_denied_port_is_a_403() {
+        let err = RadioError::PermissionDenied {
+            port: "/dev/ttyUSB0".to_string(),
+        };
+        let response = classify(&err).into_response();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn an_unclassified_failure_is_a_500_that_does_not_echo_the_path() {
+        let err = RadioError::ReadFile {
+            path: std::path::PathBuf::from("/var/lib/akroasis/image.img"),
+            source: std::io::Error::other("permission denied"),
+        };
+        assert!(
+            err.to_string().contains("/var/lib/akroasis/image.img"),
+            "the source error must carry the path, or this proves nothing"
+        );
+
+        let response = classify(&err).into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+            Err(read_err) => format!("<unreadable body: {read_err}>"),
+        };
+        assert_eq!(body, r#"{"error":"internal server error"}"#);
+        assert!(!body.contains("/var/lib/akroasis"));
+    }
 }


### PR DESCRIPTION
Split `ApiError` into a client-visible message and a server-logged detail, so raw error text from serial-device and host paths stops reaching unauthenticated clients as 500 bodies. Adds per-error status classification (404/400/403/503) instead of a blanket 500.

Verified: reviewed and cleared to land during op-pause. Opus-confirmed no internal detail reaches a client through any handler path and no authz decision changed; CI is the verifier.

Refs #227
