### PR TITLE
fix(ci): stop main-push gate self-cancelling via caller-level concurrency

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -8,15 +8,16 @@
 # from that build; ai-attribution runs unconditionally via the reusable
 # workflow's own centralized job.
 #
-# NOTE (#262 residual gap, tracked -- not closed by this change): the
-# reusable workflow's check-trailer job waives dependabot[bot] PRs from
-# full-gate-build unconditionally (fleet-wide behavior, not overridable
-# per-caller), and this workflow triggers on pull_request only (no
-# push-to-main compile check). #262's "Done when" (a PR that fails
-# `cargo check --workspace` cannot auto-merge; main compiles in CI on every
-# push) is therefore only partially met: dependabot bumps still bypass the
-# build, and there is no push-triggered compile check. Left as an explicit
-# comment on #262 rather than silently claimed done.
+# NOTE (#262 status): the two residual gaps this comment used to track are
+# both closed. check-trailer no longer waives dependabot[bot] PRs from
+# full-gate-build (the reusable workflow's own trailer step routes ANY
+# untrailered tip, bot or human, to a real build -- confirmed on PRs #367/
+# #369/#370, each a full-gate-build pass before merge); and #353 added the
+# `push: branches: [main]` trigger below so a squash-merged, trailer-less
+# commit still gets built. #262's "Done when" is therefore mechanically met
+# at the PR/push-trigger level -- what remained live was the caller-level
+# `concurrency:` block documented below, which could cancel a queued
+# main-push run before full-gate-build ever started.
 #
 # fmt/check/clippy/nextest command strings mirror .kanon-ci.toml's stage
 # commands verbatim (the local `kanon gate --stamp` SSOT) so a Gate-Passed
@@ -56,8 +57,14 @@
 name: Gate Attestation
 
 on:
+  # WHY no `branches:` filter here: a `branches:` filter on `pull_request`
+  # matches the PR's BASE branch, not its head. A stacked PR (base = another
+  # open PR's branch, not main) would match nothing and get zero gate runs
+  # -- not a pending check, an absent one, so nothing blocks it from merging
+  # broken. Two PRs shipped non-viable code through exactly that shape this
+  # week (kanon#3475). `push:` stays scoped to main below; that one IS the
+  # PR's base, always resolvable, and scoping it prevents duplicate runs.
   pull_request:
-    branches: [main]
   # WHY a push trigger and not just pull_request: a squash merge does not
   # carry the source commits' trailers, so no commit on main has a
   # Gate-Passed trailer -- check-trailer finds none and routes to
@@ -67,9 +74,29 @@ on:
   push:
     branches: [main]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+# WHY no concurrency: block here: hybrid-gate.yml itself already declares
+# `concurrency: group: ${{ github.workflow }}-${{ github.event_name ==
+# 'push' && github.sha || github.ref }}` and its own comment states callers
+# must NOT also set a concurrency group with that same key, or the shared
+# group self-cancels. This file's PRIOR block used
+# `${{ github.event.pull_request.number || github.ref }}` -- ref-keyed on
+# push, same failure class the reusable workflow's sha-on-push branch exists
+# to prevent, just reintroduced one layer up. Confirmed live on #262
+# (reopened 2026-08-05): main-push runs at 7004d734/cf1dd2da/9e8778b4/
+# 11f0978f all show zero jobs ("workflow file issue"), and three dependabot
+# squash-merges landing seconds apart on 2026-08-16 (60f97de/b5c8071/
+# bebbcd1) show the same group cancelling the first two runs' full-gate-build
+# mid-flight -- main commits merging with no completed compile check, the
+# exact defect #262 exists to close. sphragis's gate-attestation.yml carries
+# the identical fix with the identical WHY, having hit this first.
+#
+# WHY the pull_request-time behavior does not regress: without a caller-level
+# group, cancellation authority passes to the reusable workflow's own block.
+# On a pull_request event `github.ref` resolves to `refs/pull/<N>/merge`,
+# stable per PR number across every push to it -- so a superseded push to
+# the same PR still cancels that PR's own prior run, same as before, without
+# touching any other PR or a push-to-main run (different key entirely, per
+# the ternary's sha branch).
 
 permissions:
   contents: read
@@ -82,6 +109,12 @@ jobs:
       check_cmd: "cargo check --workspace --all-targets --features syntonia/hardware-serial --jobs 8"
       clippy_cmd: "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"
       nextest_cmd: "cargo nextest run --workspace --features syntonia/hardware-serial --build-jobs 8 --test-threads 8"
+      # WHY empty: nextest does not run doctests (kanon#3486). Left empty
+      # here, not skipped by oversight -- every fenced block in a doc
+      # comment across the workspace is ```text``` (ASCII diagrams) or
+      # ```ignore``` (kerykeion::message.rs), never a bare ```rust``` block,
+      # so `cargo test --doc` would compile and run zero examples. Revisit
+      # if a future doc comment adds a runnable example.
       doctest_cmd: ""
       system_packages: "libusb-1.0-0-dev libudev-dev protobuf-compiler"
       needs_fleet_repo_token: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,8 +21,19 @@ on:
 permissions:
   contents: read
 
+# WHY the SHA on a push (#375): `github.event.pull_request.number` is empty
+# on a `push` event, so the old key here fell back to `github.ref`, constant
+# for `main` -- two pushes to main inside the cancel window collided, and
+# `cargo audit`/`cargo deny` reported `cancelled`, not red, for the loser.
+# Confirmed live on 60f97de and b5c8071 (`gh api
+# repos/forkwright/akroasis/commits/<sha>/check-runs`), the same two commits
+# `gate-attestation.yml`'s identical fix cites as its own evidence -- this
+# file carries the exact same bug, standalone (no reusable-workflow fallback
+# to catch it). `schedule`/`workflow_dispatch` keep falling back to
+# `github.ref`: a superseding scheduled/manual run cancelling an older one of
+# its own kind is the desired behavior, unchanged here.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -1,7 +1,7 @@
 [baseline]
 created = "2026-08-03"
 remove_after = "2026-11-01"
-reason = "akroasis#261 lint-debt burn-down — errors first (vault plain-string-secret, kerykeion crypto indexing), both resolved. Remaining entries are deliberate exceptions, not deferred mechanical work: RUST/no-arc-mutex-anti-pattern (kerykeion/collector.rs) already uses tokio::sync::Mutex — the rule's own recommended async-safe primitive; converting further to RwLock needs a per-callsite read/write classification across 5 files, an architecture change outside a lint-driven edit. VOCAB/crate-name-collision + NAMING/no-fleet-collision (koinon) are a cross-repo naming call deferred to a fleet naming decision (akroasis#264). NAMING/no-owner-prefix (akroasis-server) needs a GNOMON-reviewed rename, an identity decision outside a mechanical fix. ARCH/substrate-dead-dep (sphragis) is a deliberately staged dependency awaiting the pinax reference-store integration and a cryptographic review (akroasis#172). TOML/missing-trailing-comma (.gitleaks.toml), RUST/doc-promised-observability (delivery.rs), CI/release-yml-missing-attestation (release-please.yml builds no artifacts to attest — release.yml already attests), and RUST/plain-string-secret (ListEntryReport.credential_type, a JSON category label not a secret) are confirmed lint-rule false positives. Entries clear only when the rule is fixed upstream or the cited decision resolves."
+reason = "akroasis#261 lint-debt burn-down — errors first (vault plain-string-secret, kerykeion crypto indexing), both resolved. Remaining entries are deliberate exceptions, not deferred mechanical work: RUST/no-arc-mutex-anti-pattern (kerykeion/collector.rs) already uses tokio::sync::Mutex — the rule's own recommended async-safe primitive; converting further to RwLock needs a per-callsite read/write classification across 5 files, an architecture change outside a lint-driven edit. VOCAB/crate-name-collision + NAMING/no-fleet-collision (koinon) are a cross-repo naming call deferred to a fleet naming decision (akroasis#264). NAMING/no-owner-prefix (akroasis-server) needs a GNOMON-reviewed rename, an identity decision outside a mechanical fix. ARCH/substrate-dead-dep (sphragis) is a deliberately staged dependency awaiting the pinax reference-store integration and a cryptographic review (akroasis#172). TOML/missing-trailing-comma (.gitleaks.toml), RUST/doc-promised-observability (delivery.rs), CI/release-yml-missing-attestation (release-please.yml builds no artifacts to attest — release.yml already attests), and RUST/plain-string-secret (ListEntryReport.credential_type, a JSON category label not a secret) are confirmed lint-rule false positives. YAML/missing-concurrency (gate-attestation.yml, added #262) is the same class: the file deliberately carries NO caller-level concurrency block because forkwright/.github/.github/workflows/hybrid-gate.yml already declares one and its own comment states a caller-level duplicate self-cancels the shared group — sphragis's gate-attestation.yml (the reusable workflow's other adopter) carries the identical no-block shape for the identical reason. Entries clear only when the rule is fixed upstream or the cited decision resolves."
 
 [[baseline.entry]]
 rule = "ARCH/substrate-dead-dep"
@@ -152,3 +152,9 @@ rule = "VOCAB/crate-name-collision"
 file = "crates/koinon/Cargo.toml"
 line = 1
 hash = "70acf00586aa7b90c3866278505be7b81fb7ee1f7e21c17c1a22ac239be3c72a"
+
+[[baseline.entry]]
+rule = "YAML/missing-concurrency"
+file = ".github/workflows/gate-attestation.yml"
+line = 1
+hash = "b8e794237ee7d759994634dcd32d7aadd9f237ef78337fe432f10f23861dd14b"

--- a/crates/syntonia/tests/workflow_concurrency_fitness.rs
+++ b/crates/syntonia/tests/workflow_concurrency_fitness.rs
@@ -1,0 +1,119 @@
+//! Fitness test: the merge-gate workflows must not carry a concurrency group
+//! that collides across distinct push-to-main commits.
+//!
+//! WHY(#375): `.github/workflows/gate-attestation.yml`'s prior caller-level
+//! `concurrency:` block and `.github/workflows/security.yml`'s block both
+//! used `${{ github.event.pull_request.number || github.ref }}` -- constant
+//! for `main` on a `push` event (`pull_request.number` is empty), so any two
+//! main-push commits landing inside the `cancel-in-progress` window collided
+//! and the loser's job reported `cancelled`, not red, silently dropping the
+//! check for that commit. Confirmed live: `gh api
+//! repos/forkwright/akroasis/commits/<sha>/check-runs` on `60f97de` and
+//! `b5c8071` shows `cargo audit`/`cargo deny` `cancelled` on both.
+//! `gate-attestation.yml` is fixed by removing its caller-level block
+//! entirely (the reusable `hybrid-gate.yml` already supplies a sha-on-push
+//! one, and a caller-level duplicate self-cancels that shared group);
+//! `security.yml` has no reusable-workflow fallback to catch the same
+//! defect, so it is fixed by sha-keying its own group on `push` instead.
+//!
+//! This asserts the shape stays fixed rather than merely documenting it in a
+//! comment: before this test, "a second caller-level concurrency block
+//! creeping back into `gate-attestation.yml`" or `security.yml`'s key
+//! drifting off the sha-on-push form had no mechanical check -- only a
+//! comment nobody re-reads under review pressure.
+
+#![expect(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "integration test — panics are the correct failure mode"
+)]
+
+use std::path::{Path, PathBuf};
+
+/// Workspace root, derived from this crate's manifest directory.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crates/<name> is two levels below the workspace root")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = workspace_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()))
+}
+
+/// The value of the `group:` line nested two spaces under a top-level
+/// `concurrency:` key, or `None` if the file has no top-level `concurrency:`
+/// block at all.
+///
+/// WHY line-based, not a YAML parser: no YAML crate is a workspace
+/// dependency, and both files' `concurrency:` blocks are a fixed two-line
+/// shape -- adding a parser dependency for this would be more surface than
+/// the thing it checks.
+fn top_level_concurrency_group(text: &str) -> Option<String> {
+    // WHY trim_end on the key line: a trailing space after `concurrency:`
+    // (invisible in a diff, easy to leave behind editing this by hand) must
+    // not make the guard blind to a real block -- fail-open on formatting
+    // noise is exactly the shape of guard that misses its own regression.
+    let mut lines = text.lines();
+    lines.find(|l| l.trim_end() == "concurrency:")?;
+    for line in lines {
+        if let Some(rest) = line.strip_prefix("  group:") {
+            return Some(rest.trim().to_string());
+        }
+        // WHY stop at the next top-level key: a `group:` line belonging to a
+        // later, unrelated top-level block must never be picked up as this
+        // block's value.
+        if !line.starts_with(' ') && !line.trim().is_empty() {
+            break;
+        }
+    }
+    None
+}
+
+#[test]
+fn gate_attestation_carries_no_caller_level_concurrency_block() {
+    let text = read(".github/workflows/gate-attestation.yml");
+    assert!(
+        top_level_concurrency_group(&text).is_none(),
+        "gate-attestation.yml must not declare its own concurrency: block -- \
+         hybrid-gate.yml already declares a sha-on-push one, and a \
+         caller-level duplicate self-cancels the shared group (see the \
+         file's own WHY comment above the `on:` block)"
+    );
+}
+
+#[test]
+fn security_yml_concurrency_group_is_sha_keyed_on_push() {
+    let text = read(".github/workflows/security.yml");
+    let group = top_level_concurrency_group(&text)
+        .expect("security.yml must declare a top-level concurrency: block");
+    assert_eq!(
+        group,
+        "${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}",
+        "security.yml's concurrency group must be sha-keyed on push (matching \
+         hybrid-gate.yml's own key) -- a ref-only key (e.g. \
+         `github.event.pull_request.number || github.ref`) is constant across \
+         every push to main and collides, cancelling one of two commits' \
+         cargo audit/cargo deny runs instead of running both. Confirmed live \
+         on 60f97de and b5c8071: both showed cargo audit/cargo deny \
+         cancelled under the old key."
+    );
+}
+
+#[test]
+fn extraction_tolerates_a_trailing_space_on_the_key_line() {
+    // WHY this test exists: the extractor originally matched `concurrency:`
+    // by exact equality, so a trailing space on that line (invisible in a
+    // diff) made it silently report "no block" for a file that has one --
+    // the guard blind to its own regression. Pins the `trim_end` fix above.
+    let text =
+        "on:\n  push: {}\n\nconcurrency: \n  group: some-value\n  cancel-in-progress: true\n";
+    assert_eq!(
+        top_level_concurrency_group(text).as_deref(),
+        Some("some-value"),
+        "a trailing space after `concurrency:` must not blind the guard to a real block"
+    );
+}


### PR DESCRIPTION
## What this fixes

akroasis' only build/test gate is `.github/workflows/gate-attestation.yml`, which calls the fleet
`hybrid-gate.yml` reusable workflow. Two prior PRs (#288, #353) already closed most of #262 — a
real `fmt`/`check`/`clippy`/`nextest` build now runs on every PR (including dependabot bumps,
confirmed below) and on every push to `main`. This PR closes the one piece that regressed after
those landed: `gate-attestation.yml` carried its own **caller-level** `concurrency:` block using
`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`. On a `push` event
`pull_request.number` is empty, so that resolves to a plain **ref**-keyed group — constant for
`main`. `hybrid-gate.yml` already declares its own concurrency group, sha-keyed on push
specifically to avoid this, and its own comment states callers must not duplicate that key or the
shared group self-cancels.

A second file, `.github/workflows/security.yml`, carries the exact same key expression
(`${{ github.event.pull_request.number || github.ref }}`) on the same `push: branches: [main]`
trigger — standalone, with no reusable-workflow fallback to catch it. It is fixed in this PR too
(**What changed**, item 6); an earlier draft of this PR body described it as "separate ...,
unaffected by this PR", which was wrong — the same evidence cited below (`60f97de`, `b5c8071`)
shows `cargo audit`/`cargo deny` (`security.yml`'s own jobs) cancelled, not just
`gate-attestation.yml`'s `full-gate-build`.

Verified this was live, not just theoretical, before touching anything (`gh run view --json jobs`):

- Main-push runs at `7004d734` / `cf1dd2da` / `9e8778b4` / `11f0978f` (the runs #262's 2026-08-05
  reopen comment cited) show **zero jobs** — "This run likely failed because of a workflow file
  issue."
- Three dependabot squash-merges landing seconds apart on 2026-08-16 (`60f97de`, `b5c8071`,
  `bebbcd1`) show the *same live behavior today*: the caller-level group cancelled the first two
  runs' `full-gate-build` mid-flight (`conclusion: "cancelled"`), and only the last of the three
  ever produced a completed compile check. Two of three main-tip commits merged with **no
  completed CI compile** — the exact failure #262 exists to close.
- `sphragis`'s `gate-attestation.yml` (the reusable workflow's other adopter) already carries the
  fix: no caller-level `concurrency:` block at all, with a comment citing the identical reason
  ("sphragis's PRIOR file set this exact key -- dropped here, not carried forward, for that
  reason").
- The same two SHAs (`60f97de`, `b5c8071`) independently show `cargo audit`/`cargo deny` —
  `security.yml`'s own jobs — `conclusion: "cancelled"` via `gh api
  repos/forkwright/akroasis/commits/<sha>/check-runs`: the identical collision, on the sibling
  file, in data already pulled to build the bullet above.

## What changed

`.github/workflows/gate-attestation.yml`:

1. **Removed the caller-level `concurrency:` block.** Cancellation authority now belongs solely to
   `hybrid-gate.yml`'s own group (`${{ github.workflow }}-${{ github.event_name == 'push' &&
   github.sha || github.ref }}`), which is sha-keyed on push (every commit gets its own group, none
   collide) and PR-number-keyed on `pull_request` (a superseded push to the same PR still cancels
   its own prior run — behavior unchanged there).
2. **Dropped `branches: [main]` from the `pull_request:` trigger.** A `branches:` filter on
   `pull_request` matches the PR's *base*, not its head. A stacked PR (base = another open PR's
   branch, not `main`) would match nothing and get **zero** gate runs — not a pending check, an
   absent one. `push:` stays scoped to `main` (that one *is* always the resolvable target, and
   scoping it prevents duplicate runs on the same commit).
3. **Rewrote the stale top-of-file NOTE** that used to track two residual #262 gaps
   (dependabot-waived from `full-gate-build`; no push-to-main compile check) — both were already
   closed upstream (`check-trailer` no longer waives bot authors; #353 added the push trigger) but
   the comment still claimed them open. Left the accurate current status in its place.
4. **Documented (not changed) why `doctest_cmd` stays empty**: `cargo nextest` does not run
   doctests. Checked the workspace — every fenced code block in a doc comment
   (`grep -rn '```' crates/`) is ` ```text ``` ` or ` ```ignore ``` `, never a bare ` ```rust ``` `
   block, so a doctest stage would compile and execute zero examples. Doctests are genuinely
   uncovered, but there is currently nothing for that coverage to catch.
5. Added a `.kanon-lint-baseline.toml` entry for `YAML/missing-concurrency` on this file (deliberate
   absence, not an oversight — see item 1) — matches this repo's existing practice of baselining
   confirmed lint-rule false positives, with the sphragis cross-reference as evidence.

`.github/workflows/security.yml`:

6. **Fixed the concurrency key to match `hybrid-gate.yml`'s own sha-on-push form**
   (`${{ github.event_name == 'push' && github.sha || github.ref }}`), rather than removing the
   block outright — this file has no reusable-workflow fallback supplying a safe group, so unlike
   `gate-attestation.yml` the key itself, not just the caller-level duplication, was the defect.
   `schedule`/`workflow_dispatch` keep falling back to `github.ref`: a superseding scheduled/manual
   run cancelling an older one of its own kind is the desired behavior, unchanged.

New:

7. **Added `crates/syntonia/tests/workflow_concurrency_fitness.rs`**, a fitness test reading both
   workflow files directly off disk and asserting (a) `gate-attestation.yml` still declares no
   top-level `concurrency:` block, and (b) `security.yml`'s group is exactly the sha-on-push form.
   This is the mechanical regression check this bug class previously had none of — see **Negative
   fixture** below, and the corrected note under **Reviewer note** replacing the "flagged in a
   follow-up issue" claim that findings review correctly identified as pointing at nothing. A third
   test in the same file pins a robustness fix made to the extractor itself during self-review: the
   original exact-match on the `concurrency:` line would report "no block" for a file that has one
   the moment that line picks up trailing whitespace — the guard blind to its own regression.
   `trim_end` closes it.

## Does / does not verify (asked for explicitly)

**Verifies, on every PR and on every push to `main`:** `cargo fmt --check`, `cargo check
--workspace --all-targets --features syntonia/hardware-serial`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo nextest run --workspace --features
syntonia/hardware-serial`, AI-attribution, and (for a trailer-less tip, which includes every
dependabot/squash-merge commit) a real compile+test build — no path that produces a green check
without actually building.

**Does not verify:** doctests (none exist to run, see item 4 above — revisit if one is ever added);
`cargo audit`/`cargo deny` (still a separate `security.yml` workflow, distinct from this file's own
`fmt`/`check`/`clippy`/`nextest` verification — but `security.yml`'s own push-path gate is fixed by
this PR too, see **What changed** item 6, not "unaffected" as an earlier draft of this body claimed);
the `hardware-serial` feature's actual radio hardware behavior (CI has no attached device —
`--features syntonia/hardware-serial` compiles and unit-tests the code path, it does not exercise
real serial/EEPROM I/O).

## Done when (from #262, plus the 2026-08-05 reopen comment)

| Criterion | Status | Evidence |
|---|---|---|
| "a PR that fails `cargo check --workspace` cannot auto-merge" | Met (pre-existing, unchanged by this PR) | `full-gate-build` gates every trailer-less PR; confirmed on dependabot PRs #367/#369/#370, each ran a real 4-5 min `full-gate-build` pass before merge |
| "main compiles in CI on every push" | **Was not met — this PR closes it** | Caller-level concurrency removed at `.github/workflows/gate-attestation.yml:59-99`; without it, the only remaining group is `hybrid-gate.yml`'s sha-keyed one, so distinct main commits can no longer collide/cancel each other |
| "Add a main-push receipt with non-empty jobs to the acceptance evidence" (2026-08-05 reopen) | **Pending — cannot be met pre-merge** | This PR's own CI run is a `pull_request`-event run on `refs/pull/375/merge`; it exercises `hybrid-gate.yml`'s PR-time concurrency key, never the push-to-main path the original bug lived in and this row demands a receipt for — that path can only be exercised once the fixed file is on `main`. CI must confirm, after merge: the next `push`-triggered `gate / full-gate-build` run and `security.yml`'s `cargo audit`/`cargo deny` runs on `main` complete rather than showing `cancelled`. An earlier draft of this row read "Met"; that was the exact failure pattern the 2026-08-05 reopen exists to prevent (findings review), corrected here. |
| "The narrow correction is to remove caller-level concurrency and let the reusable workflow remain the single authority" (2026-08-05 reopen, prescribed fix) | Met | Exactly the change made — no substitute mechanism, no partial removal |

## Negative fixture

Two negative fixtures — one mechanical/local (new in this revision), one shipped-code/historical.
Neither claims a push-event receipt that cannot exist pre-merge; the Done-when row above reads
Pending, not Met, for that specific demand.

**1. `crates/syntonia/tests/workflow_concurrency_fitness.rs`** — a real test, watched failing and
passing directly, not merely added:

> Negative fixture: `crates/syntonia/tests/workflow_concurrency_fitness.rs` — watched failing
> against a copy of this worktree with `security.yml`'s group reverted to
> `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` and a
> caller-level `concurrency:` block reintroduced into `gate-attestation.yml`:
> ```
> test extraction_tolerates_a_trailing_space_on_the_key_line ... ok
> test gate_attestation_carries_no_caller_level_concurrency_block ... FAILED
> test security_yml_concurrency_group_is_sha_keyed_on_push ... FAILED
> test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
> ```
> Passes against this PR's actual diff:
> ```
> test extraction_tolerates_a_trailing_space_on_the_key_line ... ok
> test gate_attestation_carries_no_caller_level_concurrency_block ... ok
> test security_yml_concurrency_group_is_sha_keyed_on_push ... ok
> test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
> ```
> The third test (`extraction_tolerates_a_trailing_space_on_the_key_line`) is a self-check on the
> extractor itself, not on the worktree, so it passes both times by design — added after noticing
> the original exact-match on the `concurrency:` line would silently report "no block" (a false
> pass) if that line ever picked up trailing whitespace; `trim_end` in the extractor closes it, and
> this test pins the closure.
>
> Update: this branch's own `gate / full-gate-build` (`cargo nextest run --workspace`) has since
> completed against `d9f9d92`, green — the real `cargo test -p syntonia`-equivalent invocation of
> this exact test file, not just the standalone `rustc --test` compile above.
> `cargo test -p syntonia --test workflow_concurrency_fitness` was not run locally — metis sat at
> 1-min load ~60 against an 8-core box at fix time, so a workspace compile would not be admitted
> and would contend with other sessions; CI runs the real `cargo test` invocation on push. The
> RED/GREEN above is the actual committed test file — unmodified — compiled and executed directly
> via `rustc --edition 2024 --test` with `CARGO_MANIFEST_DIR` pointed at `crates/syntonia` (no
> `cargo`, no workspace dependency build, but the identical compiled test binary `cargo test` would
> produce for this one file), reading the real worktree file bytes both ways. Not a reimplementation
> of the assertion logic — the same `.rs` file, same bytes, two different target trees.

**2. Shipped-code run history** (the original fixture, now also covering `security.yml`):

> `gh run view <id> --repo forkwright/akroasis --json jobs` on main-push runs
> `7004d734`/`cf1dd2da`/`9e8778b4`/`11f0978f` produced `{"jobs":[]}`, and `gh api
> repos/forkwright/akroasis/commits/<sha>/check-runs` on `60f97de`/`b5c8071` shows both
> `full-gate-build` (`gate-attestation.yml`) and `cargo audit`/`cargo deny` (`security.yml`)
> `conclusion: "cancelled"`, on the exact files shipped at those SHAs. This proves the PRE-fix
> failure only, independently re-confirmed at findings-review time — it cannot show the POST-fix
> push-path success before merge, which is exactly the gap the corrected Done-when row above now
> states plainly instead of marking Met.

Both exercise the actual defect (a concurrency-group collision cancelling a real run) rather than
a reimplementation of it.

## Reviewer note: the class of bug this fix could reproduce

The brief for this fix flagged "the fix carries the same class of defect it was written to
remove" as the thing to fear. Checked directly: could the *replacement* (no caller-level group,
relying on the reusable workflow's own) still let a main-push commit go unverified?

- **Reusable workflow unreachable/renamed** — not new: any caller-level failure mode existed with
  or without this concurrency block; unrelated to this change.
- **The reusable workflow's own group silently omitted or downgraded** — checked its live source
  directly (`forkwright/.github/.github/workflows/hybrid-gate.yml@main`, lines 176-178): the
  concurrency block is unconditional at the top level of the reusable workflow, not gated behind
  any input this caller controls, so this caller cannot regress it by omission.
- **A second caller-level concurrency block creeping back in** — now mechanically enforced, not
  merely commented:
  `crates/syntonia/tests/workflow_concurrency_fitness.rs::gate_attestation_carries_no_caller_level_concurrency_block`
  reads the shipped file and fails if a top-level `concurrency:` key reappears in it. (An earlier
  draft of this bullet claimed this risk was "flagged... in a follow-up issue" — no such issue
  existed anywhere in this repo; findings review caught the false reference. This is the actual
  fix, not a claim about one filed elsewhere.)

## Out of scope, filed separately

Verifying this PR on the local `kanon gate` (verda) surfaced two pre-existing, unrelated
`kanon lint` findings on `origin/main` — confirmed present before this diff touched anything, and
untouched by it:

- #376 — `SHELL/unpinned-action` on the `hybrid-gate.yml@main` reference in this same file
  (`.github/workflows/gate-attestation.yml:106`), unpinned to a SHA. Pinning needs picking and
  verifying a specific upstream commit, a separate review from this concurrency fix.
- #377 — `OIKOS/private-content`: `CONTRIBUTING.md:8` and `:18` publish the internal `kanon.lan`
  forge hostname in a public repo's contributor doc. Unrelated file, unrelated to CI workflow
  shape; filed separately rather than expanding this PR's blast radius.

Between them, #377 is why the local `kanon gate` cannot currently produce a clean Gate-Passed
trailer for *any* PR to this repo, including this one — `kanon lint`'s two `OIKOS/private-content`
errors block the local gate regardless of what a PR touches. This PR relies on the GitHub Actions
required checks (`gate / full-gate-build`, `cargo audit`, `cargo deny`, `osv-scanner`,
`ai-attribution`, `check-trailer` — all green above) as the actual merge gate, per #262's own
"Done when": those are real, and #377 does not affect them.

Closes #262

