### PR TITLE
fix(ci): make the dependabot auto-merge guard refuse instead of merging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,9 +27,14 @@ jobs:
           (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
            steps.metadata.outputs.dependency-type == 'direct:development')
         run: |
+          # WHY exit 1, not exit 0: this step is a GUARD, and `exit 0` makes
+          # it SUCCEED. The merge steps below gate only on
+          # `steps.metadata.outputs.update-type`, never on this step's
+          # outcome, and Actions skips a later step only when an earlier one
+          # FAILS -- so a zero exit printed a refusal and then merged anyway.
           if ! gh pr checks "$PR_URL" --watch --interval 30 --required; then
-            echo "Required CI checks did not pass — skipping auto-merge"
-            exit 0
+            echo "Required CI checks did not pass; refusing auto-merge." >&2
+            exit 1
           fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
The "Wait for CI checks to pass" step printed a refusal and then `exit 0`,
which makes the STEP SUCCEED.

The merge steps below it gate only on `steps.metadata.outputs.update-type`
-- never on this step's outcome. A step whose `if:` contains no status
function carries an implicit `success()`, so a later step is skipped only
when an earlier one FAILS. A guard that exits zero therefore announced
"skipping auto-merge" and then ran `gh pr merge --squash`.

Nothing has merged wrongly, and the reason is worth stating precisely
rather than as a near-miss: `main` is protected with required contexts
(cargo audit, cargo deny, gate / gate), which refuses the merge
independently. The defect is that this guard contributed no
defence-in-depth while its own message asserted otherwise -- a check
reporting a verdict it never enforced. Branch protection also only
enforces checks it knows about, so a required check that silently never
reports is invisible to it.

harmonia and the canonical reusable in forkwright/.github both already
carry this fix with a comment naming the same failure mode; this copy
predates them.

Refs #371
