### PR TITLE
fix(ci): report every gate failure, not whichever one is reached first

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -106,9 +106,9 @@ jobs:
     uses: forkwright/.github/.github/workflows/hybrid-gate.yml@main
     with:
       fmt_cmd: "cargo fmt --all -- --check"
-      check_cmd: "cargo check --workspace --all-targets --features syntonia/hardware-serial --jobs 8"
-      clippy_cmd: "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"
-      nextest_cmd: "cargo nextest run --workspace --features syntonia/hardware-serial --build-jobs 8 --test-threads 8"
+      check_cmd: "cargo check --workspace --all-targets --features syntonia/hardware-serial --jobs 8 --keep-going"
+      clippy_cmd: "cargo clippy --workspace --all-targets --jobs 8 --keep-going -- -D warnings"
+      nextest_cmd: "cargo nextest run --workspace --features syntonia/hardware-serial --build-jobs 8 --test-threads 8 --no-fail-fast"
       # WHY empty: nextest does not run doctests (kanon#3486). Left empty
       # here, not skipped by oversight -- every fenced block in a doc
       # comment across the workspace is ```text``` (ASCII diagrams) or

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -33,6 +33,16 @@
 # holds the compile-and-test half of the invariant so it cannot regress while
 # #264 is open.
 
+# WHY(#414): --keep-going on check/clippy and --no-fail-fast on nextest. Without
+# them cargo stops scheduling units at the first error and nextest cancels at the
+# first failing test, so a red run reports whichever failures were reached rather
+# than the ones that exist -- and a partial report is shaped exactly like a
+# complete one. Measured on PR #412: six red cycles, each naming one layer, the
+# last printing "1065/1162 tests were not run due to test failure". Green runs are
+# unaffected; only red runs get longer, by the work needed to finish the survey
+# they already claim to report. Matches utilities/pre-push-verify.sh, which
+# carries both flags for this reason.
+
 [pipeline]
 stages = ["cargo fmt", "cargo check", "cargo clippy", "cargo nextest", "kanon lint"]
 
@@ -41,15 +51,15 @@ cmd = "cargo fmt --all -- --check"
 timeout_secs = 300
 
 [stages."cargo check"]
-cmd = "cargo check --workspace --all-targets --features syntonia/hardware-serial --jobs 8"
+cmd = "cargo check --workspace --all-targets --features syntonia/hardware-serial --jobs 8 --keep-going"
 timeout_secs = 900
 
 [stages."cargo clippy"]
-cmd = "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"
+cmd = "cargo clippy --workspace --all-targets --jobs 8 --keep-going -- -D warnings"
 timeout_secs = 900
 
 [stages."cargo nextest"]
-cmd = "cargo nextest run --workspace --features syntonia/hardware-serial --build-jobs 8 --test-threads 8"
+cmd = "cargo nextest run --workspace --features syntonia/hardware-serial --build-jobs 8 --test-threads 8 --no-fail-fast"
 # 2700s (45 min) accommodates the cold-compile path under the 8-thread cap.
 # Warm-cache runs complete in ~30s; the headroom only matters when the build
 # cache is cold (first run after daemon restart or cache eviction). See #109.


### PR DESCRIPTION
## Summary

Add `--keep-going` to the `cargo check` and `cargo clippy` stages and `--no-fail-fast` to the
`cargo nextest` stage, in `.kanon-ci.toml` and `.github/workflows/gate-attestation.yml` identically.

## Why

Without them, a red gate run reports whichever failures it reached before stopping, in the same
shape as a complete report. Nothing distinguishes the two, so fixing everything a run named yields
another red run naming the next layer.

Measured on #412, which burned six red cycles peeling one layer each. The most recent stated the
defect outright: one test failed and `1065/1162 tests were not run due to test failure`.

`utilities/pre-push-verify.sh` already carries both flags for exactly this reason, so this is drift
correction toward existing fleet canon rather than a new policy.

## Effect

Green runs are unchanged. Red runs take longer by the work needed to finish the survey they already
present themselves as having done.

## Validation

- Both mirror halves changed to byte-identical strings; `gate_feature_coverage::the_gate_workflow_mirrors_the_local_stage_commands`
  asserts that equality and is part of this run.
- This PR's own gate run is the check: it exercises all three modified stage commands.

Closes #414
