### PR TITLE
fix(vault): avoid mutating vault dir on failed open of uninitialized path

### DIFF
--- a/crates/kryphos/src/error.rs
+++ b/crates/kryphos/src/error.rs
@@ -62,6 +62,17 @@ pub enum VaultError {
         path: std::path::PathBuf,
     },
 
+    /// No vault has been initialized at this path.
+    ///
+    /// Distinct from [`VaultError::Io`]: absence is the expected outcome of
+    /// opening a path before `create`, not a filesystem failure, and callers
+    /// branch on it to offer initialization.
+    #[snafu(display("no vault initialized at {path}", path = path.display()))]
+    NotInitialized {
+        /// Path that holds no vault.
+        path: std::path::PathBuf,
+    },
+
     /// The storage backend (fjall) returned an error.
     #[snafu(display("storage backend error: {message}"))]
     StorageBackend {

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -14,7 +14,7 @@ use snafu::ResultExt;
 use crate::crypto::{self, decrypt, encrypt};
 use crate::error::{
     AlreadyExistsSnafu, EntryCryptoSnafu, EntryNotDeletableSnafu, EntryRevokedSnafu, IoSnafu,
-    SerializationSnafu, TamperLogSnafu, VaultError, WrongPassphraseSnafu,
+    NotInitializedSnafu, SerializationSnafu, TamperLogSnafu, VaultError, WrongPassphraseSnafu,
 };
 use crate::key::VaultKey;
 use crate::vault::{
@@ -178,11 +178,30 @@ impl Vault {
     ///
     /// # Errors
     ///
+    /// Returns [`VaultError::NotInitialized`] if no vault exists at `path`.
     /// Returns [`VaultError::WrongPassphrase`] if the passphrase is incorrect.
     /// Returns [`VaultError::Locked`] if another process holds the lock.
     /// Returns [`VaultError::InvalidHeader`] if the header is malformed.
     pub fn open(path: impl AsRef<Path>, passphrase: &[u8]) -> Result<Self, VaultError> {
         let path = path.as_ref();
+
+        // WHY: establish that a vault is present before anything touches the
+        // filesystem. Locking first used to create the vault directory and the
+        // lock file on a path that held no vault, after which `create` rejected
+        // that same path as `AlreadyExists` — so a mistyped path, or any read
+        // attempted before initialization, poisoned the path until someone
+        // cleaned it up by hand.
+        //
+        // This ordering also gives `acquire_lock` its precondition: the vault
+        // directory exists by the time it runs.
+        //
+        // Checking before locking introduces no race the old order avoided. If
+        // another process creates the vault in between, we lock and read it
+        // normally; if one removes it, the header read fails exactly as before.
+        if !path.join(HEADER_FILE).is_file() {
+            return NotInitializedSnafu { path }.fail();
+        }
+
         let lock = acquire_lock(path)?;
 
         let header_bytes = fs::read(path.join(HEADER_FILE)).context(IoSnafu { path })?;
@@ -515,12 +534,14 @@ impl std::fmt::Debug for Vault {
 }
 
 /// Acquires an advisory lock on the vault directory.
+///
+/// INVARIANT: `vault_path` already exists as a vault directory. `create`
+/// builds it before locking, and `open` refuses a path with no header before
+/// it gets here. The directory-creating call this function used to make was
+/// what let `open` leave artifacts on a non-existent vault, so the caller
+/// owns directory creation now and this function only ever locks.
 fn acquire_lock(vault_path: &Path) -> Result<File, VaultError> {
     let lock_path = vault_path.join(LOCK_FILE);
-
-    // WHY: create_owner_only_dir is idempotent and needed when called from
-    // open() before the lock file exists.
-    create_owner_only_dir(vault_path)?;
 
     let file = create_owner_only_file(&lock_path)?;
 

--- a/crates/kryphos/src/storage_tests.rs
+++ b/crates/kryphos/src/storage_tests.rs
@@ -561,3 +561,59 @@ fn create_restricts_lock_file_to_owner_on_unix() {
 
     drop(vault);
 }
+
+#[test]
+fn open_on_a_missing_vault_leaves_the_path_untouched() {
+    // Regression for forkwright/akroasis#286: `open` acquired the lock
+    // before checking for a header, and `acquire_lock` created the vault
+    // directory plus the lock file. A `list`/`get` before initialization —
+    // or one mistyped path — therefore poisoned the path against `create`.
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("never-initialized");
+
+    let result = Vault::open(&vault_path, TEST_PASSPHRASE);
+
+    assert!(
+        matches!(result, Err(VaultError::NotInitialized { .. })),
+        "opening a path with no vault must report typed absence, got: {result:?}"
+    );
+    assert!(
+        !vault_path.exists(),
+        "a failed open must not create the vault directory"
+    );
+}
+
+#[test]
+fn create_succeeds_after_a_failed_open_at_the_same_path() {
+    // The acceptance condition of forkwright/akroasis#286: the failed open
+    // must leave the path usable for the initialization it preceded.
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("open-then-create");
+
+    let failed = Vault::open(&vault_path, TEST_PASSPHRASE);
+    assert!(failed.is_err(), "vault does not exist yet");
+
+    let created = Vault::create(&vault_path, TEST_PASSPHRASE);
+    assert!(
+        created.is_ok(),
+        "create must succeed at a path a failed open touched, got: {created:?}"
+    );
+    assert_eq!(created.unwrap().path(), vault_path);
+}
+
+#[test]
+fn open_reports_absence_rather_than_io_failure_for_a_bare_directory() {
+    // A directory with no header is not a vault. Callers branch on
+    // `NotInitialized` to offer initialization, so this must not surface as
+    // a generic I/O error.
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("empty-dir");
+    std::fs::create_dir(&vault_path).unwrap();
+
+    let result = Vault::open(&vault_path, TEST_PASSPHRASE);
+
+    assert!(
+        matches!(result, Err(VaultError::NotInitialized { .. })),
+        "a headerless directory must report typed absence, got: {result:?}"
+    );
+}


### PR DESCRIPTION
Reorder `Vault::open` to check for a header before `acquire_lock` can create the vault dir/lock as a side effect, so a failed open on an uninitialized path no longer poisons it against a later create. Adds a typed `VaultError::NotInitialized`.

Verified: reviewed and cleared to land during op-pause. Opus-confirmed a present-but-malformed header still fails closed and no partial/uninitialized vault is treated as valid; CI is the verifier.

Refs #286
