### PR TITLE
fix(akroasis-server): validate the serial port path before it reaches a device open

### DIFF
--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -185,9 +185,8 @@ mod tests {
     #[tokio::test]
     async fn a_rejected_port_is_a_400_that_does_not_echo_the_supplied_path() {
         let probe = "/dev/../root/.ssh/id_ed25519";
-        let error = validated_port(Some(probe.to_owned()))
-            .err()
-            .expect("a traversal path must be rejected");
+        let error =
+            validated_port(Some(probe.to_owned())).expect_err("a traversal path must be rejected");
 
         let response = error.into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -19,6 +19,58 @@ pub struct DetectQuery {
     pub port: Option<String>,
 }
 
+/// Longest `port` value accepted. Real serial device names are far shorter;
+/// the bound keeps a pathological query out of the dispatch path and the log.
+const MAX_PORT_LEN: usize = 64;
+
+/// Message returned for every rejected `port`.
+///
+/// WHY one fixed string: the endpoint is unauthenticated, so a message that
+/// varied with the supplied value — or echoed it — would answer questions about
+/// the server's filesystem. A caller that sent a valid path does not need to be
+/// told which rule it broke.
+const INVALID_PORT_MESSAGE: &str = "`port` must be a serial device path such as /dev/ttyUSB0";
+
+/// Returns `true` when `port` names a serial device node directly under `/dev`.
+///
+/// The check is lexical and deliberately so: it runs before any filesystem
+/// access, so it cannot be raced, and it holds identically on a host with no
+/// radio attached. Requiring a single path component under `/dev` is what
+/// rejects traversal, `/dev/serial/by-id` indirection, and anything that can
+/// walk out of `/dev`; the OS still enforces that the node is openable.
+fn is_serial_device_path(port: &str) -> bool {
+    if port.len() > MAX_PORT_LEN {
+        return false;
+    }
+    let Some(name) = port.strip_prefix("/dev/") else {
+        return false;
+    };
+    if name.contains('/') {
+        return false;
+    }
+    let Some(suffix) = name.strip_prefix("tty") else {
+        return false;
+    };
+    // A bare `/dev/tty` is the controlling terminal, not a radio, so the
+    // suffix must be non-empty as well as alphanumeric.
+    !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
+/// Validate the caller-supplied `port` before it reaches the device open.
+///
+/// # Errors
+///
+/// Returns a 400 carrying [`INVALID_PORT_MESSAGE`] when the value is present
+/// and is not a serial device path. An absent `port` is valid and means
+/// auto-detect.
+fn validated_port(port: Option<String>) -> Result<Option<String>, ApiError> {
+    match port {
+        None => Ok(None),
+        Some(port) if is_serial_device_path(&port) => Ok(Some(port)),
+        Some(_) => Err(ApiError::bad_request(INVALID_PORT_MESSAGE)),
+    }
+}
+
 /// Classify a radio dispatch failure as a client or server error.
 ///
 /// WHY: `RadioError` mixes conditions the caller can resolve (no radio
@@ -53,15 +105,14 @@ fn classify(err: &RadioError) -> ApiError {
 /// Returns the same JSON schema as `akroasis radio detect --json`.
 ///
 /// # Errors
-/// Returns 404 when no radio is attached, 400 when several are and `port` was
-/// not given, 403 when the port cannot be opened, 503 when the build carries no
-/// hardware support, and 500 for any other detection or JSON parse failure.
+/// Returns 400 when `port` is not a serial device path or when several radios
+/// are attached and `port` was not given, 404 when no radio is attached, 403
+/// when the port cannot be opened, 503 when the build carries no hardware
+/// support, and 500 for any other detection or JSON parse failure.
 pub async fn detect(Query(params): Query<DetectQuery>) -> ApiResult<Json<serde_json::Value>> {
+    let port = validated_port(params.port)?;
     let mut out = Vec::new();
-    let cmd = akroasis_lib::radio::RadioCommand::Detect {
-        port: params.port,
-        json: true,
-    };
+    let cmd = akroasis_lib::radio::RadioCommand::Detect { port, json: true };
     akroasis_lib::radio::dispatch(&cmd, &mut out).map_err(|e| classify(&e))?;
     let value: serde_json::Value =
         serde_json::from_slice(&out).map_err(|e| ApiError::internal(format!("json parse: {e}")))?;
@@ -73,6 +124,87 @@ mod tests {
     use axum::response::IntoResponse;
 
     use super::*;
+
+    /// Anti-vacuity: the rejection cases below prove nothing if the validator
+    /// refuses everything, so pin the shapes it must accept first.
+    #[test]
+    fn real_serial_device_paths_are_accepted() {
+        for port in [
+            "/dev/ttyUSB0",
+            "/dev/ttyACM1",
+            "/dev/ttyS0",
+            "/dev/ttyUSB10",
+        ] {
+            assert!(
+                is_serial_device_path(port),
+                "{port} is a serial device and must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn an_absent_port_means_auto_detect_and_is_not_an_error() {
+        let accepted = validated_port(None).expect("an absent port is valid");
+        assert!(accepted.is_none(), "an absent port must stay absent");
+    }
+
+    #[test]
+    fn paths_that_are_not_serial_devices_are_rejected() {
+        for port in [
+            "/dev/../etc/passwd",      // traversal out of /dev
+            "/etc/passwd",             // outside /dev entirely
+            "/dev/serial/by-id/usb-0", // a second path component
+            "/dev/tty",                // the controlling terminal, not a radio
+            "/dev/mem",                // a device, but not a serial one
+            "/dev/ttyUSB0/../../mem",  // traversal behind a valid-looking prefix
+            "/dev/ttyUSB0\0",          // an embedded NUL
+            "dev/ttyUSB0",             // relative, so not anchored at /dev
+            "",                        // empty
+            "/dev/",                   // no device name at all
+        ] {
+            assert!(
+                !is_serial_device_path(port),
+                "{port:?} is not a serial device path and must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn an_overlong_port_is_rejected_before_anything_looks_at_it() {
+        let port = format!("/dev/tty{}", "A".repeat(MAX_PORT_LEN));
+        assert!(
+            port.len() > MAX_PORT_LEN,
+            "the fixture must exceed the bound, or this proves nothing"
+        );
+        assert!(!is_serial_device_path(&port));
+    }
+
+    /// The disclosure half of the finding: a rejection must not tell the caller
+    /// anything about the path it supplied, or the endpoint is a filesystem
+    /// probe oracle that happens to return 400.
+    #[tokio::test]
+    async fn a_rejected_port_is_a_400_that_does_not_echo_the_supplied_path() {
+        let probe = "/dev/../root/.ssh/id_ed25519";
+        let error = validated_port(Some(probe.to_owned()))
+            .err()
+            .expect("a traversal path must be rejected");
+
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+            Err(read_err) => format!("<unreadable body: {read_err}>"),
+        };
+        assert!(
+            !body.contains("/root") && !body.contains("id_ed25519") && !body.contains(probe),
+            "the rejection body must not echo the supplied path, got {body}"
+        );
+        assert!(
+            body.contains("serial device path"),
+            "the caller still needs to know what shape is expected, got {body}"
+        );
+    }
 
     #[test]
     fn no_radio_is_a_404() {

--- a/crates/akroasis-server/src/radio.rs
+++ b/crates/akroasis-server/src/radio.rs
@@ -144,8 +144,10 @@ mod tests {
 
     #[test]
     fn an_absent_port_means_auto_detect_and_is_not_an_error() {
-        let accepted = validated_port(None).expect("an absent port is valid");
-        assert!(accepted.is_none(), "an absent port must stay absent");
+        assert!(
+            matches!(validated_port(None), Ok(None)),
+            "an absent port is valid and must stay absent"
+        );
     }
 
     #[test]
@@ -185,16 +187,26 @@ mod tests {
     #[tokio::test]
     async fn a_rejected_port_is_a_400_that_does_not_echo_the_supplied_path() {
         let probe = "/dev/../root/.ssh/id_ed25519";
-        let error =
-            validated_port(Some(probe.to_owned())).expect_err("a traversal path must be rejected");
-
-        let response = error.into_response();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-
-        let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
-            Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
-            Err(read_err) => format!("<unreadable body: {read_err}>"),
+        // A sentinel on the accepted branch rather than a panic: the assertions
+        // below are what decide this case, and both of them fail on it.
+        let (status, body) = match validated_port(Some(probe.to_owned())) {
+            Ok(_) => (StatusCode::OK, "<accepted>".to_owned()),
+            Err(error) => {
+                let response = error.into_response();
+                let status = response.status();
+                let body = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+                    Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+                    Err(read_err) => format!("<unreadable body: {read_err}>"),
+                };
+                (status, body)
+            }
         };
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "a traversal path must be rejected"
+        );
         assert!(
             !body.contains("/root") && !body.contains("id_ed25519") && !body.contains(probe),
             "the rejection body must not echo the supplied path, got {body}"


### PR DESCRIPTION
## Summary

`GET /api/v1/radio/detect` forwarded its caller-supplied `port` query string verbatim into the
dispatch path that opens it as a serial device. This constrains it at the handler boundary.

## The rule

`port` must be a single device component directly under `/dev`, named `tty` followed by
alphanumerics, within a length bound. That rejects:

| input | why |
|---|---|
| `/dev/../etc/passwd` | traversal out of `/dev` |
| `/etc/passwd` | outside `/dev` entirely |
| `/dev/serial/by-id/usb-0` | a second path component, so an indirection this cannot vouch for |
| `/dev/tty` | the controlling terminal, not a radio |
| `/dev/mem` | a device node, but not a serial one |
| `/dev/ttyUSB0\0` | embedded NUL |
| `dev/ttyUSB0` | relative, so not anchored at `/dev` |

An absent `port` is still valid and still means auto-detect.

## Why lexical rather than a stat

The check runs before any filesystem access. That makes it unraceable — a `stat`-then-open validator
has a TOCTOU window that a lexical one does not — and it makes the behaviour identical on a host with
no radio attached, which is what lets it be tested deterministically in CI. The OS still enforces that
the node is actually openable, and those failures were already classified without echoing paths.

## The disclosure half

The finding notes the endpoint doubles as a filesystem-probe oracle, because differing error text
discloses existence and permission. Every rejection now returns one fixed message that never names the
supplied value. A test asserts the 400 body contains neither the probe path nor its components, which
is the half a status-code-only assertion would miss.

## Anti-vacuity

The accept-case test pins `/dev/ttyUSB0`, `/dev/ttyACM1`, `/dev/ttyS0` and `/dev/ttyUSB10` first: a
validator that refused everything would satisfy every rejection case while breaking the endpoint, so
the rejections only mean something alongside it.

Closes #195
