### PR TITLE
ci(gate-attestation): pin the hybrid-gate reusable-workflow ref to a SHA

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -103,7 +103,12 @@ permissions:
 
 jobs:
   gate:
-    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@main
+    # WHY(#376) pinned: a branch ref is moved by whoever pushes to forkwright/.github,
+    # so an unpinned call changes what this repo's gate runs with no commit here to
+    # review or blame. It moved between #376 being filed and being fixed, which is the
+    # behaviour rather than a hypothetical. Dependabot tracks the github-actions
+    # ecosystem for this repo and bumps the pin.
+    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@d74efb1d2d87ec86717dad5d42d468f6e3cf7994 # main
     with:
       fmt_cmd: "cargo fmt --all -- --check"
       check_cmd: "cargo check --workspace --all-targets --features syntonia/hardware-serial --jobs 8 --keep-going"


### PR DESCRIPTION
## Summary

Pins `forkwright/.github/.github/workflows/hybrid-gate.yml` from `@main` to
`@d74efb1d2d87ec86717dad5d42d468f6e3cf7994 # main`.

## The ref moved while the issue was open

#376 recorded the resolution as `df92942bcc41cc7ffd0339b75b2f01e52269d0ef` when filed. Re-resolving
now (`gh api repos/forkwright/.github/commits/main`) gives `d74efb1d2d87ec86717dad5d42d468f6e3cf7994`.

So the workflow that decides every compile and test verdict in this repository changed underneath it,
with no commit here to review, `git blame`, or revert. That is the finding demonstrating itself rather
than a hypothetical, and it is why the SHA in the issue body was re-resolved rather than copied.

## Verification

The `Done when` asks that `kanon lint` stop reporting `SHELL/unpinned-action` for this file. Run
against both versions, because a clean result on its own would not distinguish a fixed file from a
lint that does not fire:

```
# unpinned (origin/main)
.github/workflows/gate-attestation.yml:106 [SHELL/unpinned-action] GitHub Action forkwright/.github not pinned to SHA

# pinned (this branch)
(no findings)
```

## Consistency

`sphragis`'s `gate-attestation.yml` already pins this exact call to this exact SHA with the same
`# main` trailing comment, so this brings the two repos into agreement rather than inventing a
convention. Dependabot already watches the `github-actions` ecosystem here — it opened #413 tonight —
so the pin stays current by the same route as every other action.

Closes #376
