### PR TITLE
feat(security): add validated caller contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "syn 2.0.117",
  "syntonia",
  "tempfile",
  "tokio",

--- a/crates/akroasis/Cargo.toml
+++ b/crates/akroasis/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+syn = { version = "2", features = ["full", "visit"] }
 
 [lints]
 workspace = true

--- a/crates/akroasis/src/caller.rs
+++ b/crates/akroasis/src/caller.rs
@@ -1,0 +1,606 @@
+//! Application caller resolution and audit-before-effect execution.
+//!
+//! This module adapts authenticated transport evidence into the shared
+//! `koinon` contract. It owns no credential store and does not implement any
+//! domain-specific effect or policy.
+
+use std::fmt;
+
+use koinon::{
+    AuthorizationDenial, AuthorizationRequirement, CALLER_RESOLVER_VERSION, CallerAuthority,
+    CallerContractError, CallerRef, CallerResolver, EffectDescriptor, EffectOutcome, EffectReceipt,
+    EffectReceiptError, EffectReceiptSink, EvidenceDigest, LocalPeerCredentials, PersistedIntent,
+    PersistedOutcome, ReceiptDigest, RecoveryAuthorization, RecoveryTicket, RevocationState,
+    Timestamp, ValidatedCaller, authorize_caller,
+};
+use snafu::{ResultExt, Snafu};
+use tokio::net::UnixStream;
+
+/// Version of accepted service-identity evidence.
+pub const SERVICE_IDENTITY_EVIDENCE_VERSION: u16 = 1;
+
+/// Time source used by caller resolution and effect-time authorization.
+pub trait TrustedClock {
+    /// Return the current trusted UTC timestamp.
+    fn now(&self) -> Timestamp;
+}
+
+/// Production wall-clock source.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl TrustedClock for SystemClock {
+    // kanon:ignore ARCHITECTURE/trait-impl-colocation -- built-in wall clock is the production adapter; consumers inject fake clocks
+    fn now(&self) -> Timestamp {
+        Timestamp::now()
+    }
+}
+
+/// Authenticated nonlocal service evidence accepted by the application.
+///
+/// Fields are private and the type is not deserializable, so a request cannot
+/// turn an address, header, or replayed JSON object into caller authority. A
+/// future accepted Phase 05 authenticator will own production construction.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthenticatedServiceIdentity {
+    schema_version: u16,
+    identity_ref: CallerRef,
+    authenticated_at: Timestamp,
+    expires_at: Timestamp,
+    revocation: RevocationState,
+}
+
+impl fmt::Debug for AuthenticatedServiceIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthenticatedServiceIdentity")
+            .field("schema_version", &self.schema_version)
+            .field("authenticated_at", &self.authenticated_at)
+            .field("expires_at", &self.expires_at)
+            .field("revocation", &self.revocation)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Application resolver over one trusted ACL/service authority adapter.
+///
+/// The shared resolver constructs the opaque caller type. This wrapper obtains
+/// kernel peer credentials and rejects unauthenticated network callers first.
+#[derive(Debug)]
+pub struct ApplicationCallerResolver<A> {
+    shared: CallerResolver<A>,
+}
+
+impl<A> ApplicationCallerResolver<A>
+where
+    A: CallerAuthority,
+{
+    /// Construct the current application resolver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApplicationCallerError`] when the resolver version is not
+    /// understood.
+    pub fn try_new(resolver_version: u16, authority: A) -> Result<Self, ApplicationCallerError> {
+        let shared =
+            CallerResolver::try_new(resolver_version, authority).context(CallerResolutionSnafu)?;
+        Ok(Self { shared })
+    }
+
+    /// Construct the resolver at the current known version.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApplicationCallerError`] if shared resolver construction
+    /// unexpectedly fails.
+    pub fn current(authority: A) -> Result<Self, ApplicationCallerError> {
+        Self::try_new(CALLER_RESOLVER_VERSION, authority)
+    }
+
+    /// Resolve a local caller from kernel-authenticated Unix peer credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApplicationCallerError`] when peer credentials cannot be
+    /// obtained or the authority does not grant a current caller.
+    pub fn resolve_local<C>(
+        &self,
+        stream: &UnixStream,
+        clock: &C,
+    ) -> Result<ValidatedCaller, ApplicationCallerError>
+    where
+        C: TrustedClock,
+    {
+        let credentials = stream.peer_cred().context(PeerCredentialsSnafu)?;
+        let pid = credentials
+            .pid()
+            .map(u32::try_from)
+            .transpose()
+            .context(InvalidPeerPidSnafu)?;
+        let peer = LocalPeerCredentials::from_os_peer(credentials.uid(), credentials.gid(), pid);
+        self.shared
+            .resolve_local(peer, clock.now())
+            .context(CallerResolutionSnafu)
+    }
+
+    /// Resolve a nonlocal caller from accepted service-identity evidence.
+    ///
+    /// Passing `None` represents a network address, including loopback,
+    /// without authenticated identity and always fails closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApplicationCallerError`] when evidence is absent, unknown,
+    /// future-issued, expired, revoked, mismatched, or rejected.
+    pub fn resolve_service<C>(
+        &self,
+        identity: Option<&AuthenticatedServiceIdentity>,
+        clock: &C,
+    ) -> Result<ValidatedCaller, ApplicationCallerError>
+    where
+        C: TrustedClock,
+    {
+        let identity = identity.ok_or(ApplicationCallerError::LoopbackIsNotIdentity {
+            location: snafu::location!(),
+        })?;
+        if identity.schema_version != SERVICE_IDENTITY_EVIDENCE_VERSION {
+            return Err(ApplicationCallerError::UnknownServiceIdentityVersion {
+                schema_version: identity.schema_version,
+                location: snafu::location!(),
+            });
+        }
+        if identity.revocation != RevocationState::Active {
+            return Err(ApplicationCallerError::ServiceIdentityRevoked {
+                location: snafu::location!(),
+            });
+        }
+        let observed_at = clock.now();
+        if observed_at < identity.authenticated_at {
+            return Err(ApplicationCallerError::ServiceIdentityNotYetValid {
+                location: snafu::location!(),
+            });
+        }
+        if observed_at >= identity.expires_at {
+            return Err(ApplicationCallerError::ServiceIdentityExpired {
+                location: snafu::location!(),
+            });
+        }
+        self.shared
+            .resolve_service(
+                identity.identity_ref,
+                identity.authenticated_at,
+                identity.expires_at,
+                observed_at,
+            )
+            .context(CallerResolutionSnafu)
+    }
+}
+
+/// Immutable request needed to authorize and record one protected effect.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EffectRequest {
+    requirement: AuthorizationRequirement,
+    descriptor: EffectDescriptor,
+}
+
+impl EffectRequest {
+    /// Construct one protected effect request.
+    #[must_use]
+    pub const fn new(requirement: AuthorizationRequirement, descriptor: EffectDescriptor) -> Self {
+        Self {
+            requirement,
+            descriptor,
+        }
+    }
+}
+
+/// Injected bounded-queue and cancellation decision made before domain I/O.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionDecision {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed admission state prevents silent effect execution on unknown states
+    /// The effect may be invoked after durable intent.
+    Ready,
+    /// Cancellation was observed before domain I/O.
+    Cancelled,
+    /// A declared resource budget refused admission.
+    Backpressured,
+}
+
+/// Closed result returned by an invoked fake or domain effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectExecution {
+    outcome: EffectOutcome,
+    evidence_digest: Option<EvidenceDigest>,
+}
+
+impl EffectExecution {
+    /// Record a successful domain effect.
+    #[must_use]
+    pub const fn succeeded(evidence_digest: Option<EvidenceDigest>) -> Self {
+        Self {
+            outcome: EffectOutcome::Succeeded,
+            evidence_digest,
+        }
+    }
+
+    /// Record a failed effect with no committed state change.
+    #[must_use]
+    pub const fn failed(evidence_digest: Option<EvidenceDigest>) -> Self {
+        Self {
+            outcome: EffectOutcome::Failed,
+            evidence_digest,
+        }
+    }
+
+    /// Record a partially committed effect that requires recovery.
+    #[must_use]
+    pub const fn partial(evidence_digest: Option<EvidenceDigest>) -> Self {
+        Self {
+            outcome: EffectOutcome::Partial,
+            evidence_digest,
+        }
+    }
+}
+
+/// Terminal state returned only after its outcome receipt was appended.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EffectCompletion {
+    outcome: EffectOutcome,
+    receipt_digest: ReceiptDigest,
+    recovery: Option<RecoveryAuthorization>,
+}
+
+impl EffectCompletion {
+    /// Return the recorded terminal or partial outcome.
+    #[must_use]
+    pub const fn outcome(&self) -> EffectOutcome {
+        self.outcome
+    }
+
+    /// Return the canonical durable outcome-receipt digest.
+    #[must_use]
+    pub const fn receipt_digest(&self) -> ReceiptDigest {
+        self.receipt_digest
+    }
+
+    /// Consume the completion and return explicit recovery authority, if the
+    /// persisted outcome requires it.
+    #[must_use]
+    pub const fn into_recovery(self) -> Option<RecoveryAuthorization> {
+        self.recovery
+    }
+}
+
+/// Resolve current authorization, append intent, invoke once, and append outcome.
+///
+/// The effect closure is not called on denial, intent-audit failure,
+/// cancellation, or backpressure. No reusable permit escapes this function.
+///
+/// # Errors
+///
+/// Returns [`EffectGateError`] for a typed denial, receipt-contract failure,
+/// or durable append failure. A post-intent failure carries a restart-safe
+/// recovery ticket and never reports success.
+pub fn execute_effect<S, C, F>(
+    caller: Option<&ValidatedCaller>,
+    request: EffectRequest,
+    clock: &C,
+    admission: AdmissionDecision,
+    sink: &mut S,
+    effect: F,
+) -> Result<EffectCompletion, EffectGateError<S::Error>>
+where
+    S: EffectReceiptSink,
+    C: TrustedClock,
+    F: FnOnce() -> EffectExecution,
+{
+    let EffectRequest {
+        requirement,
+        descriptor,
+    } = request;
+    let authorized_at = clock.now();
+    let authorized = authorize_caller(caller, &requirement, authorized_at).map_err(|denial| {
+        EffectGateError::Denied {
+            denial,
+            location: snafu::location!(),
+        }
+    })?;
+    let pending = EffectReceipt::intent(authorized, descriptor, authorized_at)
+        .context(ReceiptContractSnafu)?;
+    let persisted = pending
+        .append_to(sink)
+        .map_err(|source| EffectGateError::IntentAudit {
+            source,
+            location: snafu::location!(),
+        })?;
+
+    let effect_time = clock.now();
+    let effect_authorization = if effect_time < authorized_at {
+        Err(AuthorizationDenial::ClockRegression)
+    } else {
+        authorize_caller(caller, &requirement, effect_time)
+    };
+    if let Err(denial) = effect_authorization {
+        let denial_observed_at = std::cmp::max(effect_time, authorized_at);
+        let denied = append_effect_outcome(
+            persisted,
+            denial_observed_at,
+            EffectExecution {
+                outcome: EffectOutcome::AuthorizationDenied,
+                evidence_digest: None,
+            },
+            sink,
+        )?;
+        let receipt_digest = denied.digest();
+        let recovery = if outcome_needs_recovery(
+            EffectOutcome::AuthorizationDenied,
+            denied.receipt().recovery(),
+        ) {
+            Some(Box::new(
+                denied
+                    .into_recovery_authorization()
+                    .context(ReceiptContractSnafu)?,
+            ))
+        } else {
+            None
+        };
+        return Err(EffectGateError::PostIntentDenied {
+            denial,
+            receipt_digest,
+            recovery,
+            location: snafu::location!(),
+        });
+    }
+
+    let execution = match admission {
+        AdmissionDecision::Ready => effect(),
+        AdmissionDecision::Cancelled => EffectExecution {
+            outcome: EffectOutcome::Cancelled,
+            evidence_digest: None,
+        },
+        AdmissionDecision::Backpressured => EffectExecution {
+            outcome: EffectOutcome::Backpressured,
+            evidence_digest: None,
+        },
+    };
+    let persisted_outcome = append_effect_outcome(persisted, clock.now(), execution, sink)?;
+    completion_from_persisted(persisted_outcome)
+}
+
+fn append_effect_outcome<S>(
+    persisted: PersistedIntent,
+    observed_at: Timestamp,
+    execution: EffectExecution,
+    sink: &mut S,
+) -> Result<PersistedOutcome, EffectGateError<S::Error>>
+where
+    S: EffectReceiptSink,
+{
+    let pending = persisted
+        .outcome(observed_at, execution.outcome, execution.evidence_digest)
+        .map_err(|error| {
+            let (source, recovery) = error.into_parts();
+            EffectGateError::PostIntentContract {
+                source,
+                recovery,
+                location: snafu::location!(),
+            }
+        })?;
+    pending.append_to(sink).map_err(|error| {
+        let (source, recovery) = error.into_parts();
+        EffectGateError::OutcomeAudit {
+            source,
+            recovery,
+            location: snafu::location!(),
+        }
+    })
+}
+
+fn completion_from_persisted<E>(
+    persisted_outcome: PersistedOutcome,
+) -> Result<EffectCompletion, EffectGateError<E>>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let recorded_outcome = persisted_outcome.outcome().context(ReceiptContractSnafu)?;
+    let receipt_digest = persisted_outcome.digest();
+    let recovery_relation = persisted_outcome.receipt().recovery();
+    let recovery = if outcome_needs_recovery(recorded_outcome, recovery_relation) {
+        Some(
+            persisted_outcome
+                .into_recovery_authorization()
+                .context(ReceiptContractSnafu)?,
+        )
+    } else {
+        None
+    };
+
+    Ok(EffectCompletion {
+        outcome: recorded_outcome,
+        receipt_digest,
+        recovery,
+    })
+}
+
+const fn outcome_needs_recovery(
+    outcome: EffectOutcome,
+    recovery: koinon::RecoveryRelation,
+) -> bool {
+    matches!(
+        (outcome, recovery),
+        (
+            EffectOutcome::Partial | EffectOutcome::RecoveryRequired,
+            koinon::RecoveryRelation::RequiredFor(_)
+        ) | (
+            EffectOutcome::Failed
+                | EffectOutcome::Cancelled
+                | EffectOutcome::Backpressured
+                | EffectOutcome::AuthorizationDenied,
+            koinon::RecoveryRelation::RecoveryOf(_)
+        )
+    )
+}
+
+/// Errors from application caller resolution.
+#[derive(Snafu)]
+#[non_exhaustive]
+pub enum ApplicationCallerError {
+    /// Kernel peer credentials could not be read from the Unix socket.
+    #[snafu(display("failed to read local peer credentials: {source}"))]
+    PeerCredentials {
+        /// Operating-system error.
+        source: std::io::Error,
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Kernel returned a peer PID outside the shared contract.
+    #[snafu(display("local peer PID is outside the supported range: {source}"))]
+    InvalidPeerPid {
+        /// Integer conversion failure.
+        source: std::num::TryFromIntError,
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A network address was presented without authenticated service identity.
+    #[snafu(display("loopback or network address is not caller identity"))]
+    LoopbackIsNotIdentity {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service evidence used an unknown schema version.
+    #[snafu(display("unknown service identity schema version {schema_version}"))]
+    UnknownServiceIdentityVersion {
+        /// Unsupported service-evidence version.
+        schema_version: u16,
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service identity evidence is not yet valid.
+    #[snafu(display("service identity evidence is not yet valid"))]
+    ServiceIdentityNotYetValid {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service identity evidence was revoked.
+    #[snafu(display("service identity evidence is revoked"))]
+    ServiceIdentityRevoked {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service identity evidence expired.
+    #[snafu(display("service identity evidence is expired"))]
+    ServiceIdentityExpired {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Shared resolver rejected the authority decision.
+    #[snafu(display("caller resolution failed: {source}"))]
+    CallerResolution {
+        /// Shared caller-contract failure.
+        source: CallerContractError,
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+impl fmt::Debug for ApplicationCallerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::PeerCredentials { .. } => "ApplicationCallerError::PeerCredentials",
+            Self::InvalidPeerPid { .. } => "ApplicationCallerError::InvalidPeerPid",
+            Self::LoopbackIsNotIdentity { .. } => "ApplicationCallerError::LoopbackIsNotIdentity",
+            Self::UnknownServiceIdentityVersion { .. } => {
+                "ApplicationCallerError::UnknownServiceIdentityVersion"
+            }
+            Self::ServiceIdentityNotYetValid { .. } => {
+                "ApplicationCallerError::ServiceIdentityNotYetValid"
+            }
+            Self::ServiceIdentityRevoked { .. } => "ApplicationCallerError::ServiceIdentityRevoked",
+            Self::ServiceIdentityExpired { .. } => "ApplicationCallerError::ServiceIdentityExpired",
+            Self::CallerResolution { .. } => "ApplicationCallerError::CallerResolution",
+        })
+    }
+}
+
+/// Failure to authorize, invoke, or durably record a protected effect.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum EffectGateError<E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    /// Immediate caller authorization failed before intent or effect.
+    #[snafu(display("effect authorization denied: {denial}"))]
+    Denied {
+        /// Exact fail-closed authorization reason.
+        denial: AuthorizationDenial,
+        /// Source location of the denied request.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Receipt construction failed before the effect ran.
+    #[snafu(display("effect receipt contract failed: {source}"))]
+    ReceiptContract {
+        /// Shared receipt-contract error.
+        source: EffectReceiptError,
+        /// Source location of the invalid receipt.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Durable intent append failed, so no effect ran.
+    #[snafu(display("effect intent append failed: {source}"))]
+    IntentAudit {
+        /// Accepted receipt-sink failure.
+        source: E,
+        /// Source location of the failed append.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Authorization lapsed after durable intent and the no-effect outcome
+    /// was durably recorded.
+    #[snafu(display("effect authorization lapsed after durable intent: {denial}"))]
+    PostIntentDenied {
+        /// Exact effect-time denial.
+        denial: AuthorizationDenial,
+        /// Durable no-effect outcome receipt.
+        receipt_digest: ReceiptDigest,
+        /// Continuation authority when the denied intent was itself recovery.
+        recovery: Option<Box<RecoveryAuthorization>>,
+        /// Source location of the denied execution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A contract failure occurred after intent and requires reconciliation.
+    #[snafu(display("post-intent receipt contract failed: {source}"))]
+    PostIntentContract {
+        /// Shared receipt-contract error.
+        source: EffectReceiptError,
+        /// Restart-safe reconciliation ticket.
+        recovery: Box<RecoveryTicket>,
+        /// Source location of the failed transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Outcome append failed after intent and possibly effect execution.
+    #[snafu(display("effect outcome append failed: {source}"))]
+    OutcomeAudit {
+        /// Accepted receipt-sink failure.
+        source: E,
+        /// Restart-safe reconciliation ticket.
+        recovery: Box<RecoveryTicket>,
+        /// Source location of the failed append.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+#[cfg(test)]
+#[path = "caller_tests.rs"]
+mod tests;

--- a/crates/akroasis/src/caller_tests.rs
+++ b/crates/akroasis/src/caller_tests.rs
@@ -1,0 +1,261 @@
+//! Application caller-boundary unit fixtures.
+
+#![expect(
+    clippy::expect_used,
+    reason = "fixed service-boundary fixtures use checked constructors"
+)]
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use koinon::{
+    AuthorityClaims, AuthorityDecision, AuthorityGrant, AuthorizationDenial,
+    AuthorizationRequirement, CALLER_CONTEXT_VERSION, CallerContractError, CapabilityRef,
+    PersonaRef, PolicyEpoch, PrincipalSource, ScopeRef, authorize_caller,
+};
+
+use super::*;
+
+impl AuthenticatedServiceIdentity {
+    fn for_test(
+        schema_version: u16,
+        identity_ref: CallerRef,
+        authenticated_at: Timestamp,
+        expires_at: Timestamp,
+        revocation: RevocationState,
+    ) -> Self {
+        Self {
+            schema_version,
+            identity_ref,
+            authenticated_at,
+            expires_at,
+            revocation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FixedClock(Timestamp);
+
+impl TrustedClock for FixedClock {
+    fn now(&self) -> Timestamp {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ServiceMode {
+    Granted,
+    ReferenceMismatch,
+    TimeMismatch,
+    ExpiryMismatch,
+}
+
+#[derive(Debug)]
+struct ServiceAuthority {
+    mode: ServiceMode,
+    calls: Rc<Cell<usize>>,
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+}
+
+impl CallerAuthority for ServiceAuthority {
+    fn resolve_local(
+        &self,
+        _peer: LocalPeerCredentials,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        AuthorityDecision::UnknownIdentity
+    }
+
+    fn resolve_service(
+        &self,
+        identity_ref: CallerRef,
+        authenticated_at: Timestamp,
+        _evidence_expires_at: Timestamp,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        self.calls.set(self.calls.get() + 1);
+        let caller_ref = if matches!(self.mode, ServiceMode::ReferenceMismatch) {
+            CallerRef::from_canonical(b"different-service")
+        } else {
+            identity_ref
+        };
+        let claim_time = if matches!(self.mode, ServiceMode::TimeMismatch) {
+            timestamp(1_100)
+        } else {
+            authenticated_at
+        };
+        let claims_expires_at = if matches!(self.mode, ServiceMode::ExpiryMismatch) {
+            timestamp(4_000)
+        } else {
+            timestamp(3_000)
+        };
+        let claims = AuthorityClaims::builder()
+            .schema_version(CALLER_CONTEXT_VERSION)
+            .caller_ref(caller_ref)
+            .grant(self.grant)
+            .policy_epoch(self.policy_epoch)
+            .validity(claim_time, timestamp(2_000), claims_expires_at)
+            .persona(PersonaRef::from_canonical(b"service-persona"))
+            .build()
+            .expect("valid service authority claims");
+        AuthorityDecision::Granted(claims)
+    }
+}
+
+fn timestamp(millis: i64) -> Timestamp {
+    Timestamp::from_unix_millis(millis).expect("valid fixed timestamp")
+}
+
+fn resolver(mode: ServiceMode) -> (ApplicationCallerResolver<ServiceAuthority>, Rc<Cell<usize>>) {
+    let calls = Rc::new(Cell::new(0));
+    let authority = ServiceAuthority {
+        mode,
+        calls: Rc::clone(&calls),
+        grant: AuthorityGrant::new(
+            CapabilityRef::from_canonical(b"service.read"),
+            ScopeRef::from_canonical(b"service.scope"),
+        ),
+        policy_epoch: PolicyEpoch::try_from_u64(4).expect("test policy epoch"),
+    };
+    (
+        ApplicationCallerResolver::current(authority).expect("current resolver"),
+        calls,
+    )
+}
+
+fn evidence(
+    schema_version: u16,
+    authenticated_at: Timestamp,
+    expires_at: Timestamp,
+    revocation: RevocationState,
+) -> AuthenticatedServiceIdentity {
+    AuthenticatedServiceIdentity::for_test(
+        schema_version,
+        CallerRef::from_canonical(b"accepted-service"),
+        authenticated_at,
+        expires_at,
+        revocation,
+    )
+}
+
+#[test]
+fn service_evidence_fails_closed_before_authority_lookup() {
+    let (resolver, calls) = resolver(ServiceMode::Granted);
+    let clock = FixedClock(timestamp(1_500));
+    assert!(
+        matches!(
+            resolver.resolve_service(None, &clock),
+            Err(ApplicationCallerError::LoopbackIsNotIdentity { .. })
+        ),
+        "loopback without identity must fail closed"
+    );
+    assert_eq!(calls.get(), 0, "loopback must not consult authority");
+
+    for identity in [
+        evidence(
+            SERVICE_IDENTITY_EVIDENCE_VERSION + 1,
+            timestamp(1_000),
+            timestamp(3_000),
+            RevocationState::Active,
+        ),
+        evidence(
+            SERVICE_IDENTITY_EVIDENCE_VERSION,
+            timestamp(1_600),
+            timestamp(3_000),
+            RevocationState::Active,
+        ),
+        evidence(
+            SERVICE_IDENTITY_EVIDENCE_VERSION,
+            timestamp(1_000),
+            timestamp(1_500),
+            RevocationState::Active,
+        ),
+        evidence(
+            SERVICE_IDENTITY_EVIDENCE_VERSION,
+            timestamp(1_000),
+            timestamp(3_000),
+            RevocationState::Revoked,
+        ),
+    ] {
+        assert!(
+            resolver.resolve_service(Some(&identity), &clock).is_err(),
+            "invalid service evidence must fail closed"
+        );
+    }
+    assert_eq!(
+        calls.get(),
+        0,
+        "invalid evidence must fail before authority lookup"
+    );
+}
+
+#[test]
+fn service_claims_bind_to_authenticated_identity_and_time() {
+    let identity = evidence(
+        SERVICE_IDENTITY_EVIDENCE_VERSION,
+        timestamp(1_000),
+        timestamp(3_000),
+        RevocationState::Active,
+    );
+    let clock = FixedClock(timestamp(1_500));
+
+    let (resolver, calls) = resolver(ServiceMode::Granted);
+    let caller = resolver
+        .resolve_service(Some(&identity), &clock)
+        .expect("accepted service caller");
+    assert_eq!(caller.source(), PrincipalSource::ServiceIdentity);
+    assert_eq!(
+        caller.expires_at(),
+        identity.expires_at,
+        "caller validity must not outlive accepted service evidence"
+    );
+    let requirement =
+        AuthorizationRequirement::new(caller.grant(), caller.policy_epoch(), caller.persona());
+    assert_eq!(
+        authorize_caller(Some(&caller), &requirement, identity.expires_at),
+        Err(AuthorizationDenial::Expired),
+        "service caller must fail at the evidence expiry boundary"
+    );
+    assert_eq!(calls.get(), 1, "authority should be consulted once");
+
+    let (resolver, _) = resolver(ServiceMode::ReferenceMismatch);
+    let result = resolver.resolve_service(Some(&identity), &clock);
+    assert!(
+        matches!(
+            result,
+            Err(ApplicationCallerError::CallerResolution {
+                source: CallerContractError::IdentityReferenceMismatch { .. },
+                ..
+            })
+        ),
+        "service claims cannot substitute another identity"
+    );
+
+    let (resolver, _) = resolver(ServiceMode::TimeMismatch);
+    let result = resolver.resolve_service(Some(&identity), &clock);
+    assert!(
+        matches!(
+            result,
+            Err(ApplicationCallerError::CallerResolution {
+                source: CallerContractError::ServiceAuthenticationTimeMismatch { .. },
+                ..
+            })
+        ),
+        "service claims cannot backdate authentication"
+    );
+
+    let (resolver, _) = resolver(ServiceMode::ExpiryMismatch);
+    let result = resolver.resolve_service(Some(&identity), &clock);
+    assert!(
+        matches!(
+            result,
+            Err(ApplicationCallerError::CallerResolution {
+                source: CallerContractError::ServiceEvidenceExpiryMismatch { .. },
+                ..
+            })
+        ),
+        "service claims cannot outlive accepted identity evidence"
+    );
+}

--- a/crates/akroasis/src/caller_tests.rs
+++ b/crates/akroasis/src/caller_tests.rs
@@ -201,8 +201,8 @@ fn service_claims_bind_to_authenticated_identity_and_time() {
     );
     let clock = FixedClock(timestamp(1_500));
 
-    let (resolver, calls) = resolver(ServiceMode::Granted);
-    let caller = resolver
+    let (granted_resolver, calls) = resolver(ServiceMode::Granted);
+    let caller = granted_resolver
         .resolve_service(Some(&identity), &clock)
         .expect("accepted service caller");
     assert_eq!(caller.source(), PrincipalSource::ServiceIdentity);
@@ -220,8 +220,8 @@ fn service_claims_bind_to_authenticated_identity_and_time() {
     );
     assert_eq!(calls.get(), 1, "authority should be consulted once");
 
-    let (resolver, _) = resolver(ServiceMode::ReferenceMismatch);
-    let result = resolver.resolve_service(Some(&identity), &clock);
+    let (reference_mismatch_resolver, _) = resolver(ServiceMode::ReferenceMismatch);
+    let result = reference_mismatch_resolver.resolve_service(Some(&identity), &clock);
     assert!(
         matches!(
             result,
@@ -233,8 +233,8 @@ fn service_claims_bind_to_authenticated_identity_and_time() {
         "service claims cannot substitute another identity"
     );
 
-    let (resolver, _) = resolver(ServiceMode::TimeMismatch);
-    let result = resolver.resolve_service(Some(&identity), &clock);
+    let (time_mismatch_resolver, _) = resolver(ServiceMode::TimeMismatch);
+    let result = time_mismatch_resolver.resolve_service(Some(&identity), &clock);
     assert!(
         matches!(
             result,
@@ -246,8 +246,8 @@ fn service_claims_bind_to_authenticated_identity_and_time() {
         "service claims cannot backdate authentication"
     );
 
-    let (resolver, _) = resolver(ServiceMode::ExpiryMismatch);
-    let result = resolver.resolve_service(Some(&identity), &clock);
+    let (expiry_mismatch_resolver, _) = resolver(ServiceMode::ExpiryMismatch);
+    let result = expiry_mismatch_resolver.resolve_service(Some(&identity), &clock);
     assert!(
         matches!(
             result,

--- a/crates/akroasis/src/lib.rs
+++ b/crates/akroasis/src/lib.rs
@@ -8,6 +8,7 @@
     reason = "command modules pre-date the lib target; doc coverage deferred to API stabilisation"
 )]
 
+pub mod caller;
 pub mod mesh;
 pub mod radio;
 pub mod vault;

--- a/crates/akroasis/tests/caller_architecture.rs
+++ b/crates/akroasis/tests/caller_architecture.rs
@@ -75,7 +75,7 @@ fn restricted_identifiers(source: &str) -> BTreeSet<String> {
 
 #[test]
 fn caller_construction_aliases_are_detected() {
-    let source = r#"
+    let source = r"
         use koinon::{
             AuthorityClaimsBuilder as Claims,
             CallerAuthority as Authority,
@@ -86,7 +86,7 @@ fn caller_construction_aliases_are_detected() {
             let _claims = Claims::new();
             let _resolver = Resolver::<A>::try_new(1, authority);
         }
-    "#;
+    ";
     assert_eq!(
         restricted_identifiers(source),
         BTreeSet::from([

--- a/crates/akroasis/tests/caller_architecture.rs
+++ b/crates/akroasis/tests/caller_architecture.rs
@@ -37,13 +37,27 @@ impl<'ast> Visit<'ast> for RestrictedUse {
     }
 
     fn visit_macro(&mut self, node: &'ast syn::Macro) {
-        for token in node
-            .tokens
-            .to_string()
-            .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
-        {
-            if RESTRICTED.contains(&token) {
-                self.identifiers.insert(token.to_owned());
+        // WHY: a macro body is opaque to `syn`, so the token scan below matches a restricted
+        // name anywhere in it — including inside a string literal, which names an identifier
+        // without using one. Parse the body as expressions first so literals are seen as
+        // literals, and fall back to the scan only for bodies that are not expression lists.
+        if let Ok(arguments) = node.parse_body_with(
+            syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+        ) {
+            let mut parsed = Self::default();
+            for argument in &arguments {
+                parsed.visit_expr(argument);
+            }
+            self.identifiers.extend(parsed.identifiers);
+        } else {
+            for token in node
+                .tokens
+                .to_string()
+                .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+            {
+                if RESTRICTED.contains(&token) {
+                    self.identifiers.insert(token.to_owned());
+                }
             }
         }
         visit::visit_macro(self, node);
@@ -95,6 +109,21 @@ fn caller_construction_aliases_are_detected() {
             "CallerResolver".to_owned(),
         ]),
         "renamed imports and turbofish calls must not bypass the boundary"
+    );
+}
+
+#[test]
+fn quoted_restricted_names_inside_macros_are_not_uses() {
+    let source = r#"
+        fn describe() {
+            assert_eq!(actual, expected, "CallerResolver must never be minted here");
+            println!("{}", CallerAuthority::describe());
+        }
+    "#;
+    assert_eq!(
+        restricted_identifiers(source),
+        BTreeSet::from(["CallerAuthority".to_owned()]),
+        "a quoted name names an identifier without using one, while a path inside a macro is a use"
     );
 }
 

--- a/crates/akroasis/tests/caller_architecture.rs
+++ b/crates/akroasis/tests/caller_architecture.rs
@@ -1,0 +1,153 @@
+//! Semantic architecture guard for the application-owned caller resolver.
+
+#![expect(
+    clippy::expect_used,
+    reason = "workspace architecture fixtures fail immediately on unreadable Rust source"
+)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use syn::visit::{self, Visit};
+
+const RESTRICTED: [&str; 6] = [
+    "ApplicationCallerResolver",
+    "AuthorityClaims",
+    "AuthorityClaimsBuilder",
+    "AuthorityDecision",
+    "CallerAuthority",
+    "CallerResolver",
+];
+
+#[derive(Default)]
+struct RestrictedUse {
+    identifiers: BTreeSet<String>,
+}
+
+impl<'ast> Visit<'ast> for RestrictedUse {
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        for segment in &path.segments {
+            let identifier = segment.ident.to_string();
+            if RESTRICTED.contains(&identifier.as_str()) {
+                self.identifiers.insert(identifier);
+            }
+        }
+        visit::visit_path(self, path);
+    }
+
+    fn visit_macro(&mut self, node: &'ast syn::Macro) {
+        for token in node
+            .tokens
+            .to_string()
+            .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+        {
+            if RESTRICTED.contains(&token) {
+                self.identifiers.insert(token.to_owned());
+            }
+        }
+        visit::visit_macro(self, node);
+    }
+
+    fn visit_use_tree(&mut self, node: &'ast syn::UseTree) {
+        let identifier = match node {
+            syn::UseTree::Name(name) => Some(&name.ident),
+            syn::UseTree::Rename(rename) => Some(&rename.ident),
+            syn::UseTree::Path(path) => Some(&path.ident),
+            syn::UseTree::Glob(_) | syn::UseTree::Group(_) => None,
+        };
+        if let Some(identifier) = identifier {
+            let identifier = identifier.to_string();
+            if RESTRICTED.contains(&identifier.as_str()) {
+                self.identifiers.insert(identifier);
+            }
+        }
+        visit::visit_use_tree(self, node);
+    }
+}
+
+fn restricted_identifiers(source: &str) -> BTreeSet<String> {
+    let syntax = syn::parse_file(source).expect("parse Rust source fixture");
+    let mut visitor = RestrictedUse::default();
+    visitor.visit_file(&syntax);
+    visitor.identifiers
+}
+
+#[test]
+fn caller_construction_aliases_are_detected() {
+    let source = r#"
+        use koinon::{
+            AuthorityClaimsBuilder as Claims,
+            CallerAuthority as Authority,
+            CallerResolver as Resolver,
+        };
+
+        fn bypass<A: Authority>(authority: A) {
+            let _claims = Claims::new();
+            let _resolver = Resolver::<A>::try_new(1, authority);
+        }
+    "#;
+    assert_eq!(
+        restricted_identifiers(source),
+        BTreeSet::from([
+            "AuthorityClaimsBuilder".to_owned(),
+            "CallerAuthority".to_owned(),
+            "CallerResolver".to_owned(),
+        ]),
+        "renamed imports and turbofish calls must not bypass the boundary"
+    );
+}
+
+#[test]
+fn caller_construction_stays_at_the_application_boundary() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mut files = Vec::new();
+    collect_rust_files(&workspace.join("crates"), &mut files);
+    files.sort();
+
+    let mut violations = Vec::new();
+    for file in files {
+        let relative = file
+            .strip_prefix(&workspace)
+            .expect("workspace-relative source path");
+        if is_allowed(relative) {
+            continue;
+        }
+        let source = fs::read_to_string(&file).expect("read Rust source");
+        let identifiers = restricted_identifiers(&source);
+        if !identifiers.is_empty() {
+            violations.push(format!(
+                "{} references application-only caller construction: {:?}",
+                relative.display(),
+                identifiers
+            ));
+        }
+    }
+
+    assert_eq!(
+        violations,
+        Vec::<String>::new(),
+        "domain crates must consume ValidatedCaller, never mint principals"
+    );
+}
+
+fn is_allowed(path: &Path) -> bool {
+    path == Path::new("crates/akroasis/src/caller.rs")
+        || path == Path::new("crates/akroasis/src/caller_tests.rs")
+        || path == Path::new("crates/akroasis/tests/caller_contract.rs")
+        || path == Path::new("crates/akroasis/tests/caller_recovery.rs")
+        || path == Path::new("crates/akroasis/tests/caller_receipt_wire.rs")
+        || path == Path::new("crates/koinon/src/caller.rs")
+        || path == Path::new("crates/koinon/src/lib.rs")
+}
+
+fn collect_rust_files(path: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(path).expect("read workspace source directory") {
+        let path = entry.expect("workspace source entry").path();
+        if path.is_dir() {
+            collect_rust_files(&path, files);
+        } else if path.extension().and_then(|value| value.to_str()) == Some("rs") {
+            files.push(path);
+        }
+    }
+}

--- a/crates/akroasis/tests/caller_contract.rs
+++ b/crates/akroasis/tests/caller_contract.rs
@@ -386,8 +386,10 @@ async fn resolver_failures_never_reach_a_fake_effect() {
                 },
             );
         }
-        let error = caller.as_ref().err().expect("caller resolution must fail");
-        assert_resolution_error(mode, error);
+        assert!(caller.is_err(), "caller resolution unexpectedly succeeded");
+        if let Err(error) = caller.as_ref() {
+            assert_resolution_error(mode, error);
+        }
         assert_eq!(calls.get(), 1, "authority should be consulted exactly once");
         assert_eq!(
             effect_calls.get(),

--- a/crates/akroasis/tests/caller_contract.rs
+++ b/crates/akroasis/tests/caller_contract.rs
@@ -1,0 +1,712 @@
+//! End-to-end fixtures for the shared caller and effect-receipt contracts.
+
+#![expect(
+    clippy::expect_used,
+    reason = "fixed test fixtures use checked constructors and serialization"
+)]
+
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use akroasis_lib::caller::{
+    AdmissionDecision, ApplicationCallerError, ApplicationCallerResolver, EffectExecution,
+    EffectGateError, EffectRequest, TrustedClock, execute_effect,
+};
+use koinon::{
+    AuthorityClaims, AuthorityDecision, AuthorityGrant, AuthorizationDenial,
+    AuthorizationRequirement, CALLER_CONTEXT_VERSION, CALLER_RESOLVER_VERSION, CallerAuthority,
+    CallerContractError, CallerRef, CapabilityRef, EffectDescriptor, EffectOutcome, EffectReceipt,
+    EffectReceiptError, EffectReceiptSink, EffectRef, LocalPeerCredentials, PersonaRef,
+    PolicyEpoch, ReceiptDigest, ReceiptEvent, SchemaEpoch, ScopeRef, Timestamp,
+};
+use snafu::Snafu;
+use tokio::net::UnixStream;
+
+#[derive(Debug, Clone, Copy)]
+struct FixedClock(Timestamp);
+
+impl TrustedClock for FixedClock {
+    fn now(&self) -> Timestamp {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct SequenceClock(RefCell<VecDeque<Timestamp>>);
+
+impl SequenceClock {
+    fn new(values: impl IntoIterator<Item = Timestamp>) -> Self {
+        Self(RefCell::new(values.into_iter().collect()))
+    }
+}
+
+impl TrustedClock for SequenceClock {
+    fn now(&self) -> Timestamp {
+        self.0
+            .borrow_mut()
+            .pop_front()
+            .expect("clock fixture has one value per observation")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AuthorityMode {
+    Granted,
+    UnknownIdentity,
+    Untrusted,
+    Revoked,
+    Unavailable,
+    UnknownContextVersion,
+}
+
+fn assert_resolution_error(mode: AuthorityMode, error: &ApplicationCallerError) {
+    assert!(
+        matches!(
+            (mode, error),
+            (
+                AuthorityMode::UnknownIdentity,
+                ApplicationCallerError::CallerResolution {
+                    source: CallerContractError::UnknownIdentity { .. },
+                    ..
+                }
+            ) | (
+                AuthorityMode::Untrusted,
+                ApplicationCallerError::CallerResolution {
+                    source: CallerContractError::UntrustedIdentity { .. },
+                    ..
+                }
+            ) | (
+                AuthorityMode::Revoked,
+                ApplicationCallerError::CallerResolution {
+                    source: CallerContractError::RevokedIdentity { .. },
+                    ..
+                }
+            ) | (
+                AuthorityMode::Unavailable,
+                ApplicationCallerError::CallerResolution {
+                    source: CallerContractError::AuthorityUnavailable { .. },
+                    ..
+                }
+            ) | (
+                AuthorityMode::UnknownContextVersion,
+                ApplicationCallerError::CallerResolution {
+                    source: CallerContractError::UnknownCallerVersion { .. },
+                    ..
+                }
+            )
+        ),
+        "{mode:?} must retain its exact typed resolver denial"
+    );
+}
+
+#[derive(Debug)]
+struct FakeAuthority {
+    mode: AuthorityMode,
+    calls: Rc<Cell<usize>>,
+    caller_ref: CallerRef,
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+    expected_peer: Option<LocalPeerCredentials>,
+    seen_peer: Rc<RefCell<Option<LocalPeerCredentials>>>,
+}
+
+impl FakeAuthority {
+    fn granted(grant: AuthorityGrant, policy_epoch: PolicyEpoch) -> Self {
+        Self {
+            mode: AuthorityMode::Granted,
+            calls: Rc::new(Cell::new(0)),
+            caller_ref: CallerRef::from_canonical(b"operator-a"),
+            grant,
+            policy_epoch,
+            expected_peer: None,
+            seen_peer: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    fn decision(&self, authenticated_at: Timestamp) -> AuthorityDecision {
+        self.calls.set(self.calls.get() + 1);
+        match self.mode {
+            AuthorityMode::Granted | AuthorityMode::UnknownContextVersion => {
+                let schema_version = if matches!(self.mode, AuthorityMode::Granted) {
+                    CALLER_CONTEXT_VERSION
+                } else {
+                    CALLER_CONTEXT_VERSION + 1
+                };
+                let claims = AuthorityClaims::builder()
+                    .schema_version(schema_version)
+                    .caller_ref(self.caller_ref)
+                    .grant(self.grant)
+                    .policy_epoch(self.policy_epoch)
+                    .validity(authenticated_at, timestamp(2_000), timestamp(3_000))
+                    .build()
+                    .expect("valid fake authority claims");
+                AuthorityDecision::Granted(claims)
+            }
+            AuthorityMode::UnknownIdentity => AuthorityDecision::UnknownIdentity,
+            AuthorityMode::Untrusted => AuthorityDecision::UntrustedIdentity,
+            AuthorityMode::Revoked => AuthorityDecision::Revoked,
+            AuthorityMode::Unavailable => AuthorityDecision::Unavailable,
+        }
+    }
+}
+
+impl CallerAuthority for FakeAuthority {
+    fn resolve_local(
+        &self,
+        peer: LocalPeerCredentials,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        self.seen_peer.replace(Some(peer));
+        if self.expected_peer.is_some_and(|expected| expected != peer) {
+            return AuthorityDecision::UnknownIdentity;
+        }
+        self.decision(timestamp(1_000))
+    }
+
+    fn resolve_service(
+        &self,
+        _identity_ref: CallerRef,
+        authenticated_at: Timestamp,
+        _evidence_expires_at: Timestamp,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        self.decision(authenticated_at)
+    }
+}
+
+#[derive(Debug, Snafu)]
+enum FakeSinkError {
+    #[snafu(display("injected receipt append failure"))]
+    Injected {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("receipt predecessor is not present in the fake ledger"))]
+    UnknownPredecessor {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("receipt transition violates the shared contract: {source}"))]
+    InvalidTransition {
+        source: EffectReceiptError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+#[derive(Default)]
+struct FakeSink {
+    attempts: usize,
+    fail_at: Option<usize>,
+    receipts: Vec<EffectReceipt>,
+    digests: Vec<ReceiptDigest>,
+    transcript: Option<Rc<RefCell<Vec<&'static str>>>>,
+}
+
+impl FakeSink {
+    fn failing_at(attempt: usize) -> Self {
+        Self {
+            fail_at: Some(attempt),
+            ..Self::default()
+        }
+    }
+
+    fn with_transcript(transcript: Rc<RefCell<Vec<&'static str>>>) -> Self {
+        Self {
+            transcript: Some(transcript),
+            ..Self::default()
+        }
+    }
+
+    fn validate_child(&self, receipt: &EffectReceipt) -> Result<(), FakeSinkError> {
+        let Some(predecessor) = receipt.predecessor() else {
+            return Ok(());
+        };
+        let parent = self
+            .digests
+            .iter()
+            .zip(&self.receipts)
+            .find_map(|(digest, receipt)| (*digest == predecessor).then_some(receipt))
+            .ok_or(FakeSinkError::UnknownPredecessor {
+                location: snafu::location!(),
+            })?;
+        let _link = receipt
+            .validate_child_of(parent, predecessor)
+            .map_err(|source| FakeSinkError::InvalidTransition {
+                source,
+                location: snafu::location!(),
+            })?;
+        Ok(())
+    }
+}
+
+impl EffectReceiptSink for FakeSink {
+    type Error = FakeSinkError;
+
+    fn append(&mut self, receipt: &EffectReceipt) -> Result<ReceiptDigest, Self::Error> {
+        self.validate_child(receipt)?;
+        let attempt = self.attempts;
+        self.attempts += 1;
+        if self.fail_at == Some(attempt) {
+            return Err(FakeSinkError::Injected {
+                location: snafu::location!(),
+            });
+        }
+        if let Some(transcript) = &self.transcript {
+            transcript.borrow_mut().push(match receipt.event() {
+                ReceiptEvent::Intent => "audit:intent",
+                ReceiptEvent::Outcome(_) => "audit:outcome",
+            });
+        }
+        let digest = ledger_digest(receipt, self.receipts.len());
+        self.receipts.push(receipt.clone());
+        self.digests.push(digest);
+        Ok(digest)
+    }
+}
+
+fn timestamp(millis: i64) -> Timestamp {
+    Timestamp::from_unix_millis(millis).expect("valid fixed timestamp")
+}
+
+fn ledger_digest(receipt: &EffectReceipt, position: usize) -> ReceiptDigest {
+    let mut bytes = b"caller-contract-test-ledger\0".to_vec();
+    bytes.extend_from_slice(
+        &u64::try_from(position)
+            .expect("test ledger position fits u64")
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&serde_json::to_vec(receipt).expect("serialize fake receipt"));
+    ReceiptDigest::from_canonical(&bytes)
+}
+
+fn policy_epoch(value: u64) -> PolicyEpoch {
+    PolicyEpoch::try_from_u64(value).expect("non-zero policy epoch")
+}
+
+fn schema_epoch(value: u64) -> SchemaEpoch {
+    SchemaEpoch::try_from_u64(value).expect("non-zero schema epoch")
+}
+
+fn standard_grant() -> AuthorityGrant {
+    AuthorityGrant::new(
+        CapabilityRef::from_canonical(b"test.effect"),
+        ScopeRef::from_canonical(b"test.scope"),
+    )
+}
+
+fn valid_caller() -> koinon::ValidatedCaller {
+    let authority = FakeAuthority::granted(standard_grant(), policy_epoch(7));
+    let resolver = ApplicationCallerResolver::current(authority).expect("current resolver");
+    let (client, _server) = UnixStream::pair().expect("Unix socket pair");
+    resolver
+        .resolve_local(&client, &FixedClock(timestamp(1_500)))
+        .expect("valid local caller")
+}
+
+fn request(requirement: AuthorizationRequirement, effect: &[u8]) -> EffectRequest {
+    EffectRequest::new(
+        requirement,
+        EffectDescriptor::new(EffectRef::from_canonical(effect), schema_epoch(3), None),
+    )
+}
+
+fn kernel_peer(stream: &UnixStream) -> LocalPeerCredentials {
+    let credentials = stream.peer_cred().expect("Unix peer credentials");
+    let pid = credentials
+        .pid()
+        .map(u32::try_from)
+        .transpose()
+        .expect("peer PID fits the shared contract");
+    LocalPeerCredentials::from_os_peer(credentials.uid(), credentials.gid(), pid)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn local_peer_credentials_are_forwarded_and_acl_checked() {
+    let (client, _server) = UnixStream::pair().expect("Unix socket pair");
+    let expected = kernel_peer(&client);
+    let mut authority = FakeAuthority::granted(standard_grant(), policy_epoch(7));
+    authority.expected_peer = Some(expected);
+    let seen = Rc::clone(&authority.seen_peer);
+    let resolver = ApplicationCallerResolver::current(authority).expect("current resolver");
+    resolver
+        .resolve_local(&client, &FixedClock(timestamp(1_500)))
+        .expect("matching kernel peer should resolve");
+    assert_eq!(
+        *seen.borrow(),
+        Some(expected),
+        "the authority must receive exact kernel UID/GID/PID evidence"
+    );
+
+    let mut rejected = FakeAuthority::granted(standard_grant(), policy_epoch(7));
+    rejected.expected_peer = Some(LocalPeerCredentials::from_os_peer(
+        expected.uid() ^ 1,
+        expected.gid(),
+        expected.pid(),
+    ));
+    let resolver = ApplicationCallerResolver::current(rejected).expect("current resolver");
+    assert!(
+        resolver
+            .resolve_local(&client, &FixedClock(timestamp(1_500)))
+            .is_err(),
+        "an ACL mismatch must fail before any effect can be requested"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn resolver_failures_never_reach_a_fake_effect() {
+    let modes = [
+        AuthorityMode::UnknownIdentity,
+        AuthorityMode::Untrusted,
+        AuthorityMode::Revoked,
+        AuthorityMode::Unavailable,
+        AuthorityMode::UnknownContextVersion,
+    ];
+    let effect_calls = Cell::new(0);
+    let requirement = AuthorizationRequirement::new(standard_grant(), policy_epoch(7), None);
+    for mode in modes {
+        let mut authority = FakeAuthority::granted(standard_grant(), policy_epoch(7));
+        authority.mode = mode;
+        let calls = Rc::clone(&authority.calls);
+        let resolver = ApplicationCallerResolver::current(authority).expect("current resolver");
+        let (client, _server) = UnixStream::pair().expect("Unix socket pair");
+        let caller = resolver.resolve_local(&client, &FixedClock(timestamp(1_500)));
+        if let Ok(caller) = &caller {
+            let mut sink = FakeSink::default();
+            let _ = execute_effect(
+                Some(caller),
+                request(requirement, b"resolver-failure"),
+                &FixedClock(timestamp(1_500)),
+                AdmissionDecision::Ready,
+                &mut sink,
+                || {
+                    effect_calls.set(effect_calls.get() + 1);
+                    EffectExecution::succeeded(None)
+                },
+            );
+        }
+        let error = caller.as_ref().err().expect("caller resolution must fail");
+        assert_resolution_error(mode, error);
+        assert_eq!(calls.get(), 1, "authority should be consulted exactly once");
+        assert_eq!(
+            effect_calls.get(),
+            0,
+            "resolution failure must not invoke a domain effect"
+        );
+    }
+
+    let authority = FakeAuthority::granted(standard_grant(), policy_epoch(7));
+    let calls = Rc::clone(&authority.calls);
+    let result = ApplicationCallerResolver::try_new(CALLER_RESOLVER_VERSION + 1, authority);
+    assert!(matches!(
+        result,
+        Err(ApplicationCallerError::CallerResolution {
+            source: CallerContractError::UnknownResolverVersion {
+                resolver_version,
+                ..
+            },
+            ..
+        }) if resolver_version == CALLER_RESOLVER_VERSION + 1
+    ));
+    assert_eq!(
+        calls.get(),
+        0,
+        "unknown resolver versions must fail before authority lookup"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn every_effect_time_denial_prevents_intent_and_effect() {
+    let caller = valid_caller();
+    let grant = standard_grant();
+    let current_epoch = policy_epoch(7);
+    let valid = AuthorizationRequirement::new(grant, current_epoch, None);
+    let cases = [
+        (
+            None,
+            valid,
+            timestamp(1_500),
+            AuthorizationDenial::MissingContext,
+        ),
+        (
+            Some(&caller),
+            valid,
+            timestamp(999),
+            AuthorizationDenial::NotYetValid,
+        ),
+        (
+            Some(&caller),
+            valid,
+            timestamp(2_000),
+            AuthorizationDenial::Stale,
+        ),
+        (
+            Some(&caller),
+            valid,
+            timestamp(3_000),
+            AuthorizationDenial::Expired,
+        ),
+        (
+            Some(&caller),
+            AuthorizationRequirement::new(grant, policy_epoch(8), None),
+            timestamp(1_500),
+            AuthorizationDenial::PolicyEpochMismatch,
+        ),
+        (
+            Some(&caller),
+            AuthorizationRequirement::new(
+                grant,
+                current_epoch,
+                Some(PersonaRef::from_canonical(b"wrong-persona")),
+            ),
+            timestamp(1_500),
+            AuthorizationDenial::WrongPersona,
+        ),
+        (
+            Some(&caller),
+            AuthorizationRequirement::new(
+                AuthorityGrant::new(
+                    CapabilityRef::from_canonical(b"other.effect"),
+                    grant.scope(),
+                ),
+                current_epoch,
+                None,
+            ),
+            timestamp(1_500),
+            AuthorizationDenial::InsufficientCapability,
+        ),
+        (
+            Some(&caller),
+            AuthorizationRequirement::new(
+                AuthorityGrant::new(grant.capability(), ScopeRef::from_canonical(b"other.scope")),
+                current_epoch,
+                None,
+            ),
+            timestamp(1_500),
+            AuthorizationDenial::InsufficientScope,
+        ),
+    ];
+
+    for (caller, requirement, now, expected) in cases {
+        let mut sink = FakeSink::default();
+        let effect_calls = Cell::new(0);
+        let result = execute_effect(
+            caller,
+            request(requirement, b"denied-effect"),
+            &FixedClock(now),
+            AdmissionDecision::Ready,
+            &mut sink,
+            || {
+                effect_calls.set(effect_calls.get() + 1);
+                EffectExecution::succeeded(None)
+            },
+        );
+        let actual = match result {
+            Err(EffectGateError::Denied { denial, .. }) => Some(denial),
+            _ => None,
+        };
+        assert_eq!(actual, Some(expected), "denial reason must be stable");
+        assert_eq!(effect_calls.get(), 0, "denied effects must never run");
+        assert!(sink.receipts.is_empty(), "denial is not an effect receipt");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn audit_order_and_failures_are_fail_closed() {
+    let caller = valid_caller();
+    let requirement = AuthorizationRequirement::new(standard_grant(), policy_epoch(7), None);
+    let transcript = Rc::new(RefCell::new(Vec::new()));
+    let mut sink = FakeSink::with_transcript(Rc::clone(&transcript));
+
+    let completion = execute_effect(
+        Some(&caller),
+        request(requirement, b"ordered-effect"),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut sink,
+        || {
+            transcript.borrow_mut().push("effect");
+            EffectExecution::succeeded(None)
+        },
+    )
+    .expect("ordered effect should complete");
+    assert_eq!(completion.outcome(), EffectOutcome::Succeeded);
+    assert_eq!(
+        transcript.borrow().as_slice(),
+        ["audit:intent", "effect", "audit:outcome"],
+        "durable intent must precede effect and outcome"
+    );
+
+    let calls = Cell::new(0);
+    let mut intent_failure = FakeSink::failing_at(0);
+    let result = execute_effect(
+        Some(&caller),
+        request(requirement, b"intent-failure"),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut intent_failure,
+        || {
+            calls.set(calls.get() + 1);
+            EffectExecution::succeeded(None)
+        },
+    );
+    assert!(
+        matches!(result, Err(EffectGateError::IntentAudit { .. })),
+        "intent append failure must propagate"
+    );
+    assert_eq!(calls.get(), 0, "intent failure must prevent the effect");
+
+    let mut outcome_failure = FakeSink::failing_at(1);
+    let result = execute_effect(
+        Some(&caller),
+        request(requirement, b"outcome-failure"),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut outcome_failure,
+        || {
+            calls.set(calls.get() + 1);
+            EffectExecution::succeeded(None)
+        },
+    );
+    assert!(
+        matches!(result, Err(EffectGateError::OutcomeAudit { .. })),
+        "outcome append failure must require reconciliation"
+    );
+    assert_eq!(calls.get(), 1, "the admitted effect runs exactly once");
+
+    let clock = SequenceClock::new([timestamp(1_500), timestamp(1_500), timestamp(1_499)]);
+    let mut backward_outcome = FakeSink::default();
+    let result = execute_effect(
+        Some(&caller),
+        request(requirement, b"backward-outcome-time"),
+        &clock,
+        AdmissionDecision::Ready,
+        &mut backward_outcome,
+        || {
+            calls.set(calls.get() + 1);
+            EffectExecution::succeeded(None)
+        },
+    );
+    assert!(
+        matches!(result, Err(EffectGateError::PostIntentContract { .. })),
+        "an outcome timestamp before its intent must require reconciliation"
+    );
+    assert_eq!(
+        calls.get(),
+        2,
+        "the admitted effect runs before a post-effect clock fault is observed"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn authority_is_rechecked_after_durable_intent() {
+    let caller = valid_caller();
+    let requirement = AuthorizationRequirement::new(standard_grant(), policy_epoch(7), None);
+    let clock = SequenceClock::new([timestamp(1_999), timestamp(2_000)]);
+    let calls = Cell::new(0);
+    let mut sink = FakeSink::default();
+
+    let result = execute_effect(
+        Some(&caller),
+        request(requirement, b"lapsed-after-intent"),
+        &clock,
+        AdmissionDecision::Ready,
+        &mut sink,
+        || {
+            calls.set(calls.get() + 1);
+            EffectExecution::succeeded(None)
+        },
+    );
+    assert!(
+        matches!(
+            result,
+            Err(EffectGateError::PostIntentDenied {
+                denial: AuthorizationDenial::Stale,
+                ..
+            })
+        ),
+        "authority that lapses during intent append must fail closed"
+    );
+    assert_eq!(
+        calls.get(),
+        0,
+        "lapsed authority must cause zero domain I/O"
+    );
+    assert_eq!(
+        sink.receipts.len(),
+        2,
+        "intent and no-effect outcome expected"
+    );
+    assert_eq!(
+        sink.receipts
+            .get(1)
+            .expect("no-effect outcome receipt")
+            .event(),
+        ReceiptEvent::Outcome(EffectOutcome::AuthorizationDenied)
+    );
+
+    let clock = SequenceClock::new([timestamp(1_500), timestamp(1_499)]);
+    let mut sink = FakeSink::default();
+    let result = execute_effect(
+        Some(&caller),
+        request(requirement, b"regressed-clock"),
+        &clock,
+        AdmissionDecision::Ready,
+        &mut sink,
+        || {
+            calls.set(calls.get() + 1);
+            EffectExecution::succeeded(None)
+        },
+    );
+    assert!(
+        matches!(
+            result,
+            Err(EffectGateError::PostIntentDenied {
+                denial: AuthorizationDenial::ClockRegression,
+                ..
+            })
+        ),
+        "a backwards trusted clock must produce a no-effect outcome"
+    );
+    assert_eq!(
+        calls.get(),
+        0,
+        "clock regression must cause zero domain I/O"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancellation_and_backpressure_never_invoke_the_effect() {
+    let caller = valid_caller();
+    let requirement = AuthorizationRequirement::new(standard_grant(), policy_epoch(7), None);
+    for (admission, expected) in [
+        (AdmissionDecision::Cancelled, EffectOutcome::Cancelled),
+        (
+            AdmissionDecision::Backpressured,
+            EffectOutcome::Backpressured,
+        ),
+    ] {
+        let calls = Cell::new(0);
+        let mut sink = FakeSink::default();
+        let completion = execute_effect(
+            Some(&caller),
+            request(requirement, b"bounded-effect"),
+            &FixedClock(timestamp(1_500)),
+            admission,
+            &mut sink,
+            || {
+                calls.set(calls.get() + 1);
+                EffectExecution::succeeded(None)
+            },
+        )
+        .expect("bounded admission should record a terminal outcome");
+        assert_eq!(completion.outcome(), expected);
+        assert_eq!(calls.get(), 0, "bounded refusal must not invoke the effect");
+        assert_eq!(
+            sink.receipts.len(),
+            2,
+            "intent and terminal outcome expected"
+        );
+    }
+}

--- a/crates/akroasis/tests/caller_receipt_wire.rs
+++ b/crates/akroasis/tests/caller_receipt_wire.rs
@@ -1,0 +1,271 @@
+//! Wire-shape fixture for minimized effect receipts.
+
+#![expect(
+    clippy::expect_used,
+    reason = "fixed wire fixtures use checked constructors and serialization"
+)]
+
+use std::collections::BTreeSet;
+
+use akroasis_lib::caller::{
+    AdmissionDecision, ApplicationCallerResolver, EffectExecution, EffectRequest, TrustedClock,
+    execute_effect,
+};
+use koinon::{
+    AuthorityClaims, AuthorityDecision, AuthorityGrant, AuthorizationRequirement,
+    CALLER_CONTEXT_VERSION, CallerAuthority, CallerRef, CapabilityRef, EffectDescriptor,
+    EffectReceipt, EffectReceiptError, EffectReceiptSink, EffectRef, EvidenceDigest,
+    LocalPeerCredentials, PolicyEpoch, ReceiptDigest, RecoveryRelation, SchemaEpoch, ScopeRef,
+    Timestamp,
+};
+use snafu::Snafu;
+use tokio::net::UnixStream;
+
+#[derive(Debug, Clone, Copy)]
+struct FixedClock(Timestamp);
+
+impl TrustedClock for FixedClock {
+    fn now(&self) -> Timestamp {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct WireAuthority {
+    caller_ref: CallerRef,
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+}
+
+impl CallerAuthority for WireAuthority {
+    fn resolve_local(
+        &self,
+        _peer: LocalPeerCredentials,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        let claims = AuthorityClaims::builder()
+            .schema_version(CALLER_CONTEXT_VERSION)
+            .caller_ref(self.caller_ref)
+            .grant(self.grant)
+            .policy_epoch(self.policy_epoch)
+            .validity(timestamp(1_000), timestamp(2_000), timestamp(3_000))
+            .build()
+            .expect("valid wire authority claims");
+        AuthorityDecision::Granted(claims)
+    }
+
+    fn resolve_service(
+        &self,
+        _identity_ref: CallerRef,
+        _authenticated_at: Timestamp,
+        _evidence_expires_at: Timestamp,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        AuthorityDecision::UnknownIdentity
+    }
+}
+
+#[derive(Debug, Snafu)]
+enum WireSinkError {
+    #[snafu(display("receipt predecessor is not present in the wire ledger"))]
+    UnknownPredecessor {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("wire receipt transition violates the shared contract: {source}"))]
+    InvalidTransition {
+        source: EffectReceiptError,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+#[derive(Default)]
+struct WireSink {
+    receipts: Vec<EffectReceipt>,
+    digests: Vec<ReceiptDigest>,
+}
+
+impl EffectReceiptSink for WireSink {
+    type Error = WireSinkError;
+
+    fn append(&mut self, receipt: &EffectReceipt) -> Result<ReceiptDigest, Self::Error> {
+        if let Some(predecessor) = receipt.predecessor() {
+            let parent = self
+                .digests
+                .iter()
+                .zip(&self.receipts)
+                .find_map(|(digest, receipt)| (*digest == predecessor).then_some(receipt))
+                .ok_or(WireSinkError::UnknownPredecessor {
+                    location: snafu::location!(),
+                })?;
+            let _link = receipt
+                .validate_child_of(parent, predecessor)
+                .map_err(|source| WireSinkError::InvalidTransition {
+                    source,
+                    location: snafu::location!(),
+                })?;
+        }
+        let encoded = serde_json::to_vec(receipt).expect("serialize wire receipt");
+        let mut digest_material = b"caller-wire-test-ledger\0".to_vec();
+        digest_material.extend_from_slice(
+            &u64::try_from(self.receipts.len())
+                .expect("test ledger position fits u64")
+                .to_le_bytes(),
+        );
+        digest_material.extend_from_slice(&encoded);
+        let digest = ReceiptDigest::from_canonical(&digest_material);
+        self.receipts.push(receipt.clone());
+        self.digests.push(digest);
+        Ok(digest)
+    }
+}
+
+fn timestamp(millis: i64) -> Timestamp {
+    Timestamp::from_unix_millis(millis).expect("valid fixed timestamp")
+}
+
+fn policy_epoch(value: u64) -> PolicyEpoch {
+    PolicyEpoch::try_from_u64(value).expect("non-zero policy epoch")
+}
+
+fn schema_epoch(value: u64) -> SchemaEpoch {
+    SchemaEpoch::try_from_u64(value).expect("non-zero schema epoch")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn receipt_wire_shape_is_closed_and_contains_no_raw_values() {
+    let raw_identity: &[u8] = b"operator@example.invalid";
+    let raw_capability: &[u8] = b"146520000";
+    let raw_scope: &[u8] = b"allow:uid:1000";
+    let raw_effect: &[u8] = b"/dev/ttyUSB0";
+    let raw_evidence: &[u8] = b"0123456789abcdef0123456789abcdef";
+    let grant = AuthorityGrant::new(
+        CapabilityRef::from_canonical(raw_capability),
+        ScopeRef::from_canonical(raw_scope),
+    );
+    let resolver = ApplicationCallerResolver::current(WireAuthority {
+        caller_ref: CallerRef::from_canonical(raw_identity),
+        grant,
+        policy_epoch: policy_epoch(7),
+    })
+    .expect("current resolver");
+    let (client, _server) = UnixStream::pair().expect("Unix socket pair");
+    let caller = resolver
+        .resolve_local(&client, &FixedClock(timestamp(1_500)))
+        .expect("valid local caller");
+    let mut sink = WireSink::default();
+    execute_effect(
+        Some(&caller),
+        EffectRequest::new(
+            AuthorizationRequirement::new(grant, policy_epoch(7), None),
+            EffectDescriptor::new(
+                EffectRef::from_canonical(raw_effect),
+                schema_epoch(3),
+                Some(EvidenceDigest::from_canonical(raw_evidence)),
+            ),
+        ),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut sink,
+        || EffectExecution::succeeded(None),
+    )
+    .expect("effect should create a receipt");
+
+    let intent = sink.receipts.first().expect("intent receipt");
+    assert_minimized_wire(
+        intent,
+        &[
+            raw_identity,
+            raw_capability,
+            raw_scope,
+            raw_effect,
+            raw_evidence,
+        ],
+    );
+    assert_receipt_field_allowlist(intent);
+    assert_invalid_wire_shapes_fail(intent, sink.receipts.last().expect("outcome receipt"));
+}
+
+fn assert_minimized_wire(intent: &EffectReceipt, forbidden_values: &[&[u8]]) {
+    let encoded = serde_json::to_string(intent).expect("serialize intent");
+    for forbidden in forbidden_values {
+        let forbidden = std::str::from_utf8(forbidden).expect("ASCII fixture");
+        assert!(
+            !encoded.contains(forbidden),
+            "raw value must not be representable in a receipt: {forbidden}"
+        );
+    }
+}
+
+fn assert_receipt_field_allowlist(intent: &EffectReceipt) {
+    let mut value = serde_json::to_value(intent).expect("serialize intent value");
+    let object = value.as_object_mut().expect("receipt object");
+    let keys: BTreeSet<_> = object.keys().map(String::as_str).collect();
+    assert_eq!(
+        keys,
+        BTreeSet::from([
+            "context",
+            "event",
+            "evidence_digest",
+            "observed_at",
+            "predecessor",
+            "recovery",
+            "schema_version",
+        ]),
+        "receipt fields must stay allowlisted"
+    );
+    let context = object
+        .get("context")
+        .and_then(serde_json::Value::as_object)
+        .expect("receipt context");
+    let context_keys: BTreeSet<_> = context.keys().map(String::as_str).collect();
+    assert_eq!(
+        context_keys,
+        BTreeSet::from([
+            "caller_ref",
+            "capability",
+            "effect",
+            "policy_epoch",
+            "schema_epoch",
+        ]),
+        "receipt context fields must stay allowlisted"
+    );
+}
+
+fn assert_invalid_wire_shapes_fail(intent: &EffectReceipt, outcome: &EffectReceipt) {
+    let mut value = serde_json::to_value(intent).expect("serialize intent value");
+    let object = value.as_object_mut().expect("receipt object");
+    object.insert("raw_path".to_owned(), serde_json::json!("/dev/ttyUSB0"));
+    assert!(
+        serde_json::from_value::<EffectReceipt>(value).is_err(),
+        "unknown top-level fields must fail closed"
+    );
+
+    let mut nested_unknown = serde_json::to_value(intent).expect("serialize intent value");
+    nested_unknown["context"]
+        .as_object_mut()
+        .expect("receipt context")
+        .insert("raw_rule".to_owned(), serde_json::json!("allow all"));
+    assert!(
+        serde_json::from_value::<EffectReceipt>(nested_unknown).is_err(),
+        "unknown context fields must fail closed"
+    );
+
+    let mut unknown_version = serde_json::to_value(intent).expect("serialize intent value");
+    unknown_version["schema_version"] = serde_json::json!(99);
+    assert!(
+        serde_json::from_value::<EffectReceipt>(unknown_version).is_err(),
+        "unknown receipt versions must fail closed"
+    );
+
+    let mut invalid_recovery = serde_json::to_value(outcome).expect("serialize outcome value");
+    invalid_recovery["recovery"] = serde_json::to_value(RecoveryRelation::RecoveryOf(
+        EffectRef::from_canonical(b"unrelated-effect"),
+    ))
+    .expect("serialize recovery relation");
+    assert!(
+        serde_json::from_value::<EffectReceipt>(invalid_recovery).is_err(),
+        "successful outcomes cannot claim an unrelated recovery relation"
+    );
+}

--- a/crates/akroasis/tests/caller_receipt_wire.rs
+++ b/crates/akroasis/tests/caller_receipt_wire.rs
@@ -234,38 +234,87 @@ fn assert_receipt_field_allowlist(intent: &EffectReceipt) {
 }
 
 fn assert_invalid_wire_shapes_fail(intent: &EffectReceipt, outcome: &EffectReceipt) {
+    assert_receipt_round_trip(intent);
+    assert_receipt_round_trip(outcome);
+
     let mut value = serde_json::to_value(intent).expect("serialize intent value");
     let object = value.as_object_mut().expect("receipt object");
-    object.insert("raw_path".to_owned(), serde_json::json!("/dev/ttyUSB0"));
     assert!(
-        serde_json::from_value::<EffectReceipt>(value).is_err(),
-        "unknown top-level fields must fail closed"
+        object
+            .insert("raw_path".to_owned(), serde_json::json!("/dev/ttyUSB0"))
+            .is_none(),
+        "raw path fixture field must be new"
+    );
+    assert_wire_rejection(
+        value,
+        "unknown field `raw_path`",
+        "unknown top-level fields must fail closed",
     );
 
     let mut nested_unknown = serde_json::to_value(intent).expect("serialize intent value");
-    nested_unknown["context"]
+    let context = nested_unknown
         .as_object_mut()
-        .expect("receipt context")
-        .insert("raw_rule".to_owned(), serde_json::json!("allow all"));
+        .and_then(|object| object.get_mut("context"))
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("receipt context");
     assert!(
-        serde_json::from_value::<EffectReceipt>(nested_unknown).is_err(),
-        "unknown context fields must fail closed"
+        context
+            .insert("raw_rule".to_owned(), serde_json::json!("allow all"))
+            .is_none(),
+        "raw rule fixture field must be new"
+    );
+    assert_wire_rejection(
+        nested_unknown,
+        "unknown field `raw_rule`",
+        "unknown context fields must fail closed",
     );
 
     let mut unknown_version = serde_json::to_value(intent).expect("serialize intent value");
-    unknown_version["schema_version"] = serde_json::json!(99);
     assert!(
-        serde_json::from_value::<EffectReceipt>(unknown_version).is_err(),
-        "unknown receipt versions must fail closed"
+        unknown_version
+            .as_object_mut()
+            .expect("receipt object")
+            .insert("schema_version".to_owned(), serde_json::json!(99))
+            .is_some(),
+        "schema version fixture field must exist"
+    );
+    assert_wire_rejection(
+        unknown_version,
+        "unknown effect-receipt schema version 99",
+        "unknown receipt versions must fail closed",
     );
 
     let mut invalid_recovery = serde_json::to_value(outcome).expect("serialize outcome value");
-    invalid_recovery["recovery"] = serde_json::to_value(RecoveryRelation::RecoveryOf(
-        EffectRef::from_canonical(b"unrelated-effect"),
-    ))
+    let recovery = serde_json::to_value(RecoveryRelation::RecoveryOf(EffectRef::from_canonical(
+        b"unrelated-effect",
+    )))
     .expect("serialize recovery relation");
     assert!(
-        serde_json::from_value::<EffectReceipt>(invalid_recovery).is_err(),
-        "successful outcomes cannot claim an unrelated recovery relation"
+        invalid_recovery
+            .as_object_mut()
+            .expect("receipt object")
+            .insert("recovery".to_owned(), recovery)
+            .is_some(),
+        "recovery fixture field must exist"
+    );
+    assert_wire_rejection(
+        invalid_recovery,
+        "effect outcome has an incompatible recovery relation",
+        "successful outcomes cannot claim an unrelated recovery relation",
+    );
+}
+
+fn assert_receipt_round_trip(receipt: &EffectReceipt) {
+    let value = serde_json::to_value(receipt).expect("serialize valid receipt fixture");
+    let decoded =
+        serde_json::from_value::<EffectReceipt>(value).expect("valid receipt must deserialize");
+    assert_eq!(&decoded, receipt, "receipt wire round-trip must be exact");
+}
+
+fn assert_wire_rejection(value: serde_json::Value, expected: &str, message: &str) {
+    let error = serde_json::from_value::<EffectReceipt>(value).expect_err(message);
+    assert!(
+        error.to_string().contains(expected),
+        "{message}: expected {expected:?}, got {error}"
     );
 }

--- a/crates/akroasis/tests/caller_recovery.rs
+++ b/crates/akroasis/tests/caller_recovery.rs
@@ -1,0 +1,573 @@
+//! Stateful recovery fixtures for minimized effect receipts.
+
+#![expect(
+    clippy::expect_used,
+    reason = "fixed recovery fixtures use checked constructors and ledger assertions"
+)]
+
+use std::cell::Cell;
+use std::collections::BTreeSet;
+
+use akroasis_lib::caller::{
+    AdmissionDecision, ApplicationCallerResolver, EffectExecution, EffectGateError, EffectRequest,
+    TrustedClock, execute_effect,
+};
+use koinon::{
+    AuthorityClaims, AuthorityDecision, AuthorityGrant, AuthorizationRequirement,
+    CALLER_CONTEXT_VERSION, CallerAuthority, CallerRef, CapabilityRef, EFFECT_RECEIPT_VERSION,
+    EffectDescriptor, EffectOutcome, EffectReceipt, EffectReceiptError, EffectReceiptSink,
+    EffectRef, LocalPeerCredentials, PersistedIntent, PersistedOutcome, PolicyEpoch, ReceiptDigest,
+    ReceiptEvent, RecoveryAuthorization, RecoveryRelation, SchemaEpoch, ScopeRef, Timestamp,
+};
+use snafu::Snafu;
+use tokio::net::UnixStream;
+
+#[derive(Debug, Clone, Copy)]
+struct FixedClock(Timestamp);
+
+impl TrustedClock for FixedClock {
+    fn now(&self) -> Timestamp {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct RecoveryAuthority {
+    grant: AuthorityGrant,
+}
+
+impl CallerAuthority for RecoveryAuthority {
+    fn resolve_local(
+        &self,
+        _peer: LocalPeerCredentials,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        AuthorityDecision::Granted(
+            AuthorityClaims::builder()
+                .schema_version(CALLER_CONTEXT_VERSION)
+                .caller_ref(CallerRef::from_canonical(b"recovery-operator"))
+                .grant(self.grant)
+                .policy_epoch(policy_epoch(7))
+                .validity(timestamp(1_000), timestamp(2_000), timestamp(3_000))
+                .build()
+                .expect("valid recovery authority"),
+        )
+    }
+
+    fn resolve_service(
+        &self,
+        _identity_ref: CallerRef,
+        _authenticated_at: Timestamp,
+        _evidence_expires_at: Timestamp,
+        _observed_at: Timestamp,
+    ) -> AuthorityDecision {
+        AuthorityDecision::UnknownIdentity
+    }
+}
+
+#[derive(Debug, Snafu)]
+enum LedgerError {
+    #[snafu(display("injected durable append failure"))]
+    Injected {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("ledger predecessor is absent or has the wrong state"))]
+    InvalidPredecessor {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("ledger transition was already matched"))]
+    AlreadyMatched {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("ledger reconciliation claim was already consumed"))]
+    AlreadyClaimed {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    #[snafu(display("ledger already contains the same receipt identity"))]
+    DuplicateReceipt {
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+
+#[derive(Default)]
+struct StatefulLedger {
+    attempts: usize,
+    fail_at: Option<usize>,
+    receipts: Vec<EffectReceipt>,
+    claimed_intents: BTreeSet<ReceiptDigest>,
+    claimed_recoveries: BTreeSet<ReceiptDigest>,
+}
+
+impl StatefulLedger {
+    fn failing_at(attempt: usize) -> Self {
+        Self {
+            fail_at: Some(attempt),
+            ..Self::default()
+        }
+    }
+
+    fn clear_failure(&mut self) {
+        self.fail_at = None;
+    }
+
+    fn receipt(&self, index: usize) -> &EffectReceipt {
+        self.receipts.get(index).expect("ledger receipt fixture")
+    }
+
+    fn receipt_with_digest(&self, digest: ReceiptDigest) -> Option<EffectReceipt> {
+        self.receipts
+            .iter()
+            .find(|receipt| receipt_digest(receipt) == digest)
+            .cloned()
+    }
+
+    fn has_descendant(&self, digest: ReceiptDigest) -> bool {
+        self.receipts
+            .iter()
+            .any(|receipt| receipt.predecessor() == Some(digest))
+    }
+
+    fn claim_unmatched_intent(
+        &mut self,
+        digest: ReceiptDigest,
+    ) -> Result<PersistedIntent, LedgerError> {
+        let receipt = self
+            .receipt_with_digest(digest)
+            .filter(|receipt| receipt.event() == ReceiptEvent::Intent)
+            .ok_or(LedgerError::InvalidPredecessor {
+                location: snafu::location!(),
+            })?;
+        if self.has_descendant(digest) {
+            return Err(LedgerError::AlreadyMatched {
+                location: snafu::location!(),
+            });
+        }
+        if !self.claimed_intents.insert(digest) {
+            return Err(LedgerError::AlreadyClaimed {
+                location: snafu::location!(),
+            });
+        }
+        PersistedIntent::from_verified_unmatched(receipt, digest).map_err(|_| {
+            LedgerError::InvalidPredecessor {
+                location: snafu::location!(),
+            }
+        })
+    }
+
+    fn claim_recovery(
+        &mut self,
+        digest: ReceiptDigest,
+    ) -> Result<RecoveryAuthorization, LedgerError> {
+        if self.has_descendant(digest) {
+            return Err(LedgerError::AlreadyMatched {
+                location: snafu::location!(),
+            });
+        }
+        let receipt = self
+            .receipt_with_digest(digest)
+            .ok_or(LedgerError::InvalidPredecessor {
+                location: snafu::location!(),
+            })?;
+        let authorization = PersistedOutcome::from_verified(receipt, digest)
+            .and_then(PersistedOutcome::into_recovery_authorization)
+            .map_err(|_| LedgerError::InvalidPredecessor {
+                location: snafu::location!(),
+            })?;
+        if !self.claimed_recoveries.insert(digest) {
+            return Err(LedgerError::AlreadyClaimed {
+                location: snafu::location!(),
+            });
+        }
+        Ok(authorization)
+    }
+
+    fn validate_append(&self, receipt: &EffectReceipt) -> Result<(), LedgerError> {
+        if self.receipt_with_digest(receipt_digest(receipt)).is_some() {
+            return Err(LedgerError::DuplicateReceipt {
+                location: snafu::location!(),
+            });
+        }
+        let Some(predecessor) = receipt.predecessor() else {
+            return Ok(());
+        };
+        let parent =
+            self.receipt_with_digest(predecessor)
+                .ok_or(LedgerError::InvalidPredecessor {
+                    location: snafu::location!(),
+                })?;
+        let _link = receipt
+            .validate_child_of(&parent, predecessor)
+            .map_err(|_| LedgerError::InvalidPredecessor {
+                location: snafu::location!(),
+            })?;
+        if self.has_descendant(predecessor) {
+            return Err(LedgerError::AlreadyMatched {
+                location: snafu::location!(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl EffectReceiptSink for StatefulLedger {
+    type Error = LedgerError;
+
+    fn append(&mut self, receipt: &EffectReceipt) -> Result<ReceiptDigest, Self::Error> {
+        self.validate_append(receipt)?;
+        let attempt = self.attempts;
+        self.attempts += 1;
+        if self.fail_at == Some(attempt) {
+            return Err(LedgerError::Injected {
+                location: snafu::location!(),
+            });
+        }
+        let digest = receipt_digest(receipt);
+        self.receipts.push(receipt.clone());
+        Ok(digest)
+    }
+}
+
+fn timestamp(millis: i64) -> Timestamp {
+    Timestamp::from_unix_millis(millis).expect("valid timestamp fixture")
+}
+
+fn receipt_digest(receipt: &EffectReceipt) -> ReceiptDigest {
+    ReceiptDigest::from_canonical(&serde_json::to_vec(receipt).expect("serialize ledger receipt"))
+}
+
+fn policy_epoch(value: u64) -> PolicyEpoch {
+    PolicyEpoch::try_from_u64(value).expect("non-zero policy epoch")
+}
+
+fn schema_epoch(value: u64) -> SchemaEpoch {
+    SchemaEpoch::try_from_u64(value).expect("non-zero schema epoch")
+}
+
+fn grant() -> AuthorityGrant {
+    AuthorityGrant::new(
+        CapabilityRef::from_canonical(b"test.recovery"),
+        ScopeRef::from_canonical(b"test.scope"),
+    )
+}
+
+fn caller() -> koinon::ValidatedCaller {
+    let resolver = ApplicationCallerResolver::current(RecoveryAuthority { grant: grant() })
+        .expect("current caller resolver");
+    let (client, _server) = UnixStream::pair().expect("Unix socket pair");
+    resolver
+        .resolve_local(&client, &FixedClock(timestamp(1_500)))
+        .expect("valid recovery caller")
+}
+
+fn request(descriptor: EffectDescriptor) -> EffectRequest {
+    EffectRequest::new(
+        AuthorizationRequirement::new(grant(), policy_epoch(7), None),
+        descriptor,
+    )
+}
+
+fn wire_receipt(
+    context: &serde_json::Value,
+    event: ReceiptEvent,
+    observed_at: Timestamp,
+    predecessor: ReceiptDigest,
+    recovery: RecoveryRelation,
+) -> EffectReceipt {
+    serde_json::from_value(serde_json::json!({
+        "schema_version": EFFECT_RECEIPT_VERSION,
+        "context": context,
+        "event": event,
+        "observed_at": observed_at,
+        "evidence_digest": null,
+        "predecessor": predecessor,
+        "recovery": recovery,
+    }))
+    .expect("forged child is individually wire-valid")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn duplicate_intent_is_rejected_before_a_second_effect() {
+    let caller = caller();
+    let effect = EffectRef::from_canonical(b"idempotent-effect");
+    let calls = Cell::new(0);
+    let mut ledger = StatefulLedger::default();
+    let invoke = |ledger: &mut StatefulLedger| {
+        execute_effect(
+            Some(&caller),
+            request(EffectDescriptor::new(effect, schema_epoch(3), None)),
+            &FixedClock(timestamp(1_500)),
+            AdmissionDecision::Ready,
+            ledger,
+            || {
+                calls.set(calls.get() + 1);
+                EffectExecution::succeeded(None)
+            },
+        )
+    };
+    invoke(&mut ledger).expect("first intent and outcome are durable");
+    let duplicate = invoke(&mut ledger);
+    assert!(matches!(
+        duplicate,
+        Err(EffectGateError::IntentAudit {
+            source: LedgerError::DuplicateReceipt { .. },
+            ..
+        })
+    ));
+    assert_eq!(calls.get(), 1, "duplicate intent performs no second effect");
+    assert_eq!(ledger.receipts.len(), 2, "only the first pair is durable");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_child_contexts_and_recovery_targets_are_rejected() {
+    let caller = caller();
+    let original = EffectRef::from_canonical(b"normal-effect");
+    let unrelated = EffectRef::from_canonical(b"unrelated-effect");
+    let mut ledger = StatefulLedger::failing_at(1);
+    let failed_outcome = execute_effect(
+        Some(&caller),
+        request(EffectDescriptor::new(original, schema_epoch(3), None)),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || EffectExecution::failed(None),
+    );
+    assert!(matches!(
+        failed_outcome,
+        Err(EffectGateError::OutcomeAudit { .. })
+    ));
+    ledger.clear_failure();
+    let intent = ledger.receipt(0);
+    let intent_digest = receipt_digest(intent);
+    let context = serde_json::to_value(intent.context()).expect("serialize receipt context");
+    let forged_target = wire_receipt(
+        &context,
+        ReceiptEvent::Outcome(EffectOutcome::Failed),
+        timestamp(1_600),
+        intent_digest,
+        RecoveryRelation::RecoveryOf(unrelated),
+    );
+    assert!(matches!(
+        ledger.append(&forged_target),
+        Err(LedgerError::InvalidPredecessor { .. })
+    ));
+
+    let mut wrong_context = context;
+    wrong_context
+        .as_object_mut()
+        .expect("receipt context object")
+        .insert(
+            "effect".to_owned(),
+            serde_json::to_value(unrelated).expect("serialize unrelated effect"),
+        );
+    let forged_context = wire_receipt(
+        &wrong_context,
+        ReceiptEvent::Outcome(EffectOutcome::Failed),
+        timestamp(1_600),
+        intent_digest,
+        RecoveryRelation::None,
+    );
+    assert!(matches!(
+        ledger.append(&forged_context),
+        Err(LedgerError::InvalidPredecessor { .. })
+    ));
+
+    let mut partial_ledger = StatefulLedger::default();
+    execute_effect(
+        Some(&caller),
+        request(EffectDescriptor::new(original, schema_epoch(3), None)),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut partial_ledger,
+        || EffectExecution::partial(None),
+    )
+    .expect("partial chain fixture");
+    let partial = partial_ledger.receipt(1);
+    let partial_context =
+        serde_json::to_value(partial.context()).expect("serialize partial context");
+    let forged_recovery = wire_receipt(
+        &partial_context,
+        ReceiptEvent::Intent,
+        timestamp(1_700),
+        receipt_digest(partial),
+        RecoveryRelation::RecoveryOf(unrelated),
+    );
+    assert!(matches!(
+        partial_ledger.append(&forged_recovery),
+        Err(LedgerError::InvalidPredecessor { .. })
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn partial_recovery_rejects_a_backdated_child() {
+    let caller = caller();
+    let original = EffectRef::from_canonical(b"partial-time-order");
+    let mut ledger = StatefulLedger::default();
+    let partial = execute_effect(
+        Some(&caller),
+        request(EffectDescriptor::new(original, schema_epoch(3), None)),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || EffectExecution::partial(None),
+    )
+    .expect("partial outcome is durably recorded");
+    let descriptor = partial
+        .into_recovery()
+        .expect("partial outcome authorizes recovery")
+        .into_descriptor(
+            EffectRef::from_canonical(b"backdated-recovery"),
+            schema_epoch(3),
+            None,
+        );
+    let calls = Cell::new(0);
+    let result = execute_effect(
+        Some(&caller),
+        request(descriptor),
+        &FixedClock(timestamp(1_499)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || {
+            calls.set(calls.get() + 1);
+            EffectExecution::succeeded(None)
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(EffectGateError::ReceiptContract {
+            source: EffectReceiptError::RecoveryIntentPrecedesRequirement { .. },
+            ..
+        })
+    ));
+    assert_eq!(calls.get(), 0, "backdated recovery performs no domain I/O");
+    assert_eq!(ledger.receipts.len(), 2, "no recovery receipt was appended");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelled_recovery_can_retry_once_on_the_same_ledger() {
+    let caller = caller();
+    let original = EffectRef::from_canonical(b"partial-retry");
+    let mut ledger = StatefulLedger::default();
+    let partial = execute_effect(
+        Some(&caller),
+        request(EffectDescriptor::new(original, schema_epoch(3), None)),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || EffectExecution::partial(None),
+    )
+    .expect("partial outcome is durably recorded");
+    let first_recovery = partial
+        .into_recovery()
+        .expect("partial outcome authorizes recovery")
+        .into_descriptor(
+            EffectRef::from_canonical(b"cancelled-recovery"),
+            schema_epoch(3),
+            None,
+        );
+    let cancelled = execute_effect(
+        Some(&caller),
+        request(first_recovery),
+        &FixedClock(timestamp(1_700)),
+        AdmissionDecision::Cancelled,
+        &mut ledger,
+        || EffectExecution::succeeded(None),
+    )
+    .expect("cancelled recovery records a no-I/O outcome");
+    let cancelled_digest = cancelled.receipt_digest();
+    let retry = cancelled
+        .into_recovery()
+        .expect("cancelled recovery preserves continuation authority")
+        .into_descriptor(
+            EffectRef::from_canonical(b"retry-recovery"),
+            schema_epoch(3),
+            None,
+        );
+    let recovered = execute_effect(
+        Some(&caller),
+        request(retry),
+        &FixedClock(timestamp(1_800)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || EffectExecution::succeeded(None),
+    )
+    .expect("retry completes the explicit recovery chain");
+    assert_eq!(recovered.outcome(), EffectOutcome::Recovered);
+    assert_eq!(
+        ledger.receipt(4).predecessor(),
+        Some(cancelled_digest),
+        "retry intent links the cancelled recovery outcome"
+    );
+    assert!(
+        ledger.claim_recovery(cancelled_digest).is_err(),
+        "a recovery requirement with a descendant cannot be replayed"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn restart_claim_is_atomic_and_recovery_chain_is_continuous() {
+    let caller = caller();
+    let original = EffectRef::from_canonical(b"restart-effect");
+    let mut ledger = StatefulLedger::failing_at(1);
+    let result = execute_effect(
+        Some(&caller),
+        request(EffectDescriptor::new(original, schema_epoch(3), None)),
+        &FixedClock(timestamp(1_500)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || EffectExecution::succeeded(None),
+    );
+    let ticket = match result {
+        Err(EffectGateError::OutcomeAudit { recovery, .. }) => Some(recovery),
+        _ => None,
+    }
+    .expect("outcome failure returns a restart ticket");
+    assert_eq!(ticket.effect(), original);
+    let intent_digest = receipt_digest(ledger.receipt(0));
+    ledger.clear_failure();
+    let restored = ledger
+        .claim_unmatched_intent(intent_digest)
+        .expect("ledger atomically claims an unmatched intent");
+    assert!(
+        ledger.claim_unmatched_intent(intent_digest).is_err(),
+        "the same unmatched intent cannot be claimed twice"
+    );
+    let requirement_digest = restored
+        .into_recovery_ticket()
+        .recovery_required(timestamp(1_600))
+        .expect("reconciliation records recovery required")
+        .append_to(&mut ledger)
+        .expect("recovery requirement is durable")
+        .digest();
+    let authorization = ledger
+        .claim_recovery(requirement_digest)
+        .expect("ledger atomically claims the recovery requirement");
+    assert!(
+        ledger.claim_recovery(requirement_digest).is_err(),
+        "the same recovery requirement cannot be claimed twice"
+    );
+    let descriptor = authorization.into_descriptor(
+        EffectRef::from_canonical(b"restart-recovery"),
+        schema_epoch(3),
+        None,
+    );
+    let recovered = execute_effect(
+        Some(&caller),
+        request(descriptor),
+        &FixedClock(timestamp(1_800)),
+        AdmissionDecision::Ready,
+        &mut ledger,
+        || EffectExecution::succeeded(None),
+    )
+    .expect("restart recovery completes on the same ledger");
+    assert_eq!(recovered.outcome(), EffectOutcome::Recovered);
+    assert_eq!(ledger.receipt(2).predecessor(), Some(requirement_digest));
+    assert!(
+        ledger.claim_unmatched_intent(intent_digest).is_err(),
+        "a matched intent cannot be reclaimed after recovery"
+    );
+}

--- a/crates/akroasis/tests/caller_recovery.rs
+++ b/crates/akroasis/tests/caller_recovery.rs
@@ -111,7 +111,7 @@ impl StatefulLedger {
         }
     }
 
-    fn clear_failure(&mut self) {
+    const fn clear_failure(&mut self) {
         self.fail_at = None;
     }
 

--- a/crates/koinon/src/caller.rs
+++ b/crates/koinon/src/caller.rs
@@ -357,7 +357,7 @@ where
         observed_at: Timestamp,
     ) -> Result<ValidatedCaller, CallerContractError> {
         let decision = self.authority.resolve_local(peer, observed_at);
-        self.resolve_decision(PrincipalSource::LocalOsPeer, None, observed_at, decision)
+        Self::resolve_decision(PrincipalSource::LocalOsPeer, None, observed_at, decision)
     }
 
     /// Resolve a caller from accepted service-identity evidence.
@@ -387,7 +387,7 @@ where
             evidence_expires_at,
             observed_at,
         );
-        self.resolve_decision(
+        Self::resolve_decision(
             PrincipalSource::ServiceIdentity,
             Some((identity_ref, authenticated_at, evidence_expires_at)),
             observed_at,
@@ -396,7 +396,6 @@ where
     }
 
     fn resolve_decision(
-        &self,
         source: PrincipalSource,
         expected_service: Option<(CallerRef, Timestamp, Timestamp)>,
         observed_at: Timestamp,
@@ -460,6 +459,10 @@ pub struct ValidatedCaller {
 }
 
 impl ValidatedCaller {
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "authority claims are consumed exactly once at the resolver boundary"
+    )]
     const fn from_authority(source: PrincipalSource, claims: AuthorityClaims) -> Self {
         Self {
             schema_version: CALLER_CONTEXT_VERSION,

--- a/crates/koinon/src/caller.rs
+++ b/crates/koinon/src/caller.rs
@@ -1,0 +1,789 @@
+//! Versioned caller authorization contracts.
+//!
+//! Authentication happens at an application boundary. This module gives that
+//! boundary one closed type to return and gives domain crates one common,
+//! fail-closed authorization vocabulary. It deliberately contains no
+//! credential, token, clock, or policy store.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ensure};
+
+use crate::Timestamp;
+pub use crate::caller_error::CallerContractError;
+use crate::caller_error::{
+    AuthorityUnavailableSnafu, ExpiredSnafu, IdentityReferenceMismatchSnafu,
+    InvalidValidityWindowSnafu, MissingCallerFieldSnafu, NotYetValidSnafu, RevokedIdentitySnafu,
+    ServiceAuthenticationTimeMismatchSnafu, ServiceEvidenceExpiryMismatchSnafu,
+    ServiceEvidenceNotYetValidSnafu, StaleSnafu, UnknownCallerVersionSnafu, UnknownIdentitySnafu,
+    UnknownResolverVersionSnafu, UntrustedIdentitySnafu,
+};
+pub use crate::caller_ref::{
+    CallerRef, CapabilityRef, EffectRef, EvidenceDigest, PersonaRef, PolicyEpoch, ReceiptDigest,
+    SchemaEpoch, ScopeRef,
+};
+
+/// Caller-context schema version understood by this crate.
+pub const CALLER_CONTEXT_VERSION: u16 = 1;
+
+/// Policy-free resolver version understood by this crate.
+pub const CALLER_RESOLVER_VERSION: u16 = 1;
+
+/// Source that authenticated a human or service caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub enum PrincipalSource {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed security vocabulary; changes require a caller-contract version bump
+    /// Local operating-system peer credentials checked against an ACL.
+    LocalOsPeer,
+    /// A nonlocal service identity accepted by the service boundary.
+    ServiceIdentity,
+}
+
+/// Authentication trust recorded on a resolved caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub enum TrustState {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed security vocabulary; changes require a caller-contract version bump
+    /// The configured authority authenticated the principal.
+    Trusted,
+    /// The principal was not authenticated.
+    Untrusted,
+}
+
+/// Revocation state recorded on a resolved caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub enum RevocationState {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed security vocabulary; changes require a caller-contract version bump
+    /// The caller remains active under the current policy epoch.
+    Active,
+    /// The caller was revoked and cannot authorize an operation.
+    Revoked,
+}
+
+/// One exact capability and scope granted by an authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct AuthorityGrant {
+    capability: CapabilityRef,
+    scope: ScopeRef,
+}
+
+impl AuthorityGrant {
+    /// Construct one exact grant.
+    #[must_use]
+    pub const fn new(capability: CapabilityRef, scope: ScopeRef) -> Self {
+        Self { capability, scope }
+    }
+
+    /// Return the granted capability reference.
+    #[must_use]
+    pub const fn capability(&self) -> CapabilityRef {
+        self.capability
+    }
+
+    /// Return the granted scope reference.
+    #[must_use]
+    pub const fn scope(&self) -> ScopeRef {
+        self.scope
+    }
+}
+
+/// Operating-system credentials read from a connected local peer socket.
+///
+/// The application passes kernel-derived values to the shared resolver rather
+/// than treating an address, header, or caller-supplied UID as identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LocalPeerCredentials {
+    uid: u32,
+    gid: u32,
+    pid: Option<u32>,
+}
+
+impl LocalPeerCredentials {
+    /// Construct credentials obtained from an operating-system peer query.
+    #[must_use]
+    pub const fn from_os_peer(uid: u32, gid: u32, pid: Option<u32>) -> Self {
+        Self { uid, gid, pid }
+    }
+
+    /// Return the effective peer user ID.
+    #[must_use]
+    pub const fn uid(&self) -> u32 {
+        self.uid
+    }
+
+    /// Return the effective peer group ID.
+    #[must_use]
+    pub const fn gid(&self) -> u32 {
+        self.gid
+    }
+
+    /// Return the peer process ID when the platform supplies one.
+    #[must_use]
+    pub const fn pid(&self) -> Option<u32> {
+        self.pid
+    }
+}
+
+/// Builder for claims emitted by a trusted application authority adapter.
+///
+/// Authority adapters are trusted application composition, not request data.
+/// The final [`ValidatedCaller`] remains constructible only by
+/// [`CallerResolver`].
+#[derive(Debug, Default)]
+pub struct AuthorityClaimsBuilder {
+    schema_version: Option<u16>,
+    caller_ref: Option<CallerRef>,
+    grant: Option<AuthorityGrant>,
+    policy_epoch: Option<PolicyEpoch>,
+    authenticated_at: Option<Timestamp>,
+    fresh_until: Option<Timestamp>,
+    expires_at: Option<Timestamp>,
+    persona: Option<PersonaRef>,
+}
+
+impl AuthorityClaimsBuilder {
+    /// Start an empty authority-claims builder.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            schema_version: None,
+            caller_ref: None,
+            grant: None,
+            policy_epoch: None,
+            authenticated_at: None,
+            fresh_until: None,
+            expires_at: None,
+            persona: None,
+        }
+    }
+
+    /// Set the caller-contract schema version emitted by the authority.
+    #[must_use]
+    pub const fn schema_version(mut self, schema_version: u16) -> Self {
+        self.schema_version = Some(schema_version);
+        self
+    }
+
+    /// Set the opaque authenticated identity reference.
+    #[must_use]
+    pub const fn caller_ref(mut self, caller_ref: CallerRef) -> Self {
+        self.caller_ref = Some(caller_ref);
+        self
+    }
+
+    /// Set the exact capability and scope grant.
+    #[must_use]
+    pub const fn grant(mut self, grant: AuthorityGrant) -> Self {
+        self.grant = Some(grant);
+        self
+    }
+
+    /// Set the granting policy epoch.
+    #[must_use]
+    pub const fn policy_epoch(mut self, policy_epoch: PolicyEpoch) -> Self {
+        self.policy_epoch = Some(policy_epoch);
+        self
+    }
+
+    /// Set authentication, freshness, and expiry bounds.
+    #[must_use]
+    pub const fn validity(
+        mut self,
+        authenticated_at: Timestamp,
+        fresh_until: Timestamp,
+        expires_at: Timestamp,
+    ) -> Self {
+        self.authenticated_at = Some(authenticated_at);
+        self.fresh_until = Some(fresh_until);
+        self.expires_at = Some(expires_at);
+        self
+    }
+
+    /// Bind the caller to a persona.
+    #[must_use]
+    pub const fn persona(mut self, persona: PersonaRef) -> Self {
+        self.persona = Some(persona);
+        self
+    }
+
+    /// Build authority claims whose structural invariants hold.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CallerContractError`] when a required claim is absent or the
+    /// validity window is empty or non-monotonic.
+    pub fn build(self) -> Result<AuthorityClaims, CallerContractError> {
+        let schema_version = self.schema_version.context(MissingCallerFieldSnafu {
+            field: "schema_version",
+        })?;
+        let caller_ref = self.caller_ref.context(MissingCallerFieldSnafu {
+            field: "caller_ref",
+        })?;
+        let grant = self
+            .grant
+            .context(MissingCallerFieldSnafu { field: "grant" })?;
+        let policy_epoch = self.policy_epoch.context(MissingCallerFieldSnafu {
+            field: "policy_epoch",
+        })?;
+        let authenticated_at = self.authenticated_at.context(MissingCallerFieldSnafu {
+            field: "authenticated_at",
+        })?;
+        let fresh_until = self.fresh_until.context(MissingCallerFieldSnafu {
+            field: "fresh_until",
+        })?;
+        let expires_at = self.expires_at.context(MissingCallerFieldSnafu {
+            field: "expires_at",
+        })?;
+        ensure!(
+            authenticated_at < fresh_until && fresh_until < expires_at,
+            InvalidValidityWindowSnafu
+        );
+
+        Ok(AuthorityClaims {
+            schema_version,
+            caller_ref,
+            grant,
+            policy_epoch,
+            authenticated_at,
+            fresh_until,
+            expires_at,
+            persona: self.persona,
+        })
+    }
+}
+
+/// Policy claims returned by a trusted application authority adapter.
+///
+/// This intermediate type is not caller authority and cannot invoke an
+/// effect. Only [`CallerResolver`] can turn it into a [`ValidatedCaller`].
+#[derive(Debug)]
+pub struct AuthorityClaims {
+    schema_version: u16,
+    caller_ref: CallerRef,
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+    authenticated_at: Timestamp,
+    fresh_until: Timestamp,
+    expires_at: Timestamp,
+    persona: Option<PersonaRef>,
+}
+
+impl AuthorityClaims {
+    /// Start an authority-claims builder.
+    #[must_use]
+    pub const fn builder() -> AuthorityClaimsBuilder {
+        AuthorityClaimsBuilder::new()
+    }
+}
+
+/// Result of consulting the application-owned ACL or service policy.
+#[derive(Debug)]
+pub enum AuthorityDecision {
+    // kanon:ignore RUST/non-exhaustive-enum -- every authority result is handled fail-closed by the versioned resolver
+    /// The authority returned closed policy claims for the principal.
+    Granted(AuthorityClaims),
+    /// The presented identity is not known to the authority.
+    UnknownIdentity,
+    /// The authority could not authenticate the identity.
+    UntrustedIdentity,
+    /// The identity was explicitly revoked.
+    Revoked,
+    /// The authority could not make a current decision.
+    Unavailable,
+}
+
+/// Application-owned source of caller authority.
+///
+/// Implementations validate peer credentials against an ACL and accept a
+/// nonlocal identity only after the service boundary has authenticated it.
+/// Linked application authority adapters are trusted code; hostile request or
+/// wire data cannot implement this trait or deserialize a caller context.
+pub trait CallerAuthority {
+    /// Resolve kernel-derived local peer credentials.
+    fn resolve_local(
+        &self,
+        peer: LocalPeerCredentials,
+        observed_at: Timestamp,
+    ) -> AuthorityDecision;
+
+    /// Resolve an already-authenticated nonlocal identity reference.
+    fn resolve_service(
+        &self,
+        identity_ref: CallerRef,
+        authenticated_at: Timestamp,
+        evidence_expires_at: Timestamp,
+        observed_at: Timestamp,
+    ) -> AuthorityDecision;
+}
+
+/// Policy-free resolver that is the sole caller-context constructor.
+///
+/// Application composition owns this resolver. Domain crates receive only the
+/// resulting [`ValidatedCaller`] and independently enforce their effect-time
+/// scope policy.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct CallerResolver<A> {
+    authority: A,
+}
+
+impl<A> CallerResolver<A>
+where
+    A: CallerAuthority,
+{
+    /// Construct a resolver for a known resolver version.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CallerContractError::UnknownResolverVersion`] for an unknown
+    /// version before consulting the authority.
+    pub fn try_new(resolver_version: u16, authority: A) -> Result<Self, CallerContractError> {
+        ensure!(
+            resolver_version == CALLER_RESOLVER_VERSION,
+            UnknownResolverVersionSnafu { resolver_version }
+        );
+        Ok(Self { authority })
+    }
+
+    /// Resolve a caller from kernel-derived local peer credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed fail-closed error for rejected, unavailable, unknown,
+    /// revoked, stale, expired, or structurally invalid authority output.
+    pub fn resolve_local(
+        &self,
+        peer: LocalPeerCredentials,
+        observed_at: Timestamp,
+    ) -> Result<ValidatedCaller, CallerContractError> {
+        let decision = self.authority.resolve_local(peer, observed_at);
+        self.resolve_decision(PrincipalSource::LocalOsPeer, None, observed_at, decision)
+    }
+
+    /// Resolve a caller from accepted service-identity evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed fail-closed error when the authority rejects the
+    /// service or returns claims for a different identity reference.
+    pub fn resolve_service(
+        &self,
+        identity_ref: CallerRef,
+        authenticated_at: Timestamp,
+        evidence_expires_at: Timestamp,
+        observed_at: Timestamp,
+    ) -> Result<ValidatedCaller, CallerContractError> {
+        ensure!(
+            authenticated_at <= observed_at,
+            ServiceEvidenceNotYetValidSnafu
+        );
+        ensure!(
+            observed_at < evidence_expires_at,
+            ServiceEvidenceExpiryMismatchSnafu
+        );
+        let decision = self.authority.resolve_service(
+            identity_ref,
+            authenticated_at,
+            evidence_expires_at,
+            observed_at,
+        );
+        self.resolve_decision(
+            PrincipalSource::ServiceIdentity,
+            Some((identity_ref, authenticated_at, evidence_expires_at)),
+            observed_at,
+            decision,
+        )
+    }
+
+    fn resolve_decision(
+        &self,
+        source: PrincipalSource,
+        expected_service: Option<(CallerRef, Timestamp, Timestamp)>,
+        observed_at: Timestamp,
+        decision: AuthorityDecision,
+    ) -> Result<ValidatedCaller, CallerContractError> {
+        let claims = match decision {
+            AuthorityDecision::Granted(claims) => claims,
+            AuthorityDecision::UnknownIdentity => return UnknownIdentitySnafu.fail(),
+            AuthorityDecision::UntrustedIdentity => return UntrustedIdentitySnafu.fail(),
+            AuthorityDecision::Revoked => return RevokedIdentitySnafu.fail(),
+            AuthorityDecision::Unavailable => return AuthorityUnavailableSnafu.fail(),
+        };
+
+        ensure!(
+            claims.schema_version == CALLER_CONTEXT_VERSION,
+            UnknownCallerVersionSnafu {
+                schema_version: claims.schema_version,
+            }
+        );
+        if let Some((expected_identity, expected_authenticated_at, evidence_expires_at)) =
+            expected_service
+        {
+            ensure!(
+                claims.caller_ref == expected_identity,
+                IdentityReferenceMismatchSnafu
+            );
+            ensure!(
+                claims.authenticated_at == expected_authenticated_at,
+                ServiceAuthenticationTimeMismatchSnafu
+            );
+            ensure!(
+                claims.expires_at <= evidence_expires_at,
+                ServiceEvidenceExpiryMismatchSnafu
+            );
+        }
+        ensure!(observed_at >= claims.authenticated_at, NotYetValidSnafu);
+        ensure!(observed_at < claims.expires_at, ExpiredSnafu);
+        ensure!(observed_at < claims.fresh_until, StaleSnafu);
+
+        Ok(ValidatedCaller::from_authority(source, claims))
+    }
+}
+
+/// Authenticated caller claims returned by the application resolver.
+///
+/// The type is serializable for minimized diagnostics but deliberately has no
+/// `Deserialize`, `Default`, builder, or public conversion implementation.
+#[derive(PartialEq, Eq, Serialize)]
+pub struct ValidatedCaller {
+    schema_version: u16,
+    source: PrincipalSource,
+    caller_ref: CallerRef,
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+    authenticated_at: Timestamp,
+    fresh_until: Timestamp,
+    expires_at: Timestamp,
+    persona: Option<PersonaRef>,
+    trust: TrustState,
+    revocation: RevocationState,
+}
+
+impl ValidatedCaller {
+    const fn from_authority(source: PrincipalSource, claims: AuthorityClaims) -> Self {
+        Self {
+            schema_version: CALLER_CONTEXT_VERSION,
+            source,
+            caller_ref: claims.caller_ref,
+            grant: claims.grant,
+            policy_epoch: claims.policy_epoch,
+            authenticated_at: claims.authenticated_at,
+            fresh_until: claims.fresh_until,
+            expires_at: claims.expires_at,
+            persona: claims.persona,
+            trust: TrustState::Trusted,
+            revocation: RevocationState::Active,
+        }
+    }
+
+    /// Return the caller-context schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Return the source that authenticated the caller.
+    #[must_use]
+    pub const fn source(&self) -> PrincipalSource {
+        self.source
+    }
+
+    /// Return the caller's opaque identity reference.
+    #[must_use]
+    pub const fn caller_ref(&self) -> CallerRef {
+        self.caller_ref
+    }
+
+    /// Return the exact grant carried by the caller context.
+    #[must_use]
+    pub const fn grant(&self) -> AuthorityGrant {
+        self.grant
+    }
+
+    /// Return the policy epoch that granted this context.
+    #[must_use]
+    pub const fn policy_epoch(&self) -> PolicyEpoch {
+        self.policy_epoch
+    }
+
+    /// Return the optional persona binding.
+    #[must_use]
+    pub const fn persona(&self) -> Option<PersonaRef> {
+        self.persona
+    }
+
+    /// Return the authentication time.
+    #[must_use]
+    pub const fn authenticated_at(&self) -> Timestamp {
+        self.authenticated_at
+    }
+
+    /// Return the first instant at which the context is stale.
+    #[must_use]
+    pub const fn fresh_until(&self) -> Timestamp {
+        self.fresh_until
+    }
+
+    /// Return the first instant at which the context is expired.
+    #[must_use]
+    pub const fn expires_at(&self) -> Timestamp {
+        self.expires_at
+    }
+}
+
+impl fmt::Debug for ValidatedCaller {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ValidatedCaller")
+            .field("schema_version", &self.schema_version)
+            .field("source", &self.source)
+            .field("policy_epoch", &self.policy_epoch)
+            .field("authenticated_at", &self.authenticated_at)
+            .field("fresh_until", &self.fresh_until)
+            .field("expires_at", &self.expires_at)
+            .field("trust", &self.trust)
+            .field("revocation", &self.revocation)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Domain requirement checked immediately before a protected read or effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthorizationRequirement {
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+    persona: Option<PersonaRef>,
+}
+
+impl AuthorizationRequirement {
+    /// Construct one effect-time authorization requirement.
+    #[must_use]
+    pub const fn new(
+        grant: AuthorityGrant,
+        policy_epoch: PolicyEpoch,
+        persona: Option<PersonaRef>,
+    ) -> Self {
+        Self {
+            grant,
+            policy_epoch,
+            persona,
+        }
+    }
+
+    /// Return the required exact grant.
+    #[must_use]
+    pub const fn grant(&self) -> AuthorityGrant {
+        self.grant
+    }
+
+    /// Return the policy epoch that must still be current.
+    #[must_use]
+    pub const fn policy_epoch(&self) -> PolicyEpoch {
+        self.policy_epoch
+    }
+
+    /// Return the exact required persona binding.
+    #[must_use]
+    pub const fn persona(&self) -> Option<PersonaRef> {
+        self.persona
+    }
+}
+
+/// Typed reason a caller failed an immediate authorization check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AuthorizationDenial {
+    // kanon:ignore RUST/non-exhaustive-enum -- denial precedence is a closed, versioned security contract
+    /// No caller context was supplied.
+    MissingContext,
+    /// The caller context schema is not understood.
+    UnknownContextVersion,
+    /// The authority source did not trust the caller.
+    Untrusted,
+    /// The context was used before its authentication time.
+    NotYetValid,
+    /// The caller context reached its freshness bound.
+    Stale,
+    /// The caller context reached its hard expiry.
+    Expired,
+    /// The caller was revoked.
+    Revoked,
+    /// The granting policy epoch is no longer current.
+    PolicyEpochMismatch,
+    /// The caller is bound to a different persona.
+    WrongPersona,
+    /// The caller lacks the required domain capability.
+    InsufficientCapability,
+    /// The capability grant has a different domain scope.
+    InsufficientScope,
+    /// The trusted application clock moved backwards during one effect gate.
+    ClockRegression,
+}
+
+impl fmt::Display for AuthorizationDenial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::MissingContext => "caller context is missing",
+            Self::UnknownContextVersion => "caller context version is unknown",
+            Self::Untrusted => "caller is untrusted",
+            Self::NotYetValid => "caller context is not yet valid",
+            Self::Stale => "caller context is stale",
+            Self::Expired => "caller context is expired",
+            Self::Revoked => "caller is revoked",
+            Self::PolicyEpochMismatch => "caller policy epoch is not current",
+            Self::WrongPersona => "caller persona does not match",
+            Self::InsufficientCapability => "caller capability is insufficient",
+            Self::InsufficientScope => "caller scope is insufficient",
+            Self::ClockRegression => "trusted clock moved backwards during effect admission",
+        };
+        f.write_str(message)
+    }
+}
+
+/// Opaque proof that the shared caller checks passed for one requirement.
+///
+/// The type is linear and constructible only by [`authorize_caller`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuthorizedCaller {
+    caller_ref: CallerRef,
+    grant: AuthorityGrant,
+    policy_epoch: PolicyEpoch,
+    persona: Option<PersonaRef>,
+}
+
+impl AuthorizedCaller {
+    /// Return the authorized caller reference.
+    #[must_use]
+    pub const fn caller_ref(&self) -> CallerRef {
+        self.caller_ref
+    }
+
+    /// Return the exact grant checked for this authorization.
+    #[must_use]
+    pub const fn grant(&self) -> AuthorityGrant {
+        self.grant
+    }
+
+    /// Return the policy epoch checked for this authorization.
+    #[must_use]
+    pub const fn policy_epoch(&self) -> PolicyEpoch {
+        self.policy_epoch
+    }
+
+    /// Return the checked persona binding.
+    #[must_use]
+    pub const fn persona(&self) -> Option<PersonaRef> {
+        self.persona
+    }
+}
+
+/// Authorize one caller against a domain requirement at `observed_at`.
+///
+/// Domains remain responsible for their current capability/scope policy and
+/// for durably recording intent before an effect.
+///
+/// # Errors
+///
+/// Returns [`AuthorizationDenial`] for every fail-closed condition.
+pub fn authorize_caller(
+    caller: Option<&ValidatedCaller>,
+    requirement: &AuthorizationRequirement,
+    observed_at: Timestamp,
+) -> Result<AuthorizedCaller, AuthorizationDenial> {
+    let caller = caller.ok_or(AuthorizationDenial::MissingContext)?;
+    if caller.schema_version != CALLER_CONTEXT_VERSION {
+        return Err(AuthorizationDenial::UnknownContextVersion);
+    }
+    if caller.trust != TrustState::Trusted {
+        return Err(AuthorizationDenial::Untrusted);
+    }
+    if caller.revocation != RevocationState::Active {
+        return Err(AuthorizationDenial::Revoked);
+    }
+    if observed_at < caller.authenticated_at {
+        return Err(AuthorizationDenial::NotYetValid);
+    }
+    if observed_at >= caller.expires_at {
+        return Err(AuthorizationDenial::Expired);
+    }
+    if observed_at >= caller.fresh_until {
+        return Err(AuthorizationDenial::Stale);
+    }
+    if caller.policy_epoch != requirement.policy_epoch {
+        return Err(AuthorizationDenial::PolicyEpochMismatch);
+    }
+    if caller.persona != requirement.persona {
+        return Err(AuthorizationDenial::WrongPersona);
+    }
+    if caller.grant.capability != requirement.grant.capability {
+        return Err(AuthorizationDenial::InsufficientCapability);
+    }
+    if caller.grant.scope != requirement.grant.scope {
+        return Err(AuthorizationDenial::InsufficientScope);
+    }
+
+    Ok(AuthorizedCaller {
+        caller_ref: caller.caller_ref,
+        grant: caller.grant,
+        policy_epoch: caller.policy_epoch,
+        persona: caller.persona,
+    })
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "fixed test fixtures use checked constructors"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forged_context_states_fail_closed() {
+        let timestamp = |millis| Timestamp::from_unix_millis(millis).expect("test timestamp");
+        let grant = AuthorityGrant::new(
+            CapabilityRef::from_canonical(b"radio.read"),
+            ScopeRef::from_canonical(b"configured-radio"),
+        );
+        let requirement = AuthorizationRequirement::new(
+            grant,
+            PolicyEpoch::try_from_u64(1).expect("test epoch"),
+            None,
+        );
+        let base = || ValidatedCaller {
+            schema_version: CALLER_CONTEXT_VERSION,
+            source: PrincipalSource::LocalOsPeer,
+            caller_ref: CallerRef::from_canonical(b"test-caller"),
+            grant,
+            policy_epoch: PolicyEpoch::try_from_u64(1).expect("test epoch"),
+            authenticated_at: timestamp(1_000),
+            fresh_until: timestamp(2_000),
+            expires_at: timestamp(3_000),
+            persona: None,
+            trust: TrustState::Trusted,
+            revocation: RevocationState::Active,
+        };
+
+        let mut unknown = base();
+        unknown.schema_version = CALLER_CONTEXT_VERSION + 1;
+        assert_eq!(
+            authorize_caller(Some(&unknown), &requirement, timestamp(1_500)),
+            Err(AuthorizationDenial::UnknownContextVersion),
+            "unknown caller versions must fail closed"
+        );
+
+        let mut untrusted = base();
+        untrusted.trust = TrustState::Untrusted;
+        assert_eq!(
+            authorize_caller(Some(&untrusted), &requirement, timestamp(1_500)),
+            Err(AuthorizationDenial::Untrusted),
+            "untrusted contexts must fail closed"
+        );
+
+        let mut revoked = base();
+        revoked.revocation = RevocationState::Revoked;
+        assert_eq!(
+            authorize_caller(Some(&revoked), &requirement, timestamp(1_500)),
+            Err(AuthorizationDenial::Revoked),
+            "revoked contexts must fail closed"
+        );
+    }
+}

--- a/crates/koinon/src/caller_error.rs
+++ b/crates/koinon/src/caller_error.rs
@@ -1,0 +1,130 @@
+//! Errors for the shared caller resolver and contract constructors.
+
+use snafu::Snafu;
+
+/// Errors produced while constructing or resolving caller contracts.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum CallerContractError {
+    /// A required epoch was zero.
+    #[snafu(display("{field} must be non-zero"))]
+    ZeroEpoch {
+        /// Epoch type whose value was invalid.
+        field: &'static str,
+        /// Source location of the invalid construction.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A required authority claim was absent.
+    #[snafu(display("authority claim '{field}' is required"))]
+    MissingCallerField {
+        /// Missing claim name.
+        field: &'static str,
+        /// Source location of the invalid construction.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Caller validity bounds were empty or non-monotonic.
+    #[snafu(display("caller validity must satisfy authenticated_at < fresh_until < expires_at"))]
+    InvalidValidityWindow {
+        /// Source location of the invalid construction.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Resolver configuration named an unknown version.
+    #[snafu(display("unknown caller resolver version {resolver_version}"))]
+    UnknownResolverVersion {
+        /// Unsupported resolver version.
+        resolver_version: u16,
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Authority claims named an unknown caller-context version.
+    #[snafu(display("unknown caller context version {schema_version}"))]
+    UnknownCallerVersion {
+        /// Unsupported caller-context version.
+        schema_version: u16,
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// The authority did not know the presented identity.
+    #[snafu(display("caller identity is unknown"))]
+    UnknownIdentity {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// The authority could not authenticate the identity.
+    #[snafu(display("caller identity is untrusted"))]
+    UntrustedIdentity {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// The authority reported the identity as revoked.
+    #[snafu(display("caller identity is revoked"))]
+    RevokedIdentity {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// The authority could not make a current decision.
+    #[snafu(display("caller authority is unavailable"))]
+    AuthorityUnavailable {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service evidence claimed to authenticate in the future.
+    #[snafu(display("service identity evidence is not yet valid"))]
+    ServiceEvidenceNotYetValid {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service evidence and authority claims named different identities.
+    #[snafu(display("service identity reference does not match authority claims"))]
+    IdentityReferenceMismatch {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service evidence and claims named different authentication times.
+    #[snafu(display("service authentication time does not match authority claims"))]
+    ServiceAuthenticationTimeMismatch {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Service claims outlived the accepted authentication evidence.
+    #[snafu(display("service caller validity exceeds its authentication evidence"))]
+    ServiceEvidenceExpiryMismatch {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Caller claims were used before authentication.
+    #[snafu(display("caller context is not yet valid"))]
+    NotYetValid {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Caller claims reached the freshness boundary.
+    #[snafu(display("caller context is stale"))]
+    Stale {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Caller claims reached their hard expiry.
+    #[snafu(display("caller context is expired"))]
+    Expired {
+        /// Source location of the failed resolution.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/koinon/src/caller_ref.rs
+++ b/crates/koinon/src/caller_ref.rs
@@ -1,0 +1,123 @@
+//! Opaque references and epochs used by caller and receipt contracts.
+
+use std::fmt;
+use std::num::NonZeroU64;
+
+use serde::{Deserialize, Serialize};
+use snafu::OptionExt;
+
+use crate::caller_error::{CallerContractError, ZeroEpochSnafu};
+
+macro_rules! define_opaque_ref {
+    ($name:ident, $domain:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[repr(transparent)]
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            /// Derive an opaque reference from a canonical value.
+            ///
+            /// The original value is not retained. References identify a
+            /// policy object; they are not proof that the object was trusted.
+            #[must_use]
+            pub fn from_canonical(value: &[u8]) -> Self {
+                let mut hasher = blake3::Hasher::new();
+                hasher.update($domain.as_bytes());
+                hasher.update(&[0]);
+                hasher.update(value);
+                Self(hasher.finalize().into())
+            }
+
+            /// Return the opaque reference bytes.
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; 32] {
+                &self.0
+            }
+        }
+
+        impl AsRef<[u8; 32]> for $name {
+            fn as_ref(&self) -> &[u8; 32] {
+                self.as_bytes()
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(concat!(stringify!($name), "(<opaque>)"))
+            }
+        }
+    };
+}
+
+define_opaque_ref!(
+    CallerRef,
+    "akroasis.caller.v1",
+    "Opaque caller identity reference."
+);
+define_opaque_ref!(
+    PersonaRef,
+    "akroasis.persona.v1",
+    "Opaque caller persona reference."
+);
+define_opaque_ref!(
+    CapabilityRef,
+    "akroasis.capability.v1",
+    "Opaque domain-capability reference."
+);
+define_opaque_ref!(
+    ScopeRef,
+    "akroasis.scope.v1",
+    "Opaque domain-owned scope reference."
+);
+define_opaque_ref!(
+    EffectRef,
+    "akroasis.effect.v1",
+    "Opaque protected-effect reference."
+);
+define_opaque_ref!(
+    EvidenceDigest,
+    "akroasis.evidence.v1",
+    "Digest of allowlisted effect evidence."
+);
+define_opaque_ref!(
+    ReceiptDigest,
+    "akroasis.receipt.v1",
+    "Digest of a durable minimized receipt."
+);
+
+macro_rules! define_epoch {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[repr(transparent)]
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize,
+        )]
+        pub struct $name(NonZeroU64);
+
+        impl $name {
+            /// Construct a non-zero epoch.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`CallerContractError::ZeroEpoch`] when `value` is zero.
+            pub fn try_from_u64(value: u64) -> Result<Self, CallerContractError> {
+                NonZeroU64::new(value).map(Self).context(ZeroEpochSnafu {
+                    field: stringify!($name),
+                })
+            }
+
+            /// Return the epoch as an integer.
+            #[must_use]
+            pub const fn get(self) -> u64 {
+                self.0.get()
+            }
+        }
+    };
+}
+
+define_epoch!(PolicyEpoch, "Version of the policy that granted authority.");
+define_epoch!(
+    SchemaEpoch,
+    "Version of the domain schema governing an effect."
+);

--- a/crates/koinon/src/caller_ref.rs
+++ b/crates/koinon/src/caller_ref.rs
@@ -23,7 +23,7 @@ macro_rules! define_opaque_ref {
             #[must_use]
             pub fn from_canonical(value: &[u8]) -> Self {
                 let mut hasher = blake3::Hasher::new();
-                hasher.update($domain.as_bytes());
+                hasher.update($domain);
                 hasher.update(&[0]);
                 hasher.update(value);
                 Self(hasher.finalize().into())
@@ -52,37 +52,37 @@ macro_rules! define_opaque_ref {
 
 define_opaque_ref!(
     CallerRef,
-    "akroasis.caller.v1",
+    b"akroasis.caller.v1",
     "Opaque caller identity reference."
 );
 define_opaque_ref!(
     PersonaRef,
-    "akroasis.persona.v1",
+    b"akroasis.persona.v1",
     "Opaque caller persona reference."
 );
 define_opaque_ref!(
     CapabilityRef,
-    "akroasis.capability.v1",
+    b"akroasis.capability.v1",
     "Opaque domain-capability reference."
 );
 define_opaque_ref!(
     ScopeRef,
-    "akroasis.scope.v1",
+    b"akroasis.scope.v1",
     "Opaque domain-owned scope reference."
 );
 define_opaque_ref!(
     EffectRef,
-    "akroasis.effect.v1",
+    b"akroasis.effect.v1",
     "Opaque protected-effect reference."
 );
 define_opaque_ref!(
     EvidenceDigest,
-    "akroasis.evidence.v1",
+    b"akroasis.evidence.v1",
     "Digest of allowlisted effect evidence."
 );
 define_opaque_ref!(
     ReceiptDigest,
-    "akroasis.receipt.v1",
+    b"akroasis.receipt.v1",
     "Digest of a durable minimized receipt."
 );
 

--- a/crates/koinon/src/effect_receipt.rs
+++ b/crates/koinon/src/effect_receipt.rs
@@ -214,6 +214,10 @@ impl EffectReceipt {
     ///
     /// Returns [`EffectReceiptError::RecoveryIntentPrecedesRequirement`] when
     /// a recovery operation is observed before its durable requirement.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "one authorization proof must be consumed by exactly one intent"
+    )]
     pub fn intent(
         caller: AuthorizedCaller,
         descriptor: EffectDescriptor,
@@ -498,7 +502,7 @@ impl EffectReceipt {
     }
 }
 
-fn expected_outcome_relation(
+const fn expected_outcome_relation(
     intent: &EffectReceipt,
     outcome: EffectOutcome,
 ) -> Result<RecoveryRelation, EffectReceiptError> {

--- a/crates/koinon/src/effect_receipt.rs
+++ b/crates/koinon/src/effect_receipt.rs
@@ -1,0 +1,698 @@
+//! Minimized receipts for protected effects.
+//!
+//! The schema carries only opaque references, epochs, closed state, and
+//! allowlisted digests. Raw paths, frequencies, rules, payloads, content,
+//! keys, credentials, and free-form descriptions have no field to occupy.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use snafu::Snafu;
+
+use crate::Timestamp;
+use crate::caller::{
+    AuthorizedCaller, CallerRef, CapabilityRef, EffectRef, EvidenceDigest, PolicyEpoch,
+    ReceiptDigest, SchemaEpoch,
+};
+use crate::effect_receipt_state::{PendingIntent, RecoveryAuthorization};
+
+/// Current serialized effect-receipt schema version.
+pub const EFFECT_RECEIPT_VERSION: u16 = 1;
+
+/// Closed outcome of a protected effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EffectOutcome {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed receipt vocabulary; changes require a receipt-contract version bump
+    /// The effect completed successfully.
+    Succeeded,
+    /// The effect failed without a committed state change.
+    Failed,
+    /// The effect changed state only partially.
+    Partial,
+    /// Admission was cancelled before the domain effect ran.
+    Cancelled,
+    /// Admission was refused by a bounded resource budget.
+    Backpressured,
+    /// Caller authority lapsed after durable intent but before domain I/O.
+    AuthorizationDenied,
+    /// Restart reconciliation found an unmatched or uncertain intent.
+    RecoveryRequired,
+    /// An explicitly authorized recovery completed.
+    Recovered,
+}
+
+/// Typed relation between an operation and recovery work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RecoveryRelation {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed recovery state machine rejects unknown wire variants
+    /// The operation is not recovery work and needs no recovery.
+    None,
+    /// The referenced operation requires explicit recovery.
+    RequiredFor(EffectRef),
+    /// This operation is an explicit recovery of the referenced effect.
+    RecoveryOf(EffectRef),
+}
+
+/// Closed event carried by an [`EffectReceipt`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ReceiptEvent {
+    // kanon:ignore RUST/non-exhaustive-enum -- receipt schema intentionally permits only intent and outcome
+    /// Durable intent recorded before invoking the effect.
+    Intent,
+    /// Terminal, partial, or recovery state after an intent.
+    Outcome(EffectOutcome),
+}
+
+/// Proven parent/child relation between two durable receipts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ValidatedReceiptLink {
+    // kanon:ignore RUST/non-exhaustive-enum -- closed transition proof; unknown link kinds must not be admitted
+    /// An outcome is bound to its exact protected intent.
+    Outcome,
+    /// A recovery intent is bound to one unresolved outcome.
+    RecoveryIntent,
+}
+
+/// Immutable metadata describing one protected operation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EffectDescriptor {
+    effect: EffectRef,
+    schema_epoch: SchemaEpoch,
+    evidence_digest: Option<EvidenceDigest>,
+    recovery: Option<RecoveryAuthorization>,
+}
+
+impl EffectDescriptor {
+    /// Construct metadata for a normal protected operation.
+    #[must_use]
+    pub const fn new(
+        effect: EffectRef,
+        schema_epoch: SchemaEpoch,
+        evidence_digest: Option<EvidenceDigest>,
+    ) -> Self {
+        Self {
+            effect,
+            schema_epoch,
+            evidence_digest,
+            recovery: None,
+        }
+    }
+
+    pub(crate) const fn from_recovery(
+        effect: EffectRef,
+        schema_epoch: SchemaEpoch,
+        evidence_digest: Option<EvidenceDigest>,
+        recovery: RecoveryAuthorization,
+    ) -> Self {
+        Self {
+            effect,
+            schema_epoch,
+            evidence_digest,
+            recovery: Some(recovery),
+        }
+    }
+
+    /// Return the protected effect reference.
+    #[must_use]
+    pub const fn effect(&self) -> EffectRef {
+        self.effect
+    }
+
+    /// Return the governing schema epoch.
+    #[must_use]
+    pub const fn schema_epoch(&self) -> SchemaEpoch {
+        self.schema_epoch
+    }
+
+    /// Return the optional allowlisted evidence digest.
+    #[must_use]
+    pub const fn evidence_digest(&self) -> Option<EvidenceDigest> {
+        self.evidence_digest
+    }
+
+    /// Return the original effect when this is recovery work.
+    #[must_use]
+    pub const fn recovery_of(&self) -> Option<EffectRef> {
+        match &self.recovery {
+            Some(recovery) => Some(recovery.original_effect()),
+            None => None,
+        }
+    }
+}
+
+/// Stable references shared by receipts for one protected operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReceiptContext {
+    caller_ref: CallerRef,
+    effect: EffectRef,
+    capability: CapabilityRef,
+    policy_epoch: PolicyEpoch,
+    schema_epoch: SchemaEpoch,
+}
+
+impl ReceiptContext {
+    const fn from_authorized(
+        caller: &AuthorizedCaller,
+        effect: EffectRef,
+        schema_epoch: SchemaEpoch,
+    ) -> Self {
+        Self {
+            caller_ref: caller.caller_ref(),
+            effect,
+            capability: caller.grant().capability(),
+            policy_epoch: caller.policy_epoch(),
+            schema_epoch,
+        }
+    }
+
+    /// Return the canonical caller reference.
+    #[must_use]
+    pub const fn caller_ref(&self) -> CallerRef {
+        self.caller_ref
+    }
+
+    /// Return the protected effect reference.
+    #[must_use]
+    pub const fn effect(&self) -> EffectRef {
+        self.effect
+    }
+
+    /// Return the checked capability reference.
+    #[must_use]
+    pub const fn capability(&self) -> CapabilityRef {
+        self.capability
+    }
+
+    /// Return the granting policy epoch.
+    #[must_use]
+    pub const fn policy_epoch(&self) -> PolicyEpoch {
+        self.policy_epoch
+    }
+
+    /// Return the domain schema epoch.
+    #[must_use]
+    pub const fn schema_epoch(&self) -> SchemaEpoch {
+        self.schema_epoch
+    }
+}
+
+/// One versioned, minimized intent or outcome receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EffectReceipt {
+    schema_version: u16,
+    context: ReceiptContext,
+    event: ReceiptEvent,
+    observed_at: Timestamp,
+    evidence_digest: Option<EvidenceDigest>,
+    predecessor: Option<ReceiptDigest>,
+    recovery: RecoveryRelation,
+}
+
+impl EffectReceipt {
+    /// Construct an intent from a linear, effect-time authorization proof.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectReceiptError::RecoveryIntentPrecedesRequirement`] when
+    /// a recovery operation is observed before its durable requirement.
+    pub fn intent(
+        caller: AuthorizedCaller,
+        descriptor: EffectDescriptor,
+        observed_at: Timestamp,
+    ) -> Result<PendingIntent, EffectReceiptError> {
+        let EffectDescriptor {
+            effect,
+            schema_epoch,
+            evidence_digest,
+            recovery,
+        } = descriptor;
+        let (predecessor, recovery) = match recovery {
+            Some(recovery) => {
+                let (original_effect, requirement_digest, requirement_observed_at) =
+                    recovery.into_parts();
+                if observed_at < requirement_observed_at {
+                    return Err(EffectReceiptError::RecoveryIntentPrecedesRequirement {
+                        location: snafu::location!(),
+                    });
+                }
+                (
+                    Some(requirement_digest),
+                    RecoveryRelation::RecoveryOf(original_effect),
+                )
+            }
+            None => (None, RecoveryRelation::None),
+        };
+        Ok(PendingIntent::new(Self {
+            schema_version: EFFECT_RECEIPT_VERSION,
+            context: ReceiptContext::from_authorized(&caller, effect, schema_epoch),
+            event: ReceiptEvent::Intent,
+            observed_at,
+            evidence_digest,
+            predecessor,
+            recovery,
+        }))
+    }
+
+    pub(crate) fn outcome_from(
+        intent: &Self,
+        intent_digest: ReceiptDigest,
+        observed_at: Timestamp,
+        outcome: EffectOutcome,
+        evidence_digest: Option<EvidenceDigest>,
+    ) -> Result<Self, EffectReceiptError> {
+        if intent.event != ReceiptEvent::Intent {
+            return Err(EffectReceiptError::PredecessorIsNotIntent {
+                location: snafu::location!(),
+            });
+        }
+        let valid_intent = matches!(
+            (intent.predecessor, intent.recovery),
+            (None, RecoveryRelation::None) | (Some(_), RecoveryRelation::RecoveryOf(_))
+        );
+        if !valid_intent {
+            return Err(EffectReceiptError::InvalidIntentShape {
+                location: snafu::location!(),
+            });
+        }
+        if observed_at < intent.observed_at {
+            return Err(EffectReceiptError::OutcomePrecedesIntent {
+                location: snafu::location!(),
+            });
+        }
+
+        let (outcome, recovery) = match (outcome, intent.recovery) {
+            (
+                EffectOutcome::Succeeded | EffectOutcome::Recovered,
+                RecoveryRelation::RecoveryOf(original),
+            ) => (
+                EffectOutcome::Recovered,
+                RecoveryRelation::RecoveryOf(original),
+            ),
+            (EffectOutcome::Recovered, _) => {
+                return Err(EffectReceiptError::RecoveryRelationMismatch {
+                    location: snafu::location!(),
+                });
+            }
+            (EffectOutcome::Partial | EffectOutcome::RecoveryRequired, _) => (
+                outcome,
+                RecoveryRelation::RequiredFor(intent.context.effect),
+            ),
+            (other, relation @ RecoveryRelation::RecoveryOf(_)) => (other, relation),
+            (other, RecoveryRelation::None) => (other, RecoveryRelation::None),
+            (_, RecoveryRelation::RequiredFor(_)) => {
+                return Err(EffectReceiptError::RecoveryRelationMismatch {
+                    location: snafu::location!(),
+                });
+            }
+        };
+
+        Self::validate(
+            EFFECT_RECEIPT_VERSION,
+            intent.context,
+            ReceiptEvent::Outcome(outcome),
+            observed_at,
+            evidence_digest,
+            Some(intent_digest),
+            recovery,
+        )
+    }
+
+    /// Return the receipt schema version.
+    #[must_use]
+    pub const fn schema_version(&self) -> u16 {
+        self.schema_version
+    }
+
+    /// Return the minimized receipt context.
+    #[must_use]
+    pub const fn context(&self) -> &ReceiptContext {
+        &self.context
+    }
+
+    /// Return the closed event.
+    #[must_use]
+    pub const fn event(&self) -> ReceiptEvent {
+        self.event
+    }
+
+    /// Return the observation time.
+    #[must_use]
+    pub const fn observed_at(&self) -> Timestamp {
+        self.observed_at
+    }
+
+    /// Return the optional allowlisted evidence digest.
+    #[must_use]
+    pub const fn evidence_digest(&self) -> Option<EvidenceDigest> {
+        self.evidence_digest
+    }
+
+    /// Return the durable predecessor for an outcome or recovery intent.
+    #[must_use]
+    pub const fn predecessor(&self) -> Option<ReceiptDigest> {
+        self.predecessor
+    }
+
+    /// Return the typed recovery relation.
+    #[must_use]
+    pub const fn recovery(&self) -> RecoveryRelation {
+        self.recovery
+    }
+
+    /// Validate this receipt as the exact child of a durable predecessor.
+    ///
+    /// Ledger adapters call this before accepting a child. Outcome context is
+    /// copied exactly from its intent. Recovery intents may use a new effect
+    /// context, but their recovery target must equal the unresolved target
+    /// named by the predecessor outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed contract error when the digest, time, context, event,
+    /// or recovery target does not form an allowed transition.
+    pub fn validate_child_of(
+        &self,
+        predecessor: &Self,
+        predecessor_digest: ReceiptDigest,
+    ) -> Result<ValidatedReceiptLink, EffectReceiptError> {
+        if self.predecessor != Some(predecessor_digest) {
+            return Err(EffectReceiptError::PredecessorDigestMismatch {
+                location: snafu::location!(),
+            });
+        }
+        if self.observed_at < predecessor.observed_at {
+            return Err(EffectReceiptError::ChildPrecedesPredecessor {
+                location: snafu::location!(),
+            });
+        }
+        match (self.event, predecessor.event) {
+            (ReceiptEvent::Outcome(outcome), ReceiptEvent::Intent) => {
+                self.validate_outcome_child(predecessor, outcome)?;
+                Ok(ValidatedReceiptLink::Outcome)
+            }
+            (ReceiptEvent::Intent, ReceiptEvent::Outcome(outcome)) => {
+                self.validate_recovery_intent_child(predecessor, outcome)?;
+                Ok(ValidatedReceiptLink::RecoveryIntent)
+            }
+            _ => Err(EffectReceiptError::InvalidPredecessorTransition {
+                location: snafu::location!(),
+            }),
+        }
+    }
+
+    fn validate_outcome_child(
+        &self,
+        intent: &Self,
+        outcome: EffectOutcome,
+    ) -> Result<(), EffectReceiptError> {
+        if self.context != intent.context {
+            return Err(EffectReceiptError::PredecessorContextMismatch {
+                location: snafu::location!(),
+            });
+        }
+        let expected = expected_outcome_relation(intent, outcome)?;
+        if self.recovery != expected {
+            return Err(EffectReceiptError::RecoveryTargetMismatch {
+                location: snafu::location!(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_recovery_intent_child(
+        &self,
+        outcome: &Self,
+        outcome_kind: EffectOutcome,
+    ) -> Result<(), EffectReceiptError> {
+        let expected = match (outcome_kind, outcome.recovery) {
+            (
+                EffectOutcome::Partial | EffectOutcome::RecoveryRequired,
+                RecoveryRelation::RequiredFor(effect),
+            )
+            | (
+                EffectOutcome::Failed
+                | EffectOutcome::Cancelled
+                | EffectOutcome::Backpressured
+                | EffectOutcome::AuthorizationDenied,
+                RecoveryRelation::RecoveryOf(effect),
+            ) => RecoveryRelation::RecoveryOf(effect),
+            _ => {
+                return Err(EffectReceiptError::InvalidPredecessorTransition {
+                    location: snafu::location!(),
+                });
+            }
+        };
+        if self.recovery != expected {
+            return Err(EffectReceiptError::RecoveryTargetMismatch {
+                location: snafu::location!(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate(
+        schema_version: u16,
+        context: ReceiptContext,
+        event: ReceiptEvent,
+        observed_at: Timestamp,
+        evidence_digest: Option<EvidenceDigest>,
+        predecessor: Option<ReceiptDigest>,
+        recovery: RecoveryRelation,
+    ) -> Result<Self, EffectReceiptError> {
+        if schema_version != EFFECT_RECEIPT_VERSION {
+            return Err(EffectReceiptError::UnknownVersion {
+                schema_version,
+                location: snafu::location!(),
+            });
+        }
+        match event {
+            ReceiptEvent::Intent => {
+                let valid = matches!((predecessor, recovery), (None, RecoveryRelation::None))
+                    || matches!(
+                        (predecessor, recovery),
+                        (Some(_), RecoveryRelation::RecoveryOf(_))
+                    );
+                if !valid {
+                    return Err(EffectReceiptError::InvalidIntentShape {
+                        location: snafu::location!(),
+                    });
+                }
+            }
+            ReceiptEvent::Outcome(outcome) => {
+                if predecessor.is_none() {
+                    return Err(EffectReceiptError::MissingPredecessor {
+                        location: snafu::location!(),
+                    });
+                }
+                validate_outcome_relation(context.effect, outcome, recovery)?;
+            }
+        }
+        Ok(Self {
+            schema_version,
+            context,
+            event,
+            observed_at,
+            evidence_digest,
+            predecessor,
+            recovery,
+        })
+    }
+}
+
+fn expected_outcome_relation(
+    intent: &EffectReceipt,
+    outcome: EffectOutcome,
+) -> Result<RecoveryRelation, EffectReceiptError> {
+    match (intent.recovery, outcome) {
+        (
+            RecoveryRelation::None,
+            EffectOutcome::Succeeded
+            | EffectOutcome::Failed
+            | EffectOutcome::Cancelled
+            | EffectOutcome::Backpressured
+            | EffectOutcome::AuthorizationDenied,
+        ) => Ok(RecoveryRelation::None),
+        (RecoveryRelation::None, EffectOutcome::Partial | EffectOutcome::RecoveryRequired) => {
+            Ok(RecoveryRelation::RequiredFor(intent.context.effect))
+        }
+        (
+            RecoveryRelation::RecoveryOf(effect),
+            EffectOutcome::Failed
+            | EffectOutcome::Cancelled
+            | EffectOutcome::Backpressured
+            | EffectOutcome::AuthorizationDenied
+            | EffectOutcome::Recovered,
+        ) => Ok(RecoveryRelation::RecoveryOf(effect)),
+        (
+            RecoveryRelation::RecoveryOf(_),
+            EffectOutcome::Partial | EffectOutcome::RecoveryRequired,
+        ) => Ok(RecoveryRelation::RequiredFor(intent.context.effect)),
+        _ => Err(EffectReceiptError::InvalidPredecessorTransition {
+            location: snafu::location!(),
+        }),
+    }
+}
+
+fn validate_outcome_relation(
+    effect: EffectRef,
+    outcome: EffectOutcome,
+    recovery: RecoveryRelation,
+) -> Result<(), EffectReceiptError> {
+    let valid = match outcome {
+        EffectOutcome::Partial | EffectOutcome::RecoveryRequired => {
+            recovery == RecoveryRelation::RequiredFor(effect)
+        }
+        EffectOutcome::Recovered => matches!(recovery, RecoveryRelation::RecoveryOf(_)),
+        EffectOutcome::Succeeded => recovery == RecoveryRelation::None,
+        EffectOutcome::Failed
+        | EffectOutcome::Cancelled
+        | EffectOutcome::Backpressured
+        | EffectOutcome::AuthorizationDenied => matches!(
+            recovery,
+            RecoveryRelation::None | RecoveryRelation::RecoveryOf(_)
+        ),
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(EffectReceiptError::RecoveryRelationMismatch {
+            location: snafu::location!(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawEffectReceipt {
+    schema_version: u16,
+    context: ReceiptContext,
+    event: ReceiptEvent,
+    observed_at: Timestamp,
+    evidence_digest: Option<EvidenceDigest>,
+    predecessor: Option<ReceiptDigest>,
+    recovery: RecoveryRelation,
+}
+
+impl<'de> Deserialize<'de> for EffectReceipt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawEffectReceipt::deserialize(deserializer)?;
+        Self::validate(
+            raw.schema_version,
+            raw.context,
+            raw.event,
+            raw.observed_at,
+            raw.evidence_digest,
+            raw.predecessor,
+            raw.recovery,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Errors returned when a minimized effect receipt violates its schema.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum EffectReceiptError {
+    /// The serialized schema version is not understood.
+    #[snafu(display("unknown effect-receipt schema version {schema_version}"))]
+    UnknownVersion {
+        /// Unsupported version.
+        schema_version: u16,
+        /// Source location of the invalid receipt.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// An intent carried an invalid predecessor or recovery relation.
+    #[snafu(display("effect intent has an invalid predecessor or recovery relation"))]
+    InvalidIntentShape {
+        /// Source location of the invalid receipt.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// An outcome was not linked to its durable intent.
+    #[snafu(display("effect outcome requires a durable intent predecessor"))]
+    MissingPredecessor {
+        /// Source location of the invalid receipt.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// An outcome constructor was given a non-intent predecessor.
+    #[snafu(display("effect outcome predecessor is not an intent receipt"))]
+    PredecessorIsNotIntent {
+        /// Source location of the invalid receipt.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A persisted receipt presented as an outcome was not one.
+    #[snafu(display("persisted receipt is not an effect outcome"))]
+    PersistedReceiptIsNotOutcome {
+        /// Source location of the invalid reconstruction.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A terminal outcome was presented as recovery authority.
+    #[snafu(display("persisted outcome does not require recovery"))]
+    NotRecoveryRequirement {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Outcome time moved backwards relative to its intent.
+    #[snafu(display("effect outcome precedes its durable intent"))]
+    OutcomePrecedesIntent {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A recovery intent predates the durable requirement authorizing it.
+    #[snafu(display("recovery intent precedes its durable recovery requirement"))]
+    RecoveryIntentPrecedesRequirement {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A child did not name the supplied predecessor's canonical digest.
+    #[snafu(display("effect receipt predecessor digest does not match"))]
+    PredecessorDigestMismatch {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A child receipt predates its durable predecessor.
+    #[snafu(display("effect receipt child precedes its durable predecessor"))]
+    ChildPrecedesPredecessor {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// An outcome changed the protected intent's receipt context.
+    #[snafu(display("effect outcome context does not match its intent"))]
+    PredecessorContextMismatch {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// Parent and child events do not form an allowed receipt transition.
+    #[snafu(display("effect receipts do not form an allowed predecessor transition"))]
+    InvalidPredecessorTransition {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// A recovery child named a different unresolved operation.
+    #[snafu(display("effect receipt recovery target does not match its predecessor"))]
+    RecoveryTargetMismatch {
+        /// Source location of the invalid transition.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+    /// The outcome and recovery relation describe incompatible state.
+    #[snafu(display("effect outcome has an incompatible recovery relation"))]
+    RecoveryRelationMismatch {
+        /// Source location of the invalid receipt.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}

--- a/crates/koinon/src/effect_receipt_state.rs
+++ b/crates/koinon/src/effect_receipt_state.rs
@@ -209,7 +209,7 @@ impl PersistedOutcome {
     ///
     /// Returns [`EffectReceiptError::PersistedReceiptIsNotOutcome`] unless the
     /// verified receipt is an outcome.
-    pub fn from_verified(
+    pub const fn from_verified(
         receipt: EffectReceipt,
         digest: ReceiptDigest,
     ) -> Result<Self, EffectReceiptError> {
@@ -227,7 +227,7 @@ impl PersistedOutcome {
     ///
     /// Returns [`EffectReceiptError::PersistedReceiptIsNotOutcome`] if a
     /// ledger adapter violated the persisted-outcome constructor contract.
-    pub fn outcome(&self) -> Result<EffectOutcome, EffectReceiptError> {
+    pub const fn outcome(&self) -> Result<EffectOutcome, EffectReceiptError> {
         match self.receipt.event() {
             ReceiptEvent::Outcome(outcome) => Ok(outcome),
             ReceiptEvent::Intent => Err(EffectReceiptError::PersistedReceiptIsNotOutcome {
@@ -259,7 +259,9 @@ impl PersistedOutcome {
     ///
     /// Returns [`EffectReceiptError::NotRecoveryRequirement`] for an outcome
     /// that does not authorize recovery.
-    pub fn into_recovery_authorization(self) -> Result<RecoveryAuthorization, EffectReceiptError> {
+    pub const fn into_recovery_authorization(
+        self,
+    ) -> Result<RecoveryAuthorization, EffectReceiptError> {
         match (self.receipt.event(), self.receipt.recovery()) {
             (
                 ReceiptEvent::Outcome(EffectOutcome::Partial | EffectOutcome::RecoveryRequired),

--- a/crates/koinon/src/effect_receipt_state.rs
+++ b/crates/koinon/src/effect_receipt_state.rs
@@ -1,0 +1,404 @@
+//! Linear persistence and recovery states for effect receipts.
+
+use snafu::Snafu;
+
+use crate::Timestamp;
+use crate::caller::{EffectRef, EvidenceDigest, ReceiptDigest, SchemaEpoch};
+use crate::effect_receipt::{
+    EffectDescriptor, EffectOutcome, EffectReceipt, EffectReceiptError, ReceiptEvent,
+    RecoveryRelation,
+};
+
+/// Append-only application ledger for minimized effect receipts.
+///
+/// Implementations bind this contract to the accepted tamper-log primitive;
+/// domains do not create a second receipt schema or log. Linked ledger
+/// adapters are trusted application composition, not request data.
+pub trait EffectReceiptSink {
+    /// Sink-specific append failure.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Durably append one receipt and return its canonical ledger digest.
+    ///
+    /// The returned digest must identify exactly one accepted ledger entry.
+    /// An adapter must either allocate a distinct position/hash-chain digest
+    /// or atomically reject a byte-identical receipt already present. It must
+    /// validate child receipts with [`EffectReceipt::validate_child_of`]
+    /// before returning success, so an effect never runs on ambiguous intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns the adapter's typed failure when the receipt was not durably
+    /// accepted. Callers must not construct a persisted handle on failure.
+    fn append(&mut self, receipt: &EffectReceipt) -> Result<ReceiptDigest, Self::Error>;
+}
+
+/// Linear intent that has not yet been durably appended.
+#[derive(Debug)]
+pub struct PendingIntent {
+    receipt: EffectReceipt,
+}
+
+impl PendingIntent {
+    pub(crate) const fn new(receipt: EffectReceipt) -> Self {
+        Self { receipt }
+    }
+
+    /// Borrow the intent receipt before durable append.
+    #[must_use]
+    pub const fn receipt(&self) -> &EffectReceipt {
+        &self.receipt
+    }
+
+    /// Append the exact intent and return a sealed persisted handle.
+    ///
+    /// A handle cannot be fabricated from a bare digest during normal
+    /// execution. The accepted ledger remains a trusted application adapter;
+    /// hostile request data never implements it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the ledger error without producing a persisted handle.
+    pub fn append_to<S>(self, sink: &mut S) -> Result<PersistedIntent, S::Error>
+    where
+        S: EffectReceiptSink,
+    {
+        let digest = sink.append(&self.receipt)?;
+        Ok(PersistedIntent {
+            receipt: self.receipt,
+            digest,
+        })
+    }
+}
+
+/// Sealed proof that one exact intent was accepted by the application ledger.
+///
+/// The handle is linear, non-serializable, and the only normal constructor for
+/// an outcome. Restart reconciliation may reconstruct it only from a receipt
+/// the accepted ledger has verified as durably present and unmatched.
+#[derive(Debug)]
+pub struct PersistedIntent {
+    receipt: EffectReceipt,
+    digest: ReceiptDigest,
+}
+
+impl PersistedIntent {
+    /// Reconstruct an unmatched intent after accepted-ledger verification.
+    ///
+    /// This is a ledger boundary, not a parser for request data.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectReceiptError::PredecessorIsNotIntent`] unless the
+    /// verified receipt is an intent.
+    pub fn from_verified_unmatched(
+        receipt: EffectReceipt,
+        digest: ReceiptDigest,
+    ) -> Result<Self, EffectReceiptError> {
+        if receipt.event() != ReceiptEvent::Intent {
+            return Err(EffectReceiptError::PredecessorIsNotIntent {
+                location: snafu::location!(),
+            });
+        }
+        Ok(Self { receipt, digest })
+    }
+
+    /// Borrow the persisted intent receipt.
+    #[must_use]
+    pub const fn receipt(&self) -> &EffectReceipt {
+        &self.receipt
+    }
+
+    /// Consume this intent into exactly one pending outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed transition error carrying the same reconciliation
+    /// candidate when time moves backwards or the transition is invalid.
+    pub fn outcome(
+        self,
+        observed_at: Timestamp,
+        outcome: EffectOutcome,
+        evidence_digest: Option<EvidenceDigest>,
+    ) -> Result<PendingOutcome, ReceiptTransitionError> {
+        let receipt = match EffectReceipt::outcome_from(
+            &self.receipt,
+            self.digest,
+            observed_at,
+            outcome,
+            evidence_digest,
+        ) {
+            Ok(receipt) => receipt,
+            Err(source) => {
+                return Err(ReceiptTransitionError {
+                    source,
+                    recovery: Box::new(RecoveryTicket { intent: self }),
+                    location: snafu::location!(),
+                });
+            }
+        };
+        Ok(PendingOutcome {
+            receipt,
+            intent: self,
+        })
+    }
+
+    /// Consume the unmatched intent into an explicit reconciliation ticket.
+    #[must_use]
+    pub const fn into_recovery_ticket(self) -> RecoveryTicket {
+        RecoveryTicket { intent: self }
+    }
+}
+
+/// Linear outcome waiting for durable append.
+#[derive(Debug)]
+pub struct PendingOutcome {
+    receipt: EffectReceipt,
+    intent: PersistedIntent,
+}
+
+impl PendingOutcome {
+    /// Borrow the pending outcome receipt.
+    #[must_use]
+    pub const fn receipt(&self) -> &EffectReceipt {
+        &self.receipt
+    }
+
+    /// Append the outcome and bind its ledger digest to the transition.
+    ///
+    /// # Errors
+    ///
+    /// Returns the sink error plus the original unmatched intent ticket.
+    pub fn append_to<S>(
+        self,
+        sink: &mut S,
+    ) -> Result<PersistedOutcome, OutcomeAppendError<S::Error>>
+    where
+        S: EffectReceiptSink,
+    {
+        let digest = match sink.append(&self.receipt) {
+            Ok(digest) => digest,
+            Err(source) => {
+                return Err(OutcomeAppendError {
+                    source,
+                    recovery: Box::new(RecoveryTicket {
+                        intent: self.intent,
+                    }),
+                    location: snafu::location!(),
+                });
+            }
+        };
+        Ok(PersistedOutcome {
+            receipt: self.receipt,
+            digest,
+        })
+    }
+}
+
+/// One outcome proven present by the accepted application ledger.
+#[derive(Debug)]
+pub struct PersistedOutcome {
+    receipt: EffectReceipt,
+    digest: ReceiptDigest,
+}
+
+impl PersistedOutcome {
+    /// Reconstruct a persisted outcome after accepted-ledger verification.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectReceiptError::PersistedReceiptIsNotOutcome`] unless the
+    /// verified receipt is an outcome.
+    pub fn from_verified(
+        receipt: EffectReceipt,
+        digest: ReceiptDigest,
+    ) -> Result<Self, EffectReceiptError> {
+        if !matches!(receipt.event(), ReceiptEvent::Outcome(_)) {
+            return Err(EffectReceiptError::PersistedReceiptIsNotOutcome {
+                location: snafu::location!(),
+            });
+        }
+        Ok(Self { receipt, digest })
+    }
+
+    /// Return the recorded outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EffectReceiptError::PersistedReceiptIsNotOutcome`] if a
+    /// ledger adapter violated the persisted-outcome constructor contract.
+    pub fn outcome(&self) -> Result<EffectOutcome, EffectReceiptError> {
+        match self.receipt.event() {
+            ReceiptEvent::Outcome(outcome) => Ok(outcome),
+            ReceiptEvent::Intent => Err(EffectReceiptError::PersistedReceiptIsNotOutcome {
+                location: snafu::location!(),
+            }),
+        }
+    }
+
+    /// Return the canonical durable outcome digest.
+    #[must_use]
+    pub const fn digest(&self) -> ReceiptDigest {
+        self.digest
+    }
+
+    /// Borrow the persisted outcome receipt.
+    #[must_use]
+    pub const fn receipt(&self) -> &EffectReceipt {
+        &self.receipt
+    }
+
+    /// Consume an unresolved outcome into one continuation authority.
+    ///
+    /// # Errors
+    ///
+    /// Partial and recovery-required outcomes authorize recovery of their
+    /// referenced operation. A failed, cancelled, backpressured, or
+    /// authorization-denied recovery attempt authorizes another attempt for
+    /// the original operation. Successful and recovered outcomes are final.
+    ///
+    /// Returns [`EffectReceiptError::NotRecoveryRequirement`] for an outcome
+    /// that does not authorize recovery.
+    pub fn into_recovery_authorization(self) -> Result<RecoveryAuthorization, EffectReceiptError> {
+        match (self.receipt.event(), self.receipt.recovery()) {
+            (
+                ReceiptEvent::Outcome(EffectOutcome::Partial | EffectOutcome::RecoveryRequired),
+                RecoveryRelation::RequiredFor(original_effect),
+            )
+            | (
+                ReceiptEvent::Outcome(
+                    EffectOutcome::Failed
+                    | EffectOutcome::Cancelled
+                    | EffectOutcome::Backpressured
+                    | EffectOutcome::AuthorizationDenied,
+                ),
+                RecoveryRelation::RecoveryOf(original_effect),
+            ) => Ok(RecoveryAuthorization {
+                original_effect,
+                requirement_digest: self.digest,
+                requirement_observed_at: self.receipt.observed_at(),
+            }),
+            _ => Err(EffectReceiptError::NotRecoveryRequirement {
+                location: snafu::location!(),
+            }),
+        }
+    }
+}
+
+/// Linear authority to describe one explicit recovery operation.
+///
+/// The authority comes only from a persisted unresolved outcome, binding a
+/// recovery or continuation attempt to that outcome's ledger digest and time.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RecoveryAuthorization {
+    original_effect: EffectRef,
+    requirement_digest: ReceiptDigest,
+    requirement_observed_at: Timestamp,
+}
+
+impl RecoveryAuthorization {
+    pub(crate) const fn original_effect(&self) -> EffectRef {
+        self.original_effect
+    }
+
+    /// Consume this authority into one recovery effect descriptor.
+    #[must_use]
+    pub const fn into_descriptor(
+        self,
+        effect: EffectRef,
+        schema_epoch: SchemaEpoch,
+        evidence_digest: Option<EvidenceDigest>,
+    ) -> EffectDescriptor {
+        EffectDescriptor::from_recovery(effect, schema_epoch, evidence_digest, self)
+    }
+
+    pub(crate) const fn into_parts(self) -> (EffectRef, ReceiptDigest, Timestamp) {
+        (
+            self.original_effect,
+            self.requirement_digest,
+            self.requirement_observed_at,
+        )
+    }
+}
+
+/// Restart-safe ticket for an intent with no accepted terminal outcome.
+///
+/// Recovery is explicit and never replays the original effect. The ticket is
+/// linear and reconstructed after restart only through
+/// [`PersistedIntent::from_verified_unmatched`].
+#[derive(Debug)]
+pub struct RecoveryTicket {
+    intent: PersistedIntent,
+}
+
+impl RecoveryTicket {
+    /// Return the original protected effect reference.
+    #[must_use]
+    pub const fn effect(&self) -> EffectRef {
+        self.intent.receipt.context().effect()
+    }
+
+    /// Consume this ticket into a recovery-required outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReceiptTransitionError`] if the supplied time precedes the
+    /// original intent.
+    pub fn recovery_required(
+        self,
+        observed_at: Timestamp,
+    ) -> Result<PendingOutcome, ReceiptTransitionError> {
+        self.intent
+            .outcome(observed_at, EffectOutcome::RecoveryRequired, None)
+    }
+}
+
+/// Failed persisted-intent transition with its reconciliation candidate.
+#[derive(Debug, Snafu)]
+#[snafu(display("persisted intent transition failed: {source}"))]
+#[non_exhaustive]
+pub struct ReceiptTransitionError {
+    /// Receipt state-machine failure.
+    source: EffectReceiptError,
+    /// Original unmatched intent.
+    recovery: Box<RecoveryTicket>,
+    /// Source location of the failed transition.
+    #[snafu(implicit)]
+    location: snafu::Location,
+}
+
+impl ReceiptTransitionError {
+    /// Split the error into the contract failure and reconciliation ticket.
+    #[must_use]
+    pub const fn into_parts(self) -> (EffectReceiptError, Box<RecoveryTicket>) {
+        (self.source, self.recovery)
+    }
+}
+
+/// Failed durable outcome append with its reconciliation candidate.
+#[derive(Debug, Snafu)]
+#[snafu(display("effect outcome append failed: {source}"))]
+#[non_exhaustive]
+pub struct OutcomeAppendError<E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    /// Accepted ledger failure.
+    source: E,
+    /// Original unmatched intent.
+    recovery: Box<RecoveryTicket>,
+    /// Source location of the failed append.
+    #[snafu(implicit)]
+    location: snafu::Location,
+}
+
+impl<E> OutcomeAppendError<E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    /// Split the append failure from the reconciliation candidate.
+    #[must_use]
+    pub const fn into_parts(self) -> (E, Box<RecoveryTicket>) {
+        (self.source, self.recovery)
+    }
+}

--- a/crates/koinon/src/effect_receipt_state.rs
+++ b/crates/koinon/src/effect_receipt_state.rs
@@ -370,7 +370,7 @@ pub struct ReceiptTransitionError {
 impl ReceiptTransitionError {
     /// Split the error into the contract failure and reconciliation ticket.
     #[must_use]
-    pub const fn into_parts(self) -> (EffectReceiptError, Box<RecoveryTicket>) {
+    pub fn into_parts(self) -> (EffectReceiptError, Box<RecoveryTicket>) {
         (self.source, self.recovery)
     }
 }
@@ -398,7 +398,7 @@ where
 {
     /// Split the append failure from the reconciliation candidate.
     #[must_use]
-    pub const fn into_parts(self) -> (E, Box<RecoveryTicket>) {
+    pub fn into_parts(self) -> (E, Box<RecoveryTicket>) {
         (self.source, self.recovery)
     }
 }

--- a/crates/koinon/src/lib.rs
+++ b/crates/koinon/src/lib.rs
@@ -3,7 +3,12 @@
 #![deny(missing_docs)]
 
 pub mod baseline;
+pub mod caller;
+mod caller_error;
+mod caller_ref;
 pub mod coordinates;
+pub mod effect_receipt;
+mod effect_receipt_state;
 pub mod entity;
 pub mod frequency;
 pub mod hardware;
@@ -16,7 +21,23 @@ pub mod timestamp;
 pub use baseline::{
     AnomalyScore, Baseline, ScoringConfig, TemporalBucketedBaseline, TimeWindowedBaseline,
 };
+pub use caller::{
+    AuthorityClaims, AuthorityClaimsBuilder, AuthorityDecision, AuthorityGrant,
+    AuthorizationDenial, AuthorizationRequirement, AuthorizedCaller, CALLER_CONTEXT_VERSION,
+    CALLER_RESOLVER_VERSION, CallerAuthority, CallerContractError, CallerRef, CallerResolver,
+    CapabilityRef, EffectRef, EvidenceDigest, LocalPeerCredentials, PersonaRef, PolicyEpoch,
+    PrincipalSource, ReceiptDigest, RevocationState, SchemaEpoch, ScopeRef, TrustState,
+    ValidatedCaller, authorize_caller,
+};
 pub use coordinates::{Coordinates, CoordinatesError, Datum};
+pub use effect_receipt::{
+    EFFECT_RECEIPT_VERSION, EffectDescriptor, EffectOutcome, EffectReceipt, EffectReceiptError,
+    ReceiptContext, ReceiptEvent, RecoveryRelation, ValidatedReceiptLink,
+};
+pub use effect_receipt_state::{
+    EffectReceiptSink, OutcomeAppendError, PendingIntent, PendingOutcome, PersistedIntent,
+    PersistedOutcome, ReceiptTransitionError, RecoveryAuthorization, RecoveryTicket,
+};
 pub use entity::{Entity, EntityKind};
 pub use frequency::Frequency;
 pub use hardware::{


### PR DESCRIPTION
## Summary

- Add one closed, versioned `ValidatedCaller` contract with typed authority, freshness, revocation, persona, capability, and scope denials.
- Add the application resolver boundary for authenticated Unix peer credentials and accepted service identities; loopback alone is rejected.
- Add minimized, linear effect intent/outcome/recovery receipts with audit-before-effect and effect-time reauthorization.
- Add deterministic architecture, wire-shape, denial, cancellation, backpressure, partial-call, restart, recovery, replay, and forged-relation fixtures.

## Scope

This is a software-only dependency-leaf contract. It performs no hardware, host-networking, firewall, credential-store, or production-endpoint mutation.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused Kanon lint on every changed Rust source/test
- Three independent reviews approved candidate commit `a78e8d62f06d12975875dda3a83accde9f00b4d8` with exact 15-path manifest `eac21422c4c1362b26423fa3a2f2fe863e9b66805e60ec9157524e1bf620cb75`
- Compilation, Clippy, and tests run through the repository's hosted full gate; no local Cargo build/test was run

Closes #409