### PR TITLE
fix(akroasis): zeroize vault passphrase and new-secret terminal input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/akroasis/Cargo.toml
+++ b/crates/akroasis/Cargo.toml
@@ -39,6 +39,7 @@ syntonia = { path = "../syntonia" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/akroasis/src/vault/mod.rs
+++ b/crates/akroasis/src/vault/mod.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use clap::Subcommand;
 use comfy_table::{Cell, Table};
 use snafu::{ResultExt, Snafu};
+use zeroize::Zeroizing;
 
 use kryphos::{CredentialType, EntryInfo, InstallationIdentity, Vault, VaultError};
 
@@ -125,8 +126,15 @@ fn parse_credential_type(s: &str) -> Result<CredentialType, String> {
 }
 
 /// Reads a passphrase from the terminal (no echo).
-fn read_passphrase(prompt: &str) -> Result<String, VaultCliError> {
-    rpassword::prompt_password(prompt).context(PassphraseInputSnafu)
+///
+/// WHY(#379) `Zeroizing`: what the operator types is the same plaintext
+/// credential material a `DecryptedEntry` protects on the way out, so it is
+/// wrapped on the way in too. A bare `String` leaves the passphrase in freed
+/// heap memory after the last use.
+fn read_passphrase(prompt: &str) -> Result<Zeroizing<String>, VaultCliError> {
+    rpassword::prompt_password(prompt)
+        .map(Zeroizing::new)
+        .context(PassphraseInputSnafu)
 }
 
 /// Validates a passphrase confirmation: the two entries must match, and the
@@ -161,7 +169,7 @@ fn confirm_passphrase(first: &str, second: &str) -> Result<(), VaultCliError> {
 /// double-Enter fails immediately with a clear retry message rather than
 /// silently succeeding and relying on `Vault::create`'s own rejection to
 /// surface as a less specific downstream error (forkwright/akroasis#287).
-fn read_passphrase_confirmed(prompt: &str) -> Result<String, VaultCliError> {
+fn read_passphrase_confirmed(prompt: &str) -> Result<Zeroizing<String>, VaultCliError> {
     let first = read_passphrase(prompt)?;
     let second = read_passphrase("Confirm passphrase: ")?;
 
@@ -171,8 +179,14 @@ fn read_passphrase_confirmed(prompt: &str) -> Result<String, VaultCliError> {
 }
 
 /// Reads a secret value from the terminal (no echo).
-fn read_secret(prompt: &str) -> Result<String, VaultCliError> {
-    rpassword::prompt_password(prompt).context(PassphraseInputSnafu)
+///
+/// WHY(#379) `Zeroizing`: a freshly typed replacement secret is credential
+/// material before it ever reaches the vault, and is wrapped for the same
+/// reason as [`read_passphrase`].
+fn read_secret(prompt: &str) -> Result<Zeroizing<String>, VaultCliError> {
+    rpassword::prompt_password(prompt)
+        .map(Zeroizing::new)
+        .context(PassphraseInputSnafu)
 }
 
 /// Dispatches a vault subcommand.


### PR DESCRIPTION
## Summary

`read_passphrase`, `read_passphrase_confirmed` and `read_secret` now return `Zeroizing<String>`.

## Why

A vault passphrase and a freshly typed replacement secret are credential material from the moment the
operator types them, but they were held in ordinary `String`s between the terminal read and their last
use. Nothing cleared those allocations on drop, so the plaintext lingered in freed heap memory.

#218 fixed exactly this class for `DecryptedEntry.secret` — the material the vault hands *back*. This is
the same material on the way *in*, which was outside that issue's stated scope. With both, the protected
span covers the whole path rather than only one end of it.

## Scope of the change

Three private function signatures and one import. Call sites are untouched: `Zeroizing` derefs, so
`passphrase.as_bytes()`, `new_secret.as_bytes()` and the `confirm_passphrase(&first, &second)`
comparison read exactly as they did.

`zeroize` becomes a direct dependency of `crates/akroasis`. It was already in the tree as a workspace
dependency and in the lockfile via `kryphos`, so the manifest and lock changes are one line each with no
version movement. The type appears only in private signatures, so nothing is added to this crate's public
API.

## Verification note

`rpassword::prompt_password` reads the real terminal with no injection seam, which is why
`confirm_passphrase` was already split out as a pure, unit-tested function — that structure is unchanged
here. The property this PR adds is a type-level one the compiler enforces at every call site rather than
something a test can observe, since it concerns memory after drop.

Closes #379
