### PR TITLE
feat(kerykeion): add the BLE transport and its injectable scan/GATT seam

### DIFF
--- a/crates/kerykeion/src/transport/ble.rs
+++ b/crates/kerykeion/src/transport/ble.rs
@@ -1,0 +1,232 @@
+//! BLE GATT transport for Meshtastic radio connections.
+//!
+//! GATT is message-oriented rather than a byte stream, so this transport does
+//! not sit on the [`crate::codec::MeshCodec`] framing the serial and TCP
+//! transports share. It encodes and decodes protobuf message bodies directly
+//! and delegates every radio interaction to an injected [`BlePeripheral`].
+//!
+//! That injection is the point: the transport's connect, send, receive,
+//! notification-wait and reconnect behaviour is exercised against a
+//! deterministic in-memory peripheral, so none of it depends on an adapter or a
+//! radio being present.
+
+use prost::Message as _;
+use tracing::instrument;
+
+use crate::Error;
+use crate::config::TransportConfig;
+use crate::connection::MeshConnection;
+use crate::error::{BleConnectSnafu, ConnectionLostSnafu};
+use crate::proto::{FromRadio, ToRadio};
+
+/// The scan and GATT operations a BLE adapter must provide.
+///
+/// Payloads crossing this boundary are complete protobuf message bodies. A GATT
+/// characteristic operation carries a whole value, so the stream framing the
+/// byte-oriented transports apply does not belong here; an implementation that
+/// needs a header for its own link is responsible for it on both sides.
+///
+/// Implementations are not required to be cancel-safe.
+// WHY: matches `MeshConnection` — Rust 2024 native async fn in traits, no
+// `async_trait` crate, so callers are generic over the implementation rather
+// than boxing it.
+#[expect(
+    async_fn_in_trait,
+    reason = "mirrors MeshConnection; implementations are Send and consumers are generic"
+)]
+pub trait BlePeripheral: Send + Sync {
+    /// Scan for a device whose advertised name starts with `name_prefix` and
+    /// establish a GATT connection to it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::BleConnect`] when no advertising device matches the
+    /// prefix, or when the connection or service discovery fails.
+    async fn connect(&mut self, name_prefix: &str) -> Result<(), Error>;
+
+    /// Write one encoded `ToRadio` body to the radio.
+    ///
+    /// # Errors
+    ///
+    /// Returns a transport error if the characteristic write fails.
+    async fn write_to_radio(&mut self, payload: &[u8]) -> Result<(), Error>;
+
+    /// Read the next queued `FromRadio` body, or `None` when the radio has
+    /// nothing waiting.
+    ///
+    /// `None` means "empty right now", never "disconnected" — a dropped link is
+    /// an error, so that a caller cannot mistake a dead radio for a quiet one.
+    ///
+    /// # Errors
+    ///
+    /// Returns a transport error if the characteristic read fails or the link
+    /// has dropped.
+    async fn read_from_radio(&mut self) -> Result<Option<Vec<u8>>, Error>;
+
+    /// Wait until the radio signals that at least one message may be readable.
+    ///
+    /// # Errors
+    ///
+    /// Returns a transport error if the link drops while waiting.
+    async fn wait_for_data(&mut self) -> Result<(), Error>;
+
+    /// Returns `true` while the GATT link is established.
+    fn is_connected(&self) -> bool;
+}
+
+/// Meshtastic transport over a BLE GATT link.
+pub struct BleTransport<P> {
+    /// Advertising name prefix used to find the device on every connect.
+    device_name: String,
+    /// The injected adapter every radio interaction is delegated to.
+    peripheral: P,
+    /// Whether the transport believes the link is usable.
+    connected: bool,
+    /// Tuning applied to reconnect attempts.
+    config: TransportConfig,
+}
+
+impl<P> BleTransport<P>
+where
+    P: BlePeripheral,
+{
+    /// Connect `peripheral` to the first device advertising `device_name`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::BleConnect`] if no matching device is reachable.
+    #[instrument(level = "debug", skip(peripheral), fields(device = %device_name))]
+    pub async fn connect(device_name: &str, peripheral: P) -> Result<Self, Error> {
+        Self::connect_with_config(device_name, peripheral, &TransportConfig::default()).await
+    }
+
+    /// Connect `peripheral` with explicit transport tuning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::BleConnect`] if no matching device is reachable.
+    #[instrument(level = "debug", skip(peripheral, config), fields(device = %device_name))]
+    pub async fn connect_with_config(
+        device_name: &str,
+        mut peripheral: P,
+        config: &TransportConfig,
+    ) -> Result<Self, Error> {
+        peripheral.connect(device_name).await?;
+        Ok(Self {
+            device_name: device_name.to_owned(),
+            peripheral,
+            connected: true,
+            config: config.clone(),
+        })
+    }
+
+    /// Borrow the injected peripheral.
+    pub const fn peripheral(&self) -> &P {
+        &self.peripheral
+    }
+}
+
+impl<P> MeshConnection for BleTransport<P>
+where
+    P: BlePeripheral,
+{
+    async fn send(&mut self, packet: ToRadio) -> Result<(), Error> {
+        let payload = packet.encode_to_vec();
+        let result = self.peripheral.write_to_radio(&payload).await;
+        if result.is_err() {
+            self.connected = false;
+        }
+        result
+    }
+
+    async fn recv(&mut self) -> Result<FromRadio, Error> {
+        loop {
+            match self.peripheral.read_from_radio().await {
+                Ok(Some(payload)) => {
+                    return FromRadio::decode(payload.as_slice()).map_err(|source| {
+                        Error::ProtobufDecode {
+                            source,
+                            location: snafu::location!(),
+                        }
+                    });
+                }
+                // WHY loop rather than return: an empty read is the radio being
+                // quiet, not the link being closed, so the only correct response
+                // is to wait for the notification that says otherwise. Returning
+                // here would surface "no message yet" as a received message.
+                Ok(None) => {
+                    if let Err(error) = self.peripheral.wait_for_data().await {
+                        self.connected = false;
+                        return Err(error);
+                    }
+                }
+                Err(error) => {
+                    self.connected = false;
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected && self.peripheral.is_connected()
+    }
+
+    async fn reconnect(&mut self) -> Result<(), Error> {
+        self.connected = false;
+        let mut delay = self.config.reconnect_initial_delay();
+        let max_backoff = self.config.reconnect_max_backoff();
+
+        loop {
+            tokio::time::sleep(delay).await;
+            match self.peripheral.connect(&self.device_name).await {
+                Ok(()) => {
+                    self.connected = true;
+                    tracing::info!(device = %self.device_name, "BLE reconnected");
+                    return Ok(());
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        delay_secs = delay.as_secs(),
+                        device = %self.device_name,
+                        "BLE reconnect failed; retrying"
+                    );
+                    delay = (delay * 2).min(max_backoff);
+                }
+            }
+        }
+    }
+}
+
+/// Build the [`Error::BleConnect`] a peripheral returns when a scan finds no
+/// device advertising the requested prefix.
+///
+/// # Errors
+///
+/// Always returns [`Error::BleConnect`]; the `Result` shape lets an
+/// implementation return it with `?`.
+pub fn no_matching_device<T>(device: &str) -> Result<T, Error> {
+    BleConnectSnafu {
+        device: device.to_owned(),
+    }
+    .fail()
+}
+
+/// Build the [`Error::ConnectionLost`] a peripheral returns when the GATT link
+/// drops out from under an operation.
+///
+/// # Errors
+///
+/// Always returns [`Error::ConnectionLost`]; the `Result` shape lets an
+/// implementation return it with `?`.
+pub fn link_dropped<T>(detail: impl Into<String>) -> Result<T, Error> {
+    ConnectionLostSnafu {
+        detail: detail.into(),
+    }
+    .fail()
+}
+
+#[cfg(test)]
+#[path = "ble_tests.rs"]
+mod tests;

--- a/crates/kerykeion/src/transport/ble_tests.rs
+++ b/crates/kerykeion/src/transport/ble_tests.rs
@@ -17,6 +17,17 @@ use crate::config::TransportConfig;
 use crate::connection::MeshConnection;
 use crate::proto::{FromRadio, ToRadio, from_radio, to_radio};
 
+/// The operation, if any, scripted to report a dropped link.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Drops {
+    /// `write_to_radio` reports the link is gone.
+    Write,
+    /// `read_from_radio` reports the link is gone.
+    Read,
+    /// `wait_for_data` reports the link is gone.
+    Wait,
+}
+
 /// One scripted outcome of [`BlePeripheral::read_from_radio`].
 enum Read {
     /// The radio had nothing queued at this point in the sequence.
@@ -42,12 +53,8 @@ struct FakePeripheral {
     connect_failures: usize,
     /// How many times `wait_for_data` has been called.
     waits: usize,
-    /// Whether a write should report a dropped link.
-    write_drops: bool,
-    /// Whether a read should report a dropped link.
-    read_drops: bool,
-    /// Whether a wait should report a dropped link.
-    wait_drops: bool,
+    /// Which operation, if any, reports a dropped link.
+    drops: Option<Drops>,
 }
 
 impl FakePeripheral {
@@ -85,7 +92,7 @@ impl BlePeripheral for FakePeripheral {
     }
 
     async fn write_to_radio(&mut self, payload: &[u8]) -> Result<(), Error> {
-        if self.write_drops {
+        if self.drops == Some(Drops::Write) {
             self.connected = false;
             return super::link_dropped("write while disconnected");
         }
@@ -94,7 +101,7 @@ impl BlePeripheral for FakePeripheral {
     }
 
     async fn read_from_radio(&mut self) -> Result<Option<Vec<u8>>, Error> {
-        if self.read_drops {
+        if self.drops == Some(Drops::Read) {
             self.connected = false;
             return super::link_dropped("read while disconnected");
         }
@@ -106,7 +113,7 @@ impl BlePeripheral for FakePeripheral {
 
     async fn wait_for_data(&mut self) -> Result<(), Error> {
         self.waits += 1;
-        if self.wait_drops {
+        if self.drops == Some(Drops::Wait) {
             self.connected = false;
             return super::link_dropped("link dropped while awaiting notification");
         }
@@ -242,12 +249,12 @@ async fn recv_waits_through_empty_reads_instead_of_returning() {
 #[tokio::test]
 async fn recv_reports_a_dropped_link_rather_than_a_quiet_one() {
     let mut peripheral = FakePeripheral::advertising("Meshtastic_1234");
-    peripheral.read_drops = true;
+    peripheral.drops = Some(Drops::Read);
     let mut transport = BleTransport::connect("Meshtastic", peripheral)
         .await
         .expect("connect");
 
-    let error = transport.recv().await.err().expect("a dropped read errors");
+    let error = transport.recv().await.expect_err("a dropped read errors");
 
     assert!(
         matches!(error, Error::ConnectionLost { .. }),
@@ -263,7 +270,7 @@ async fn recv_reports_a_dropped_link_rather_than_a_quiet_one() {
 async fn a_failed_notification_wait_disconnects_the_transport() {
     let mut peripheral =
         FakePeripheral::advertising("Meshtastic_1234").with_reads(vec![Read::Empty]);
-    peripheral.wait_drops = true;
+    peripheral.drops = Some(Drops::Wait);
     let mut transport = BleTransport::connect("Meshtastic", peripheral)
         .await
         .expect("connect");
@@ -271,8 +278,7 @@ async fn a_failed_notification_wait_disconnects_the_transport() {
     transport
         .recv()
         .await
-        .err()
-        .expect("a dropped wait must error");
+        .expect_err("a dropped wait must error");
 
     assert!(
         !transport.is_connected(),
@@ -283,7 +289,7 @@ async fn a_failed_notification_wait_disconnects_the_transport() {
 #[tokio::test]
 async fn a_failed_write_disconnects_the_transport() {
     let mut peripheral = FakePeripheral::advertising("Meshtastic_1234");
-    peripheral.write_drops = true;
+    peripheral.drops = Some(Drops::Write);
     let mut transport = BleTransport::connect("Meshtastic", peripheral)
         .await
         .expect("connect");
@@ -291,8 +297,7 @@ async fn a_failed_write_disconnects_the_transport() {
     transport
         .send(a_to_radio(1))
         .await
-        .err()
-        .expect("a dropped write must error");
+        .expect_err("a dropped write must error");
 
     assert!(
         !transport.is_connected(),
@@ -312,8 +317,7 @@ async fn recv_surfaces_an_undecodable_body_as_a_protobuf_error() {
     let error = transport
         .recv()
         .await
-        .err()
-        .expect("a truncated body must not decode");
+        .expect_err("a truncated body must not decode");
 
     assert!(
         matches!(error, Error::ProtobufDecode { .. }),

--- a/crates/kerykeion/src/transport/ble_tests.rs
+++ b/crates/kerykeion/src/transport/ble_tests.rs
@@ -1,0 +1,363 @@
+//! Deterministic coverage for the BLE transport over an in-memory peripheral.
+//!
+//! Every case here runs with no adapter, no radio and no timer: the injected
+//! [`FakePeripheral`] is scripted with the exact sequence of reads, failures and
+//! connect outcomes each behaviour needs.
+
+#![expect(
+    clippy::expect_used,
+    reason = "unit test — an unmet expectation is the correct failure mode"
+)]
+
+use std::collections::VecDeque;
+
+use super::{BlePeripheral, BleTransport};
+use crate::Error;
+use crate::config::TransportConfig;
+use crate::connection::MeshConnection;
+use crate::proto::{FromRadio, ToRadio, from_radio, to_radio};
+
+/// One scripted outcome of [`BlePeripheral::read_from_radio`].
+enum Read {
+    /// The radio had nothing queued at this point in the sequence.
+    Empty,
+    /// The radio returned this encoded body.
+    Body(Vec<u8>),
+}
+
+/// An in-memory peripheral scripted by the test that builds it.
+#[derive(Default)]
+struct FakePeripheral {
+    /// Names this fake will answer a scan with.
+    advertised: Vec<String>,
+    /// Remaining scripted read outcomes, consumed in order.
+    reads: VecDeque<Read>,
+    /// Every body written through `write_to_radio`.
+    written: Vec<Vec<u8>>,
+    /// Whether the link is currently up.
+    connected: bool,
+    /// How many times `connect` has been called.
+    connect_calls: usize,
+    /// Connect attempts still scripted to fail before one succeeds.
+    connect_failures: usize,
+    /// How many times `wait_for_data` has been called.
+    waits: usize,
+    /// Whether a write should report a dropped link.
+    write_drops: bool,
+    /// Whether a read should report a dropped link.
+    read_drops: bool,
+    /// Whether a wait should report a dropped link.
+    wait_drops: bool,
+}
+
+impl FakePeripheral {
+    /// A peripheral advertising one device that answers scans for it.
+    fn advertising(name: &str) -> Self {
+        Self {
+            advertised: vec![name.to_owned()],
+            ..Self::default()
+        }
+    }
+
+    /// Script the sequence of read outcomes this fake will return.
+    fn with_reads(mut self, reads: Vec<Read>) -> Self {
+        self.reads = reads.into();
+        self
+    }
+}
+
+impl BlePeripheral for FakePeripheral {
+    async fn connect(&mut self, name_prefix: &str) -> Result<(), Error> {
+        self.connect_calls += 1;
+        if self.connect_failures > 0 {
+            self.connect_failures -= 1;
+            return super::no_matching_device(name_prefix);
+        }
+        if self
+            .advertised
+            .iter()
+            .any(|name| name.starts_with(name_prefix))
+        {
+            self.connected = true;
+            return Ok(());
+        }
+        super::no_matching_device(name_prefix)
+    }
+
+    async fn write_to_radio(&mut self, payload: &[u8]) -> Result<(), Error> {
+        if self.write_drops {
+            self.connected = false;
+            return super::link_dropped("write while disconnected");
+        }
+        self.written.push(payload.to_vec());
+        Ok(())
+    }
+
+    async fn read_from_radio(&mut self) -> Result<Option<Vec<u8>>, Error> {
+        if self.read_drops {
+            self.connected = false;
+            return super::link_dropped("read while disconnected");
+        }
+        match self.reads.pop_front() {
+            Some(Read::Body(body)) => Ok(Some(body)),
+            Some(Read::Empty) | None => Ok(None),
+        }
+    }
+
+    async fn wait_for_data(&mut self) -> Result<(), Error> {
+        self.waits += 1;
+        if self.wait_drops {
+            self.connected = false;
+            return super::link_dropped("link dropped while awaiting notification");
+        }
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+}
+
+/// Reconnect tuning with no delay, so a backoff loop runs at test speed without
+/// a paused clock.
+fn instant_backoff() -> TransportConfig {
+    TransportConfig {
+        reconnect_initial_delay_secs: 0,
+        reconnect_max_backoff_secs: 0,
+        ..TransportConfig::default()
+    }
+}
+
+fn a_from_radio(id: u32) -> FromRadio {
+    FromRadio {
+        id,
+        payload_variant: Some(from_radio::PayloadVariant::ConfigCompleteId(id)),
+    }
+}
+
+fn a_to_radio(id: u32) -> ToRadio {
+    ToRadio {
+        payload_variant: Some(to_radio::PayloadVariant::WantConfigId(id)),
+    }
+}
+
+fn encoded(message: &FromRadio) -> Vec<u8> {
+    prost::Message::encode_to_vec(message)
+}
+
+/// Anti-vacuity: every case below leans on this fake reporting failure, so a
+/// fake that could only succeed would make them all pass without testing
+/// anything. Prove both outcomes are reachable on the same operation.
+#[tokio::test]
+async fn the_fake_peripheral_can_both_refuse_and_accept_a_scan() {
+    let mut peripheral = FakePeripheral::advertising("Meshtastic_1234");
+
+    peripheral
+        .connect("Nothing")
+        .await
+        .expect_err("a prefix nothing advertises must not connect");
+    peripheral
+        .connect("Meshtastic")
+        .await
+        .expect("the advertised prefix must connect");
+}
+
+#[tokio::test]
+async fn connect_fails_closed_when_no_device_advertises_the_prefix() {
+    let peripheral = FakePeripheral::advertising("SomeOtherRadio");
+
+    let error = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .err()
+        .expect("connecting to an unadvertised prefix must fail");
+
+    assert!(
+        matches!(error, Error::BleConnect { .. }),
+        "an absent device must surface as BleConnect, got {error}"
+    );
+}
+
+#[tokio::test]
+async fn send_writes_exactly_one_encoded_body() {
+    let peripheral = FakePeripheral::advertising("Meshtastic_1234");
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    transport.send(a_to_radio(7)).await.expect("send");
+
+    let written = &transport.peripheral().written;
+    assert_eq!(written.len(), 1, "one send must write one body");
+    let body = written.first().expect("one written body");
+    let decoded: ToRadio =
+        prost::Message::decode(body.as_slice()).expect("written body must decode");
+    assert_eq!(
+        decoded,
+        a_to_radio(7),
+        "the body must survive the round trip"
+    );
+}
+
+#[tokio::test]
+async fn recv_decodes_a_queued_body() {
+    let peripheral = FakePeripheral::advertising("Meshtastic_1234")
+        .with_reads(vec![Read::Body(encoded(&a_from_radio(42)))]);
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    let received = transport.recv().await.expect("recv");
+
+    assert_eq!(received, a_from_radio(42));
+    assert_eq!(
+        transport.peripheral().waits,
+        0,
+        "a body already queued must not wait for a notification"
+    );
+}
+
+/// The behaviour the loop in `recv` exists for: an empty read means the radio is
+/// quiet, so the transport must wait rather than return.
+#[tokio::test]
+async fn recv_waits_through_empty_reads_instead_of_returning() {
+    let peripheral = FakePeripheral::advertising("Meshtastic_1234").with_reads(vec![
+        Read::Empty,
+        Read::Empty,
+        Read::Body(encoded(&a_from_radio(9))),
+    ]);
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    let received = transport.recv().await.expect("recv");
+
+    assert_eq!(received, a_from_radio(9));
+    assert_eq!(
+        transport.peripheral().waits,
+        2,
+        "each empty read must be followed by exactly one notification wait"
+    );
+}
+
+#[tokio::test]
+async fn recv_reports_a_dropped_link_rather_than_a_quiet_one() {
+    let mut peripheral = FakePeripheral::advertising("Meshtastic_1234");
+    peripheral.read_drops = true;
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    let error = transport.recv().await.err().expect("a dropped read errors");
+
+    assert!(
+        matches!(error, Error::ConnectionLost { .. }),
+        "a dropped link must not read as an empty queue, got {error}"
+    );
+    assert!(
+        !transport.is_connected(),
+        "a dropped read must mark the transport disconnected"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_notification_wait_disconnects_the_transport() {
+    let mut peripheral =
+        FakePeripheral::advertising("Meshtastic_1234").with_reads(vec![Read::Empty]);
+    peripheral.wait_drops = true;
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    transport
+        .recv()
+        .await
+        .err()
+        .expect("a dropped wait must error");
+
+    assert!(
+        !transport.is_connected(),
+        "a dropped wait must mark the transport disconnected"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_write_disconnects_the_transport() {
+    let mut peripheral = FakePeripheral::advertising("Meshtastic_1234");
+    peripheral.write_drops = true;
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    transport
+        .send(a_to_radio(1))
+        .await
+        .err()
+        .expect("a dropped write must error");
+
+    assert!(
+        !transport.is_connected(),
+        "a failed write must mark the transport disconnected"
+    );
+}
+
+#[tokio::test]
+async fn recv_surfaces_an_undecodable_body_as_a_protobuf_error() {
+    // A field-1 varint tag with no value: structurally a truncated message.
+    let peripheral =
+        FakePeripheral::advertising("Meshtastic_1234").with_reads(vec![Read::Body(vec![0x08])]);
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+
+    let error = transport
+        .recv()
+        .await
+        .err()
+        .expect("a truncated body must not decode");
+
+    assert!(
+        matches!(error, Error::ProtobufDecode { .. }),
+        "a malformed body must surface as a decode error, got {error}"
+    );
+}
+
+#[tokio::test]
+async fn reconnect_retries_until_the_peripheral_accepts() {
+    let peripheral = FakePeripheral::advertising("Meshtastic_1234");
+    let config = instant_backoff();
+    let mut transport = BleTransport::connect_with_config("Meshtastic", peripheral, &config)
+        .await
+        .expect("connect");
+    assert_eq!(transport.peripheral().connect_calls, 1);
+
+    transport.peripheral.connect_failures = 3;
+    transport.reconnect().await.expect("reconnect must succeed");
+
+    assert_eq!(
+        transport.peripheral().connect_calls,
+        5,
+        "one initial connect, three scripted failures, then the accepting attempt"
+    );
+    assert!(
+        transport.is_connected(),
+        "a successful reconnect must restore the connected state"
+    );
+}
+
+/// `is_connected` must not report the transport's own optimism when the
+/// peripheral underneath it has gone.
+#[tokio::test]
+async fn is_connected_follows_the_peripheral() {
+    let peripheral = FakePeripheral::advertising("Meshtastic_1234");
+    let mut transport = BleTransport::connect("Meshtastic", peripheral)
+        .await
+        .expect("connect");
+    assert!(transport.is_connected());
+
+    transport.peripheral.connected = false;
+
+    assert!(
+        !transport.is_connected(),
+        "a peripheral that has dropped must make the transport report disconnected"
+    );
+}

--- a/crates/kerykeion/src/transport/mod.rs
+++ b/crates/kerykeion/src/transport/mod.rs
@@ -4,6 +4,7 @@
 //! transports, plus a factory function that creates the right transport from a
 //! [`ConnectionConfig`].
 
+pub mod ble;
 pub mod serial;
 pub mod tcp;
 
@@ -96,7 +97,12 @@ pub async fn connect_with_config(
             Ok(ConnectionHandle::Tcp(conn))
         }
         ConnectionConfig::Ble { device_name } => {
-            // WHY: BLE transport is deferred; serial and TCP cover all hardware targets.
+            // WHY(#83): the BLE transport and its scan/GATT seam exist in `ble`, but
+            // this factory has no adapter to hand it. `ConnectionHandle` dispatches
+            // over concrete variants, so a `Ble` variant needs a production
+            // `BlePeripheral` implementation, which needs both a chosen adapter crate
+            // and the authoritative Meshtastic GATT identifiers. Neither is
+            // established here, and inventing either is what this arm refuses to do.
             BleConnectSnafu {
                 device: device_name.clone(),
             }


### PR DESCRIPTION
## Summary

Adds `kerykeion::transport::ble` — a `BleTransport` implementing `MeshConnection`, driven through an
injected `BlePeripheral` seam — plus twelve deterministic tests that run with no adapter, no radio,
and no timer.

This advances #83's remaining BLE clause. It does not close it; see **What is deliberately not here**.

## Design

GATT is message-oriented rather than a byte stream, so this transport does not sit on the `MeshCodec`
framing that serial and TCP share. It encodes and decodes protobuf bodies directly and delegates every
radio interaction to the seam.

The load-bearing distinction is in `recv`: an empty read means *the radio is quiet*, a dropped link is
an *error*. Conflating them would let a caller read a dead radio as a silent one, so an empty read
waits for a notification and only an error returns. `is_connected` is the conjunction of the
transport's own state and the peripheral's, so the transport cannot report health the link does not
have.

`BlePeripheral` mirrors `MeshConnection`'s native-async-fn-in-trait choice, so consumers are generic
over the implementation rather than boxing it.

## Tests

Twelve cases: connect fails closed on an unadvertised prefix; send encodes exactly one body; a queued
body decodes without waiting; two empty reads produce exactly two notification waits; dropped links on
read, write and wait each disconnect the transport; an undecodable body surfaces as a decode error;
reconnect retries a scripted number of failures and restores state; and `is_connected` follows the
peripheral.

One case exists only to prove the fake can *fail* as well as succeed on the same operation — without
it, a fake that could only succeed would make the other eleven pass while testing nothing.

## What is deliberately not here

No `ConnectionHandle::Ble` variant. `ConnectionHandle` dispatches over concrete variants, so that
variant requires a production `BlePeripheral`, which requires two things this repository does not
establish: a chosen adapter crate, and the authoritative Meshtastic GATT service and characteristic
identifiers.

#83 explicitly refuses the Phase 2 research snapshots' UUID/MTU assertions as acceptance, and those
snapshots were the only place such values appeared — they were retired in #419. Inventing the
identifiers to make a variant compile is exactly the failure that refusal exists to prevent, so the
factory arm now states the real reason rather than calling BLE "deferred".

## Validation

`cargo fmt --all -- --check` clean locally. Compilation, clippy and the test run are this PR's gate —
akroasis is public, so that is where the workspace build belongs, and since #415 the gate reports every
failure in one run rather than one per push.

Refs #83
