### PR TITLE
fix(semaino): scope convergence detection to the signal's own cell

### DIFF
--- a/crates/semaino/src/alert.rs
+++ b/crates/semaino/src/alert.rs
@@ -382,8 +382,6 @@ mod tests {
         signal::{EnvironmentalDetail, RfDetail},
     };
 
-    use crate::convergence::DomainHit;
-
     use super::*;
 
     // ── helper builders ───────────────────────────────────────────────────────
@@ -429,21 +427,8 @@ mod tests {
     }
 
     fn fake_convergence(domain_count: usize) -> Convergence {
-        let kind = koinon::signal::SignalKind::Rf(RfDetail::Transmission {
-            frequency: Frequency::mhz(146),
-            power: Power::dbm(-30.0),
-            modulation: "FM".into(),
-            bandwidth: Frequency::khz(25),
-        });
-        let hits: Vec<DomainHit> = (0..domain_count)
-            .map(|_| DomainHit {
-                kind: kind.clone(),
-                timestamp: Timestamp::now(),
-            })
-            .collect();
         Convergence {
             center: Coordinates::new(51.5, -0.1, None).unwrap(),
-            hits,
             domain_count,
         }
     }

--- a/crates/semaino/src/convergence.rs
+++ b/crates/semaino/src/convergence.rs
@@ -75,9 +75,13 @@ pub struct DomainHit {
 pub struct Convergence {
     /// Approximate centre coordinates of the convergence cell.
     pub center: Coordinates,
-    /// All domain observations inside this cell within the time window.
-    pub hits: Vec<DomainHit>,
-    /// Number of distinct [`SignalKind`] domains represented in `hits`.
+    /// Number of distinct [`SignalKind`] domains observed in this cell within
+    /// the time window.
+    ///
+    /// WHY(#223) there is no `hits` field: this type previously also carried
+    /// every windowed [`DomainHit`], cloned on every detection. No consumer
+    /// ever read it -- the alert path reads only this count -- so the clone was
+    /// pure cost that scaled with input volume.
     pub domain_count: usize,
 }
 
@@ -135,6 +139,16 @@ impl DomainSlots {
             .iter()
             .filter_map(Option::as_ref)
             .filter(move |h| h.timestamp.as_unix_millis() >= cutoff_ms)
+    }
+
+    /// Count domains with a live hit at or after `cutoff_ms`.
+    ///
+    /// WHY this is the distinct count rather than a set built from the hits:
+    /// a slot holds at most one hit per domain discriminant by construction,
+    /// so a live slot *is* a distinct domain. Building a `HashSet` to
+    /// rediscover that re-derives an invariant the type already guarantees.
+    fn distinct_domains(&self, cutoff_ms: i64) -> usize {
+        self.within_window(cutoff_ms).count()
     }
 
     /// Drop hits older than `cutoff_ms`. Returns `true` if any slot remains.
@@ -218,24 +232,51 @@ impl ConvergenceGrid {
         let window_ms = window.as_millis() as i64; // SAFETY: Duration::as_millis() returns u128 but real windows are bounded; fits i64
         let cutoff_ms = now.as_unix_millis() - window_ms;
 
-        let mut result = Vec::new();
+        self.cells
+            .keys()
+            .filter_map(|&cell| self.converged_cell(cell, min_domains, cutoff_ms))
+            .collect()
+    }
 
-        for (&cell, slots) in &self.cells {
-            let window_hits: Vec<&DomainHit> = slots.within_window(cutoff_ms).collect();
+    /// Convergence for the cell containing `coords`, if that one cell has
+    /// `>= min_domains` distinct domains within `window`.
+    ///
+    /// WHY(#223) this exists alongside [`detect`]: a caller evaluating one
+    /// signal wants that signal's cell, and scanning the whole grid to find it
+    /// makes per-signal work scale with the number of populated cells rather
+    /// than with the one cell in question. Reading the cell directly is a hash
+    /// lookup regardless of how much of the grid an adversary has populated.
+    ///
+    /// [`detect`]: ConvergenceGrid::detect
+    #[must_use]
+    pub fn detect_at(
+        &self,
+        coords: &Coordinates,
+        min_domains: usize,
+        window: std::time::Duration,
+        now: Timestamp,
+    ) -> Option<Convergence> {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "Duration::as_millis() returns u128; converting to i64 is safe for any reasonable window (i64::MAX ms >> practical window sizes)"
+        )]
+        let window_ms = window.as_millis() as i64; // SAFETY: Duration::as_millis() returns u128 but real windows are bounded; fits i64
+        let cutoff_ms = now.as_unix_millis() - window_ms;
+        self.converged_cell(quantize(coords, self.resolution), min_domains, cutoff_ms)
+    }
 
-            // Count distinct domain discriminants.
-            let distinct = domain_count(&window_hits);
-            if distinct >= min_domains {
-                let center = cell_center(cell, self.resolution);
-                result.push(Convergence {
-                    center,
-                    hits: window_hits.into_iter().cloned().collect(),
-                    domain_count: distinct,
-                });
-            }
-        }
-
-        result
+    /// Evaluate one cell against the domain threshold.
+    fn converged_cell(
+        &self,
+        cell: GridCell,
+        min_domains: usize,
+        cutoff_ms: i64,
+    ) -> Option<Convergence> {
+        let distinct = self.cells.get(&cell)?.distinct_domains(cutoff_ms);
+        (distinct >= min_domains).then(|| Convergence {
+            center: cell_center(cell, self.resolution),
+            domain_count: distinct,
+        })
     }
 
     /// Remove all hits older than `older_than` from every cell.
@@ -250,14 +291,6 @@ impl ConvergenceGrid {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Count distinct top-level domain discriminants in a slice of [`DomainHit`] refs.
-fn domain_count(hits: &[&DomainHit]) -> usize {
-    use std::collections::HashSet;
-
-    let discriminants: HashSet<u8> = hits.iter().map(|h| kind_discriminant(&h.kind)).collect();
-    discriminants.len()
-}
 
 /// Map a [`SignalKind`] to a stable integer discriminant for domain counting.
 ///
@@ -422,6 +455,116 @@ mod tests {
             cell,
             GridCell(-2, -2),
             "floor(-1.5) must be -2, not -1 (truncation-toward-zero)"
+        );
+    }
+
+    /// Anti-vacuity for the scoping cases below: `detect_at` must be able to
+    /// return `Some`, or a test asserting `None` elsewhere proves nothing.
+    #[test]
+    fn detect_at_finds_the_convergence_in_its_own_cell() {
+        let loc = coords(51.5, -0.1);
+        let mut grid = ConvergenceGrid::new(10_000);
+        grid.ingest(&signal_at(rf_kind(), loc));
+        grid.ingest(&signal_at(mesh_kind(), loc));
+
+        let found = grid.detect_at(&loc, 2, std::time::Duration::from_secs(30), ts_now());
+
+        assert!(
+            found.is_some_and(|c| c.domain_count == 2),
+            "two domains in this cell must converge here"
+        );
+    }
+
+    #[test]
+    fn detect_at_is_none_where_nothing_converged() {
+        let busy = coords(51.5, -0.1);
+        let quiet = coords(48.85, 2.35);
+        let mut grid = ConvergenceGrid::new(10_000);
+        grid.ingest(&signal_at(rf_kind(), busy));
+        grid.ingest(&signal_at(mesh_kind(), busy));
+
+        assert!(
+            grid.detect_at(&quiet, 2, std::time::Duration::from_secs(30), ts_now())
+                .is_none(),
+            "a convergence elsewhere must not be reported for this cell"
+        );
+    }
+
+    /// The scoping property: what `detect_at` returns depends only on the cell
+    /// asked about, so one cell's contents cannot answer for another's.
+    #[test]
+    fn detect_at_reports_the_asked_cell_not_the_busiest_one() {
+        let quiet = coords(48.85, 2.35);
+        let busy = coords(51.5, -0.1);
+        let mut grid = ConvergenceGrid::new(10_000);
+        // Three domains in the busy cell, one in the quiet cell.
+        grid.ingest(&signal_at(rf_kind(), busy));
+        grid.ingest(&signal_at(mesh_kind(), busy));
+        grid.ingest(&signal_at(
+            SignalKind::Gps(GpsDetail::SpoofingSuspected { confidence: 0.9 }),
+            busy,
+        ));
+        grid.ingest(&signal_at(rf_kind(), quiet));
+
+        let window = std::time::Duration::from_secs(30);
+        let now = ts_now();
+
+        assert!(
+            grid.detect_at(&quiet, 2, window, now).is_none(),
+            "one domain in the quiet cell must not converge"
+        );
+        assert_eq!(
+            grid.detect_at(&busy, 2, window, now)
+                .map(|c| c.domain_count),
+            Some(3),
+            "the busy cell must report its own three domains"
+        );
+    }
+
+    /// The bound #223 exists for: a sustained flood at one coordinate cannot
+    /// grow that cell past one retained hit per domain, so neither its reported
+    /// count nor the work of reading it scales with input rate.
+    #[test]
+    fn a_flood_at_one_coordinate_cannot_grow_past_the_domain_bound() {
+        let loc = coords(51.5, -0.1);
+        let mut grid = ConvergenceGrid::new(10_000);
+        for _ in 0..10_000 {
+            grid.ingest(&signal_at(rf_kind(), loc));
+            grid.ingest(&signal_at(mesh_kind(), loc));
+        }
+
+        let found = grid
+            .detect_at(&loc, 2, std::time::Duration::from_secs(30), ts_now())
+            .expect("two domains must converge");
+
+        assert_eq!(
+            found.domain_count, 2,
+            "20 000 ingests of two domains must still report two"
+        );
+        assert!(
+            DOMAIN_SLOTS <= 8,
+            "per-cell retention is bounded by DOMAIN_SLOTS, not by input volume"
+        );
+    }
+
+    /// `detect` and `detect_at` must not disagree about the same cell.
+    #[test]
+    fn detect_at_agrees_with_the_full_scan_for_that_cell() {
+        let loc = coords(51.5, -0.1);
+        let mut grid = ConvergenceGrid::new(10_000);
+        grid.ingest(&signal_at(rf_kind(), loc));
+        grid.ingest(&signal_at(mesh_kind(), loc));
+
+        let window = std::time::Duration::from_secs(30);
+        let now = ts_now();
+        let scanned = grid.detect(2, window, now);
+        let scoped = grid.detect_at(&loc, 2, window, now);
+
+        assert_eq!(scanned.len(), 1, "one cell converged");
+        assert_eq!(
+            scanned.first().map(|c| c.domain_count),
+            scoped.map(|c| c.domain_count),
+            "the scoped read and the full scan must agree about this cell"
         );
     }
 

--- a/crates/semaino/src/convergence.rs
+++ b/crates/semaino/src/convergence.rs
@@ -500,10 +500,7 @@ mod tests {
         // Three domains in the busy cell, one in the quiet cell.
         grid.ingest(&signal_at(rf_kind(), busy));
         grid.ingest(&signal_at(mesh_kind(), busy));
-        grid.ingest(&signal_at(
-            SignalKind::Gps(GpsDetail::SpoofingSuspected { confidence: 0.9 }),
-            busy,
-        ));
+        grid.ingest(&signal_at(gps_kind(), busy));
         grid.ingest(&signal_at(rf_kind(), quiet));
 
         let window = std::time::Duration::from_secs(30);

--- a/crates/semaino/src/convergence.rs
+++ b/crates/semaino/src/convergence.rs
@@ -534,13 +534,11 @@ mod tests {
             .detect_at(&loc, 2, std::time::Duration::from_secs(30), ts_now())
             .expect("two domains must converge");
 
+        // This count is the bound: it is the number of live slots, so a cell
+        // whose storage grew with input volume could not still report two.
         assert_eq!(
             found.domain_count, 2,
             "20 000 ingests of two domains must still report two"
-        );
-        assert!(
-            DOMAIN_SLOTS <= 8,
-            "per-cell retention is bounded by DOMAIN_SLOTS, not by input volume"
         );
     }
 

--- a/crates/semaino/src/pipeline.rs
+++ b/crates/semaino/src/pipeline.rs
@@ -256,14 +256,21 @@ impl SemainoPipeline {
         self.grid.ingest(&aggregated.signal);
 
         let now = koinon::Timestamp::now();
-        let convergences = self
-            .grid
-            .detect(self.min_convergence_domains, self.time_window, now);
+        // WHY(#223): this read the whole grid and then took `.first()`, under a
+        // comment claiming it was "the cell matching the signal". A HashMap has
+        // no first, so with more than one converged cell the alert was attributed
+        // to an arbitrary one and the choice varied between runs. Asking for the
+        // triggering signal's own cell is both what the comment meant and a hash
+        // lookup instead of a scan whose cost an adversary controls.
+        let matching_convergence = aggregated.signal.location.as_ref().and_then(|coords| {
+            self.grid
+                .detect_at(coords, self.min_convergence_domains, self.time_window, now)
+        });
 
-        // Use the first convergence event for the cell matching the signal, if any.
-        let matching_convergence = convergences.first();
-
-        if let Some(alert) = self.alerts.process(aggregated, matching_convergence) {
+        if let Some(alert) = self
+            .alerts
+            .process(aggregated, matching_convergence.as_ref())
+        {
             tracing::info!(
                 alert_id = %alert.id,
                 severity = ?alert.severity,
@@ -540,6 +547,81 @@ mod tests {
             "an Elevated score with 2-domain convergence classifies as \
              Medium; a Low severity here means the RF trigger's own signal \
              was missing from the grid at detection time (#224)"
+        );
+    }
+
+    /// WHY(#223): convergence detection read the whole grid and then took
+    /// `.first()`, so a cluster anywhere on the map could supply the
+    /// convergence used to classify a signal that landed somewhere else
+    /// entirely. Here the trigger's own cell holds only the trigger, and a
+    /// two-domain cluster sits far away; an Elevated score with no convergence
+    /// at the trigger must classify Low. Under the old scan-then-first this
+    /// returned Medium, escalating an alert on the strength of an unrelated
+    /// location.
+    #[test]
+    fn a_convergence_in_another_cell_does_not_escalate_this_signal() {
+        use koinon::signal::MeshDetail;
+
+        let elsewhere = Coordinates::new(51.5, -0.1, None).expect("valid coordinates");
+        let trigger_loc = Coordinates::new(48.85, 2.35, None).expect("valid coordinates");
+
+        let mut pipeline = SemainoPipeline::new(&SemainoConfig {
+            suppression_window_secs: 0,
+            min_convergence_domains: 2,
+            ..SemainoConfig::default()
+        });
+        let sink = CollectingSink::default();
+        let sink_data = Arc::clone(&sink.0);
+        pipeline.add_sink(sink);
+
+        // A genuine two-domain convergence, far from the signal below.
+        pipeline.grid.ingest(&GeoSignal::new(
+            SignalKind::Mesh(MeshDetail::NodeSeen {
+                node_id: 1,
+                snr: 5.0,
+                hop_count: 1,
+            }),
+            Timestamp::now(),
+            Some(elsewhere),
+        ));
+        pipeline.grid.ingest(&GeoSignal::new(
+            SignalKind::Rf(RfDetail::Transmission {
+                frequency: Frequency::mhz(146),
+                power: Power::dbm(50.0),
+                modulation: "FM".into(),
+                bandwidth: Frequency::khz(25),
+            }),
+            Timestamp::now(),
+            Some(elsewhere),
+        ));
+
+        let aggregated = AggregatedSignal {
+            signal: GeoSignal::new(
+                SignalKind::Rf(RfDetail::Transmission {
+                    frequency: Frequency::mhz(433),
+                    power: Power::dbm(20.0),
+                    modulation: "FM".into(),
+                    bandwidth: Frequency::khz(25),
+                }),
+                Timestamp::now(),
+                Some(trigger_loc),
+            ),
+            score: AnomalyScore::Elevated(2.2),
+            baseline_mean: Some(-50.0),
+            baseline_stddev: Some(1.0),
+        };
+
+        pipeline.handle_aggregated(&aggregated);
+
+        let first_severity = {
+            let alerts = sink_data.lock().expect("sink lock");
+            alerts.first().map(|a| a.severity.clone())
+        };
+        assert_eq!(
+            first_severity,
+            Some(koinon::signal::AlertSeverity::Low),
+            "the trigger's own cell holds one domain, so this must classify \
+             Low; Medium means an unrelated cell's convergence was used"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the two clauses of #223 that were still open. The per-cell `DomainSlots` bound from the earlier
half is unchanged; this is the scoping and the clone.

## The part that is a correctness bug, not a cost one

`handle_aggregated` called `grid.detect(..)` — a scan of every populated cell — and then took
`.first()`, under a comment reading *"the first convergence event for the cell matching the signal"*.

A `HashMap` has no first. With more than one converged cell, `.first()` returned an arbitrary one, and
which one varied between runs. `classify` reads `convergence.domain_count`, so a cluster anywhere on the
map could escalate an `Elevated` signal that landed somewhere quiet.

`a_convergence_in_another_cell_does_not_escalate_this_signal` pins it: the trigger's own cell holds one
domain while a two-domain cluster sits elsewhere, so the alert must classify `Low`. The previous code
returned `Medium`.

## The scoping

`detect_at(coords, ..)` reads the one cell the signal landed in. Per-signal work becomes a hash lookup
instead of a walk over however many cells a flood has populated — which is the amplification half of the
finding, since an adversary chooses how many cells exist.

`detect` is unchanged for callers that genuinely want the whole grid; both now route through one
`converged_cell`, and a test asserts the two agree about the same cell rather than trusting that they do.

## The clone

`Convergence.hits` cloned every windowed `DomainHit` on every detection. Nothing read it — the only
non-test reference was a test helper *constructing* it. Removed.

Counting distinct domains no longer builds a `HashSet` either: a slot holds at most one hit per domain
by construction, so a live slot **is** a distinct domain, and the set was rediscovering an invariant the
type already guarantees.

## Tests

Five new cases in `convergence.rs` — one anti-vacuity case proving `detect_at` can return `Some`, the
quiet/busy scoping pair, agreement with the full scan, and the bound stated outright: twenty thousand
ingests at one coordinate still report two domains. Plus the pipeline regression above.

Refs #223
