### PR TITLE
docs: state the mesh stack as clean-room, which is what it is

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ Foundation:     koinon (shared types), kryphos (encryption), lethe (privacy)
 | Temporal baseline | Welford's algorithm | Online mean/variance without storing history |
 | Tamper logging | BLAKE3 hash chain | Append-only with cryptographic integrity |
 | SDR | Own dataflow engine | FutureSDR dependency risk too high (single maintainer, 0.0.x) |
-| Mesh | Meshtastic official crate + own crypto | Transport via crate, encryption/topology/routing ourselves |
+| Mesh | Clean-room stack over `prost` | The official `meshtastic` crate is GPL-3 and covers ~15% of the protocol; framing, crypto, routing and topology are ours |
 
 ## Dependency philosophy
 


### PR DESCRIPTION
## Summary

One row of the architecture decision table said the mesh transport comes from the official
Meshtastic crate. It does not.

## Evidence

- `crates/kerykeion/Cargo.toml` declares no `meshtastic` dependency; the wire types are generated
  from the protocol with `prost` via a build script.
- #392 removed the vendored GPL protos and authored the schema from the protocol.
- `AGENTS.md:35` — "clean-room Meshtastic stack via `prost` - not the official `meshtastic` crate
  (GPL-3, ~15% coverage)".
- `_llm/architecture.toml:49` and `_llm/glossary.toml:41` both say clean-room.

Four sources said clean-room and one said the opposite; the manifest settles it.

## Why it is worth a change rather than a note

The stale row read as an admission that a GPL-3 crate is linked into an AGPL workspace that
deliberately avoided one. #387 is open on exactly this class of licensing-provenance question, so a
doc asserting the wrong answer is a doc someone will answer from.

The corrected row also now agrees with the "Dependency philosophy" paragraph directly beneath it,
which already describes this decision in general terms.
