### PR TITLE
docs: derive mutable README facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Every tool for radio, mesh networking, spectrum monitoring, network security, or
 
 Akroasis is the attempt to fix that.
 
-One system. One signal model. The shared pipeline is designed for every domain to produce typed signals; today the live production `GeoSignal` producer is kerykeion mesh, while the remaining domains are planned or covered with synthetic pipeline tests. Radio anomalies correlate with network threats correlate with proximity intelligence correlate with OSINT. The convergence is where the intelligence lives - not in any single domain but in the relationships between them.
+One system. One signal model. The shared pipeline is designed for every domain to produce typed signals. Shipped crates define mesh collection and domain-agnostic processing components, but the application does not yet wire a live collector-to-semaino pipeline; remaining domains are planned or covered with synthetic pipeline tests. Radio anomalies correlate with network threats correlate with proximity intelligence correlate with OSINT. The convergence is where the intelligence lives - not in any single domain but in the relationships between them.
 
 Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, offensive security, signal intelligence, and geospatial modeling. Rust from the ground up. See the domain table below for shipped crates (✓) vs planned crates (◻).
 
@@ -18,11 +18,11 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 
 | Domain | Crate | Crate Shipped | Hardware Backend | What |
 |--------|-------|:-------------:|:----------------:|------|
-| **Application shell** | akroasis, akroasis-server | ✓ | ◻ | CLI binary + typed axum HTTP backend. Radio uses `StubHardware` by default; opt-in `hardware-serial` enables live detect. Mesh CLI is static/no-live-connection until daemon mode is implemented. |
+| **Application shell** | akroasis, akroasis-server | ✓ | △ | CLI binary + typed axum library routes. No server binary or desktop ships yet. Radio uses `StubHardware` by default; opt-in `hardware-serial` enables Baofeng detect/read/program/export sessions. Mesh CLI is static/no-live-connection until daemon mode is implemented. |
 | **Foundation** | koinon | ✓ |  -  | Shared IDs, coordinates, frequency and power types, 7-domain `GeoSignal` model, hardware asset registry, temporal baselines, and tamper-evident logging. |
 | **Foundation** | kryphos | ✓ |  -  | Credential vault and installation identity: fjall-backed encrypted storage, Argon2id derivation, ChaCha20-Poly1305 encryption, Ed25519 signing keys, rotation/revocation metadata, and mutation audit logging at `tamper.log` beside the vault store. |
-| **Radio Management** | syntonia | ✓ | ◻ | Frequency plans, CHIRP CSV/IMG import, CHIRP CSV export, validation, USB detection metadata, and Baofeng UV-5R-family codec. With `akroasis/hardware-serial`, `radio detect` uses live serial probing; read/program/export still require the future protocol session backend. |
-| **Mesh Networking** | kerykeion | ✓ | ✓ | Clean-room Meshtastic stack: protobuf framing, serial/TCP transports, handshake, encryption, node database, topology, discovery, routing, delivery tracking, store-and-forward, gateway bridge, and signal conversion. |
+| **Radio Management** | syntonia | ✓ | △ | Frequency plans, CHIRP CSV/IMG import, CHIRP CSV export, validation, USB detection metadata, and Baofeng UV-5R-family codec. With `akroasis/hardware-serial`, live Baofeng serial detect/read/program/export sessions ship; real-device verification and Yaesu protocol sessions remain incomplete. |
+| **Mesh Networking** | kerykeion | ✓ | △ | Meshtastic protocol stack implemented in this repository: protobuf framing, serial/TCP transports, handshake, encryption, node database, topology, discovery, routing, delivery tracking, store-and-forward, gateway bridge, and signal conversion. Real-device wire fixtures and live application wiring remain open. |
 | **Signal Processing** | semaino | ✓ |  -  | Signal aggregation, per-kind anomaly baselines, convergence detection, and deduplicated severity-classified alert pipeline. |
 | **SDR / Reception** | dektis | ◻ | ◻ | Future spectrum monitoring, FM/AM/SSB demodulation, protocol decoding (APRS, ADS-B, P25), jamming detection, direction finding, and emitter fingerprinting. |
 | **Proximity Intelligence** | engys | ◻ | ◻ | Future WiFi, BLE, Zigbee, Z-Wave, NFC, and RFID collection with presence analytics, rogue device detection, and counter-surveillance input. |
@@ -34,14 +34,9 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
 | **Navigation** | chorografia | ◻ | ◻ | Future RF propagation modeling, infrastructure graphs, offline OSM navigation, and space weather HF prediction. |
 | **Knowledge** | pinax | ◻ |  -  | Future offline repository for frequency databases, protocol specs, equipment manuals, topo maps, and indexed references. Target instance layout is documented in [docs/reference-store.md](docs/reference-store.md). |
 | **Privacy** | lethe | ◻ | ◻ | Future VPN/proxy management, anonymization, IMSI catcher detection, and OPSEC scoring. The etymological complement to [Aletheia](https://github.com/forkwright/aletheia). |
-| **Interface** | opsis | ◻ |  -  | Operator surfaces: desktop-first via theatron (akroasis-desktop). `akroasis-server` (shipped) provides the typed HTTP API (`/api/v1/*`) that the desktop and agent clients call. #118 resolved. |
+| **Interface** | opsis | ◻ |  -  | Operator surfaces are planned desktop-first via theatron. The shipped `akroasis-server` library provides routes intended for future desktop and agent clients; no server binary or desktop ships yet. #118 resolved. |
 
-**Legend:** ✓ = shipped in `crates/`, ◻ = planned/not shipped,  -  = not applicable.
-
-> **Snapshot 2026-05-04.** Workspace ships 6 crates under `crates/`: `akroasis`,
-> `kerykeion`, `koinon`, `kryphos`, `semaino`, and `syntonia`. The long-term
-> domains below are architectural targets, not claims of current crate or hardware
-> availability.
+**Legend:** ✓ = shipped in `crates/`, △ = implementation shipped but live-device verification or application wiring is incomplete, ◻ = planned/not shipped,  -  = not applicable.
 
 ---
 
@@ -62,7 +57,7 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
           ┌────────▼─────────┐         │  threat scoring)  │    ┌──────▼──────┐
           │ koinon           │         └──────────────────┘    │ opsis       │
           │ (signal model,   │                                  │ (operator   │
-          │  entity index,   │         ┌──────────────────┐    │  surfaces)  │
+          │  entity types,   │         ┌──────────────────┐    │  surfaces)  │
           │  temporal engine)│         │ chorografia      │    └─────────────┘
           │                  │         │ (geo, nav, RF    │
           │ kryphos          │         │  propagation)    │
@@ -75,17 +70,17 @@ Capability domains span radio, mesh, SDR, proximity, network defense, OSINT, off
           └──────────────────┘
 ```
 
-Every collection crate is expected to produce typed `GeoSignal` objects into koinon; the current live producer is kerykeion mesh. Semaino aggregates domain-agnostically, and its tests cover the full seven-domain signal model synthetically. Ichneutes analyzes domain-agnostically. Praxis acts. Opsis displays. Add a domain, add a crate - signals flow automatically once the collector exists.
+Every collection crate is expected to produce typed `GeoSignal` objects defined by koinon. Kerykeion implements mesh-to-signal conversion, while semaino provides domain-agnostic aggregation and synthetic coverage for the seven-domain signal model; neither is wired into a live application pipeline yet. Ichneutes, Praxis, and Opsis remain architectural targets. Add a domain, add a crate, then explicitly wire and verify the collector-to-processing path.
 
 ---
 
 ## Design constraints
 
-- **Standalone.** Runs without internet, without an LLM, without anything but the hardware in front of you. Grid-down capable.
-- **Sovereignty.** Every protocol owned. No cloud dependencies, no subscriptions, no external trust.
-- **Security default.** Encrypted by default. Unencrypted is the opt-in.
+- **Standalone target.** Designed to run without internet, an LLM, or anything beyond local hardware, including grid-down operation.
+- **Local control.** Protocol implementations live locally. No required cloud dependencies, subscriptions, or external trust anchors.
+- **Security default.** Credential data at rest is encrypted by default; authenticated and encrypted service transport remains planned.
 - **Auditable.** Credential vault mutations are recorded in a tamper-evident BLAKE3 hash-chain log beside the vault store. Broader action logging and evidence packaging are planned follow-ons.
-- **Reproducible deployment (planned).** NixOS flake + systemd unit hardening + declarative deployment is the intended target shape; no deployment artifacts ship today. Tracked in #125.
+- **Reproducible deployment (planned).** NixOS flake + systemd unit hardening + declarative deployment is the intended target shape; no deployment artifacts ship today.
 
 ---
 
@@ -94,17 +89,17 @@ Every collection crate is expected to produce typed `GeoSignal` objects into koi
 | Area | Current / Planned |
 |------|-------------------|
 | Language | Rust edition 2024, MSRV 1.85 |
-| Version | 0.1.11 workspace package version |
+| Version | Derived from [`workspace.package.version`](Cargo.toml) |
 | Errors | snafu context wrapping |
 | Async | tokio |
 | Storage | fjall for vault state; CBOR + BLAKE3 hash chains for tamper logs |
-| Mesh | Shipped: clean-room Meshtastic stack with prost protobuf, serial/TCP transports, AES-CTR channel crypto, routing, topology, and store-and-forward |
-| Radio | Shipped: frequency-plan model, validation, import/export, Baofeng UV-5R-family codec, and opt-in live serial detection through `akroasis/hardware-serial`; planned: live read/program/export protocol sessions beyond stub dispatch |
-| SDR | Planned: FutureSDR, FFT, RTL-SDR, and SoapySDR work will land with `dektis` |
+| Mesh | Shipped library: Meshtastic protocol stack implemented in this repository with prost protobuf, serial/TCP transports, AES-CTR channel crypto, routing, topology, and store-and-forward; real captured-frame compatibility and live application wiring remain unverified |
+| Radio | Shipped library and CLI: frequency-plan model, validation, import/export, Baofeng UV-5R-family codec, and opt-in Baofeng serial detect/read/program/export through `akroasis/hardware-serial`; real-device verification and Yaesu protocol sessions remain incomplete |
+| SDR | Planned: an operator-owned RTL-SDR V4 driver over `rusb` and an owned async DSP engine will land with `dektis` |
 | IDS/IPS | Planned: Suricata and Zeek orchestration will land with `aspis` |
 | Maps | Planned: OSM vector tiles and SRTM elevation will land with `chorografia` |
 | Search | Planned: full-text indexing will land with `pinax` |
-| Interfaces | Schema-versioned JSON is the canonical programmatic contract. CLI: `akroasis radio import --json`, `radio detect --json`, `radio export --json`, `mesh {status,nodes,topology} --json`, `vault list --json`, `vault identity --json`. HTTP: `akroasis-server` exposes `/api/v1/radio/detect`, `/api/v1/mesh/{status,nodes,topology}` with the same JSON schemas for durable clients. Interactive secret vault commands and planned placeholder domains remain TTY-only until their service surfaces ship. Desktop: desktop-first via theatron + akroasis-server (chalkeion Phase 6). |
+| Interfaces | Schema-versioned JSON is the canonical programmatic contract. CLI: `akroasis radio import --json`, `radio detect --json`, `radio export --json`, `mesh {status,nodes,topology} --json`, `vault list --json`, `vault identity --json`. HTTP: the `akroasis-server` library defines `/api/v1/radio/detect` and `/api/v1/mesh/{status,nodes,topology}` routes with the same JSON schemas, but no server binary or in-repo client ships. Interactive secret vault commands and planned placeholder domains remain TTY-only until their service surfaces ship. Desktop remains planned via theatron. |
 | License | AGPL-3.0-only |
 
 ---
@@ -121,15 +116,15 @@ Akroasis reads these environment variables at runtime; unset variables fall back
 
 ## Documentation
 
-- [standards/](standards/): Pointer to canonical kanon standards (STANDARDS.md, GNOMON.md, etc.)
+- [standards/README.md](standards/README.md): Pointer to the canonical Kanon standards
 - [docs/lexicon.md](docs/lexicon.md): Project name registry
 - [docs/reference-store.md](docs/reference-store.md): Target `/instance/reference/` layout for the planned pinax knowledge store
 
 ## Status
 
-**Phase 02 complete** (project state 2026-04-22). Kerykeion mesh networking fully landed and is the current live `GeoSignal` collector.
-For current planning and phase status, see
-[CLAUDE.md](CLAUDE.md) and the kanon planning substrate at `kanon:projects/akroasis/STATE.md`.
+Use this repository's releases and default branch for shipped status. Internal
+planning and work sequencing live in `forkwright/kanon` at
+`projects/akroasis/STATE.md` and require fleet access.
 
 The scope is massive. Each domain is independent: a crate with clear boundaries, producing typed signals into the shared model. Pieces don't need to arrive simultaneously. They just need to speak the same language when they do.
 
@@ -137,7 +132,7 @@ The scope is massive. Each domain is independent: a crate with clear boundaries,
 
 ## Hardware
 
-Developed against:
+Hardware targets; shipped support varies by the capability table above:
 
 - **SDR:** RTL-SDR Blog V4, HackRF One
 - **Mesh:** Lilygo T-Echo, T-Deck Plus, RAK Pi HAT gateway, WisBlock
@@ -155,7 +150,7 @@ Hardware support is additive: if it speaks serial, USB, or IP, it can be integra
 
 Names follow the project naming philosophy, where each name reveals its essential nature across four layers of reading.
 
-**Lethe** (λήθη) and **Aletheia** (ἀ-λήθεια) share the same root. One unconceals truth. The other conceals the operator. Same word, opposite directions. Two systems, one for understanding and one for sovereignty, and the Greek already knew they were the same thing.
+**Lethe** (λήθη) and **Aletheia** (ἀ-λήθεια) share the same root. One unconceals truth. The other conceals the operator. Same word, opposite directions: one system supports understanding while the other protects operational privacy.
 
 ---
 


### PR DESCRIPTION
## Summary

- remove dated workspace crate, version, and phase snapshots in favor of derived sources
- distinguish shipped libraries and feature-gated Baofeng sessions from unverified live-device and application wiring
- correct interface, security, SDR, standards, and hardware-target descriptions

## Verification

- `git diff --check`
- `kanon gate --tier nobuild --git-diff origin/main .` — passed: fmt and diff-scoped Kanon lint, 0 findings
- No local Rust build: Akroasis is public and docs-only GitHub CI is authoritative
- Full unscoped `kanon lint . --all` remains red on 25 pre-existing warnings outside this README diff; it is not claimed as passed, and #377 remains open

Refs #116.

This does not close #116; STATE and `_llm/current_state.toml` remain separate work. Real captured-frame acceptance remains tracked by #388.