### PR TITLE
fix(semaino): make the signal path lossless end to end

### DIFF
--- a/crates/semaino/src/aggregator.rs
+++ b/crates/semaino/src/aggregator.rs
@@ -12,7 +12,7 @@ use koinon::{
     signal::{EnvironmentalDetail, GpsDetail, MeshDetail, ProximityDetail, RfDetail, SignalKind},
 };
 use snafu::Snafu;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -84,7 +84,7 @@ impl KindKey {
 
 /// Signal aggregator with per-kind temporal baselines.
 ///
-/// Receives [`GeoSignal`]s from a broadcast channel, maintains per-kind
+/// Receives [`GeoSignal`]s from a bounded channel, maintains per-kind
 /// [`TemporalBucketedBaseline`]s, scores each signal, and forwards
 /// [`AggregatedSignal`]s downstream when the score is elevated or anomalous.
 pub struct SignalAggregator {
@@ -145,8 +145,15 @@ impl SignalAggregator {
     ///
     /// # Cancellation Safety
     ///
-    /// `recv()` on a broadcast receiver is cancel-safe; no signal is lost on
+    /// `recv()` on an mpsc receiver is cancel-safe; no signal is lost on
     /// cancellation at the `select!` boundary.
+    ///
+    /// # Why the output is unbounded (#232)
+    ///
+    /// This task has exactly one await — its input `recv`. That is what makes a
+    /// bounded input safe: the aggregator can never be blocked by its consumer,
+    /// so the consumer can block on sending to it without the two deadlocking.
+    /// A bounded output would restore that await and close the cycle.
     #[tracing::instrument(
         level = "debug",
         skip(self, rx, tx),
@@ -154,20 +161,13 @@ impl SignalAggregator {
     )]
     pub async fn run(
         &mut self,
-        mut rx: broadcast::Receiver<GeoSignal>,
-        tx: mpsc::Sender<AggregatedSignal>,
+        mut rx: mpsc::Receiver<GeoSignal>,
+        tx: mpsc::UnboundedSender<AggregatedSignal>,
     ) {
         loop {
-            let signal = match rx.recv().await {
-                Ok(s) => s,
-                Err(broadcast::error::RecvError::Closed) => {
-                    tracing::debug!("aggregator: broadcast channel closed");
-                    return;
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!(dropped = n, "aggregator: lagged behind broadcast");
-                    continue;
-                }
+            let Some(signal) = rx.recv().await else {
+                tracing::debug!("aggregator: signal channel closed");
+                return;
             };
 
             tracing::trace!(signal_id = %signal.signal_id, kind = ?KindKey::from_signal(&signal.kind), "signal received");
@@ -215,7 +215,7 @@ impl SignalAggregator {
                     "aggregator: anomaly emitted"
                 );
 
-                if tx.send(aggregated).await.is_err() {
+                if tx.send(aggregated).is_err() {
                     tracing::debug!("aggregator: downstream receiver dropped, exiting");
                     return;
                 }
@@ -444,19 +444,19 @@ mod tests {
 
     #[tokio::test]
     async fn aggregator_scores_anomaly_after_baseline() {
-        let (broadcast_tx, broadcast_rx) = broadcast::channel::<GeoSignal>(64);
-        let (agg_tx, mut agg_rx) = mpsc::channel::<AggregatedSignal>(64);
+        let (signal_tx, signal_rx) = mpsc::channel::<GeoSignal>(64);
+        let (agg_tx, mut agg_rx) = mpsc::unbounded_channel::<AggregatedSignal>();
 
         let mut aggregator = SignalAggregator::new();
         let handle = tokio::spawn(async move {
-            aggregator.run(broadcast_rx, agg_tx).await;
+            aggregator.run(signal_rx, agg_tx).await;
         });
 
         // Feed 20 normal signals around -50.0 dBm to build a stable baseline.
         for i in 0..20_i32 {
             // Vary slightly so stddev > 0.
             let power = -50.0 + f64::from(i % 3);
-            broadcast_tx.send(rf_signal(power)).unwrap();
+            signal_tx.send(rf_signal(power)).await.unwrap();
         }
 
         // Small delay to ensure the aggregator processes the normal signals before
@@ -467,7 +467,7 @@ mod tests {
         while agg_rx.try_recv().is_ok() {}
 
         // Send a clear outlier far from the baseline mean.
-        broadcast_tx.send(rf_signal(50.0)).unwrap();
+        signal_tx.send(rf_signal(50.0)).await.unwrap();
 
         // Wait for the aggregated signal to arrive.
         let result =
@@ -485,7 +485,7 @@ mod tests {
             aggregated.score
         );
 
-        drop(broadcast_tx);
+        drop(signal_tx);
         handle.await.unwrap();
     }
 
@@ -513,23 +513,26 @@ mod tests {
         // across i in 0..20, so the baseline mean is -50 + 19/20.
         const EXPECTED_MEAN: f64 = -49.05;
 
-        let (broadcast_tx, broadcast_rx) = broadcast::channel::<GeoSignal>(64);
-        let (agg_tx, mut agg_rx) = mpsc::channel::<AggregatedSignal>(64);
+        let (signal_tx, signal_rx) = mpsc::channel::<GeoSignal>(64);
+        let (agg_tx, mut agg_rx) = mpsc::unbounded_channel::<AggregatedSignal>();
 
         let mut aggregator = SignalAggregator::new();
         let handle = tokio::spawn(async move {
-            aggregator.run(broadcast_rx, agg_tx).await;
+            aggregator.run(signal_rx, agg_tx).await;
         });
 
         for i in 0..20_i32 {
             let power = -50.0 + f64::from(i % 3);
-            broadcast_tx.send(rf_signal_at(power, BUCKET_MS)).unwrap();
+            signal_tx
+                .send(rf_signal_at(power, BUCKET_MS))
+                .await
+                .unwrap();
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(20)).await; // kanon:ignore TESTING/sleep-in-test -- synchronises with the spawned aggregator task; a barrier would re-implement the channel's ready signal
         while agg_rx.try_recv().is_ok() {}
 
-        broadcast_tx.send(rf_signal_at(50.0, BUCKET_MS)).unwrap();
+        signal_tx.send(rf_signal_at(50.0, BUCKET_MS)).await.unwrap();
 
         let timed = tokio::time::timeout(tokio::time::Duration::from_millis(500), agg_rx.recv())
             .await
@@ -553,7 +556,7 @@ mod tests {
             "reported mean must predate the outlier: expected {EXPECTED_MEAN}, got {mean}"
         );
 
-        drop(broadcast_tx);
+        drop(signal_tx);
         handle.await.unwrap();
     }
 

--- a/crates/semaino/src/pipeline.rs
+++ b/crates/semaino/src/pipeline.rs
@@ -114,14 +114,28 @@ impl SemainoPipeline {
         // feed the grid from the same signal. The aggregator's public API is
         // sufficient: extract_feature and the internal baseline are accessed
         // through run(). We drive the aggregator's channel ourselves here.
-        let (agg_tx, mut agg_rx) = mpsc::channel::<AggregatedSignal>(256);
+        // WHY(#232) unbounded: the signal path below is lossless and applies
+        // backpressure, which is only safe because the aggregator cannot block.
+        // Its sole await is its input `recv`, so a bounded output here would
+        // give it a second one and close a cycle — main loop waiting to hand it
+        // a signal while it waits to hand back an aggregate. The alert stream is
+        // the filtered notable subset rather than every signal, so trading a
+        // bounded-memory guarantee on the low-volume leg for a no-loss guarantee
+        // on the high-volume one is the right way round.
+        let (agg_tx, mut agg_rx) = mpsc::unbounded_channel::<AggregatedSignal>();
         let (signal_tx, signal_rx) = mpsc::channel::<GeoSignal>(256);
 
         // Spawn aggregator task: receives GeoSignals via mpsc, emits AggregatedSignals.
         let mut aggregator = SignalAggregator::new();
         // WHY: We pipe GeoSignals into the aggregator via a local broadcast-backed
         // channel so we can reuse its run() loop without forking the implementation.
-        let (inner_tx, inner_rx) = broadcast::channel::<GeoSignal>(256);
+        // WHY(#232) mpsc rather than broadcast: a broadcast receiver that falls
+        // behind loses samples silently, so the aggregator's baselines could
+        // diverge from the grid's view of the same signals — under load, which
+        // is when the divergence matters. A bounded mpsc backpressures instead,
+        // and the caller's own broadcast stays the single place a signal can be
+        // dropped.
+        let (inner_tx, inner_rx) = mpsc::channel::<GeoSignal>(256);
         let agg_task = tokio::spawn(
             async move {
                 aggregator.run(inner_rx, agg_tx).await;
@@ -208,7 +222,7 @@ impl SemainoPipeline {
                             // Forward to the aggregator only now. This single
                             // line is the ordering guarantee (#224); moving it
                             // above the ingest reinstates the race.
-                            if let Err(error) = inner_tx.send(s) {
+                            if let Err(error) = inner_tx.send(s).await {
                                 tracing::trace!(
                                     %error,
                                     "aggregator channel closed, dropping signal"
@@ -344,6 +358,54 @@ mod tests {
             Timestamp::now(),
             None,
         )
+    }
+
+    /// WHY(#232): the saturation case. The internal signal channel holds 256,
+    /// so a burst larger than that is what forces the question the finding
+    /// asked — does a signal survive the hand-off when the aggregator is behind?
+    ///
+    /// It used to be a broadcast, which drops for a receiver that falls behind,
+    /// so the aggregator's baselines could diverge from the grid's view of the
+    /// same signals precisely under load. It is now a bounded mpsc, so the
+    /// producer waits instead and nothing between the fan and the aggregator is
+    /// lost.
+    ///
+    /// The outlier arrives last, after three hundred readings. It can only
+    /// produce an alert if it survived the burst, and the burst itself must
+    /// produce none: the first ten are insufficient data and the rest sit
+    /// exactly on a zero-variance baseline.
+    #[tokio::test]
+    async fn a_burst_larger_than_the_channel_loses_no_signal() {
+        const BURST: usize = 300;
+
+        let (tx, rx) = broadcast::channel::<GeoSignal>(1024);
+        let mut pipeline = SemainoPipeline::new(&SemainoConfig {
+            suppression_window_secs: 0,
+            ..SemainoConfig::default()
+        });
+        let sink = CollectingSink::default();
+        let sink_data = Arc::clone(&sink.0);
+        pipeline.add_sink(sink);
+
+        for _ in 0..BURST {
+            tx.send(rf_signal(-30.0)).expect("send burst");
+        }
+        tx.send(rf_signal(50.0)).expect("send outlier");
+        drop(tx);
+
+        pipeline.run(rx).await;
+
+        let severities: Vec<_> = {
+            let alerts = sink_data.lock().expect("sink lock");
+            alerts.iter().map(|a| a.severity.clone()).collect()
+        };
+        assert_eq!(
+            severities,
+            vec![koinon::signal::AlertSeverity::High],
+            "exactly one alert, from the outlier: an empty list means it was \
+             dropped crossing a saturated channel (#232), and more than one \
+             means the flat burst itself scored"
+        );
     }
 
     /// WHY(#224): the literal `Done when` — N co-located multi-domain signals


### PR DESCRIPTION
## Summary

Closes #232's surviving clause: the aggregator fed through a lossy bounded broadcast while the grid
fed through a blocking bounded mpsc, so under load the baselines could diverge from the grid's view of
the same signals.

## The asymmetry was load-bearing, which is why it survived a pass

Making both legs bounded-and-blocking closes a cycle:

```
main loop --(bounded, blocking)--> aggregator --(bounded, blocking)--> main loop
```

The main loop waits to hand the aggregator a signal; the aggregator waits to hand back an aggregate;
the main loop is the only consumer of aggregates and is not in its `select!` while blocked mid-branch.
That deadlocks. The lossy broadcast was breaking that cycle — it just did so silently, and by dropping
exactly the samples the baselines needed.

## The fix breaks the cycle at the other leg

Making the **aggregate** channel unbounded leaves the aggregator with exactly one await — its input
`recv`. It can therefore never be blocked by its consumer, which is what makes a bounded, blocking
input safe. The signal path from the fan onward now loses nothing, and the caller's own broadcast
becomes the single place a signal can be dropped — a channel the caller already owns and already
reasons about.

**The trade, stated rather than buried:** an unbounded queue carries no memory ceiling. It holds the
filtered notable subset rather than every signal, so the no-loss guarantee is bought on the low-volume
leg. That is the right way round; the reverse is what this PR removes.

## Verification

`a_burst_larger_than_the_channel_loses_no_signal` sends 300 readings and then an outlier through a
channel that holds 256, so the burst is what forces the hand-off question. The outlier can only
produce an alert if it survived; the burst must produce none of its own (the first ten are
insufficient data, the rest sit exactly on a zero-variance baseline). The assertion compares the whole
severity list, so a lost outlier and a spurious extra alert both fail.

The aggregator's own tests now drive it through an mpsc, matching how the pipeline feeds it.

Closes #232
