### PR TITLE
fix(kryphos): reject a bad vault salt instead of panicking on it

### DIFF
--- a/crates/kryphos/src/crypto.rs
+++ b/crates/kryphos/src/crypto.rs
@@ -8,7 +8,7 @@ use rand_core::{OsRng, RngCore};
 
 use snafu::ResultExt;
 
-use crate::error::{CryptoError, SerializationSnafu, VaultError};
+use crate::error::{CryptoError, InvalidSaltLengthSnafu, SerializationSnafu, VaultError};
 use crate::key::VaultKey;
 use crate::vault::{CredentialType, NONCE_LEN};
 
@@ -54,7 +54,20 @@ pub fn generate_salt() -> [u8; SALT_LEN] {
     clippy::expect_used,
     reason = "Argon2id params are compile-time constants; construction cannot fail"
 )]
-pub fn derive_key(passphrase: &[u8], salt: &[u8]) -> VaultKey {
+pub fn derive_key(passphrase: &[u8], salt: &[u8]) -> Result<VaultKey, CryptoError> {
+    // WHY this is fallible: the salt reaching here can come off disk. A stored
+    // vault header carries it as a variable-length field, so a corrupt or
+    // tampered file can supply one shorter than Argon2 accepts. That used to
+    // reach an `expect` whose stated justification covered only the output
+    // length, turning a bad file into a panic instead of an error.
+    if salt.len() != SALT_LEN {
+        return InvalidSaltLengthSnafu {
+            expected: SALT_LEN,
+            actual: salt.len(),
+        }
+        .fail();
+    }
+
     let params = argon2::Params::new(KDF_M_COST, KDF_T_COST, KDF_P_COST, Some(32))
         .expect("Argon2id params are compile-time constants"); // SAFETY: KDF_M_COST/T_COST/P_COST are compile-time constants within valid ranges per argon2 docs
     let argon2 = argon2::Argon2::new(
@@ -64,11 +77,17 @@ pub fn derive_key(passphrase: &[u8], salt: &[u8]) -> VaultKey {
     );
 
     let mut key_bytes = [0u8; 32];
+    // WHY mapped rather than expected: the length check above already rejects
+    // the reachable failure, so this arm is defence for a future caller. Turning
+    // it into an error rather than a panic costs nothing and means no later
+    // change to the parameters can reintroduce the crash.
     argon2
         .hash_password_into(passphrase, salt, &mut key_bytes)
-        .expect("Argon2id KDF should not fail with valid inputs"); // SAFETY: key_bytes length (32) is within the OUTPUT_SIZE range documented by argon2::Params
+        .map_err(|source| CryptoError::EncryptionFailed {
+            reason: format!("Argon2id key derivation failed: {source}"),
+        })?;
 
-    VaultKey::from_bytes(key_bytes)
+    Ok(VaultKey::from_bytes(key_bytes))
 }
 
 /// Encrypts plaintext with ChaCha20-Poly1305.
@@ -214,13 +233,51 @@ fn checked_len_prefix(field: &'static str, len: usize) -> Result<[u8; 4], VaultE
 mod tests {
     use super::*;
 
+    /// WHY(#231): a stored vault header carries its salt as a variable-length
+    /// field, so a corrupt or tampered file can supply one Argon2 rejects. That
+    /// used to reach an `expect` and crash the process. Every length that is not
+    /// the one this crate writes must now be an error.
+    #[test]
+    fn a_salt_of_the_wrong_length_is_an_error_rather_than_a_panic() {
+        let passphrase = b"correct horse battery staple";
+
+        for salt in [
+            vec![],                   // empty, as a truncated file would give
+            vec![0xAA; 1],            // shorter than Argon2's own minimum
+            vec![0xAA; SALT_LEN - 1], // one byte short of what this crate writes
+            vec![0xAA; SALT_LEN + 1], // one byte over
+            vec![0xAA; 4096],         // absurd, from a hand-edited header
+        ] {
+            let error = derive_key(passphrase, &salt).unwrap_err();
+            assert!(
+                matches!(error, CryptoError::InvalidSaltLength { expected, actual }
+                    if expected == SALT_LEN && actual == salt.len()),
+                "a {}-byte salt must report its own length, got {error}",
+                salt.len()
+            );
+        }
+    }
+
+    /// Anti-vacuity for the case above: the length this crate actually writes
+    /// must still derive, or the rejection test would pass against a function
+    /// that refuses everything.
+    #[test]
+    fn a_generated_salt_still_derives() {
+        let salt = generate_salt();
+        assert_eq!(salt.len(), SALT_LEN);
+        assert!(
+            derive_key(b"correct horse battery staple", &salt).is_ok(),
+            "a freshly generated salt must derive"
+        );
+    }
+
     #[test]
     fn derive_key_is_deterministic() {
         let passphrase = b"correct horse battery staple";
         let salt = [0xAA; SALT_LEN];
 
-        let key1 = derive_key(passphrase, &salt);
-        let key2 = derive_key(passphrase, &salt);
+        let key1 = derive_key(passphrase, &salt).unwrap();
+        let key2 = derive_key(passphrase, &salt).unwrap();
 
         assert_eq!(
             key1.as_bytes(),
@@ -233,8 +290,8 @@ mod tests {
     fn derive_key_differs_with_different_salt() {
         let passphrase = b"correct horse battery staple";
 
-        let key1 = derive_key(passphrase, &[0xAA; SALT_LEN]);
-        let key2 = derive_key(passphrase, &[0xBB; SALT_LEN]);
+        let key1 = derive_key(passphrase, &[0xAA; SALT_LEN]).unwrap();
+        let key2 = derive_key(passphrase, &[0xBB; SALT_LEN]).unwrap();
 
         assert_ne!(
             key1.as_bytes(),
@@ -247,8 +304,8 @@ mod tests {
     fn derive_key_differs_with_different_passphrase() {
         let salt = [0xAA; SALT_LEN];
 
-        let key1 = derive_key(b"passphrase-one", &salt);
-        let key2 = derive_key(b"passphrase-two", &salt);
+        let key1 = derive_key(b"passphrase-one", &salt).unwrap();
+        let key2 = derive_key(b"passphrase-two", &salt).unwrap();
 
         assert_ne!(
             key1.as_bytes(),

--- a/crates/kryphos/src/crypto.rs
+++ b/crates/kryphos/src/crypto.rs
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt_round_trip() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
         let plaintext = b"secret vault entry data";
 
         let ciphertext = encrypt(&key, plaintext, b"").unwrap();
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt_empty_plaintext() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
 
         let ciphertext = encrypt(&key, b"", b"").unwrap();
         let decrypted = decrypt(&key, &ciphertext, b"").unwrap();
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt_large_payload() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
         let plaintext = vec![0xAB; 1_000_000];
 
         let ciphertext = encrypt(&key, &plaintext, b"").unwrap();
@@ -357,8 +357,8 @@ mod tests {
 
     #[test]
     fn decrypt_with_wrong_key_returns_error() {
-        let key1 = derive_key(b"correct-passphrase", &[0x42; SALT_LEN]);
-        let key2 = derive_key(b"wrong-passphrase", &[0x42; SALT_LEN]);
+        let key1 = derive_key(b"correct-passphrase", &[0x42; SALT_LEN]).unwrap();
+        let key2 = derive_key(b"wrong-passphrase", &[0x42; SALT_LEN]).unwrap();
 
         let ciphertext = encrypt(&key1, b"secret data", b"").unwrap();
         let result = decrypt(&key2, &ciphertext, b"");
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn tampered_ciphertext_returns_error() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
 
         let mut ciphertext = encrypt(&key, b"secret data", b"").unwrap();
 
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt_round_trip_with_associated_data() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
         let plaintext = b"secret vault entry data";
         let aad = b"entry-identity-binding";
 
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn decrypt_with_mismatched_associated_data_fails() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
         let plaintext = b"secret vault entry data";
 
         let ciphertext = encrypt(&key, plaintext, b"entry-a").unwrap();
@@ -420,7 +420,7 @@ mod tests {
 
     #[test]
     fn decrypt_with_empty_aad_against_bound_ciphertext_fails() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
 
         let ciphertext = encrypt(&key, b"secret data", b"entry-a").unwrap();
         let result = decrypt(&key, &ciphertext, b"");
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn nonce_is_random_per_encryption() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
         let plaintext = b"identical plaintext";
 
         let ct1 = encrypt(&key, plaintext, b"").unwrap();
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn ciphertext_includes_nonce_prefix() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
         let plaintext = b"hello";
 
         let ciphertext = encrypt(&key, plaintext, b"").unwrap();
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn decrypt_rejects_too_short_input() {
-        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]);
+        let key = derive_key(b"test-passphrase", &[0x42; SALT_LEN]).unwrap();
 
         let result = decrypt(&key, &[0u8; 5], b"");
         assert!(

--- a/crates/kryphos/src/crypto.rs
+++ b/crates/kryphos/src/crypto.rs
@@ -45,11 +45,21 @@ pub fn generate_salt() -> [u8; SALT_LEN] {
 ///
 /// Uses secure defaults: m=64 MiB, t=3 iterations, p=4 lanes.
 ///
+/// # Errors
+///
+/// Returns [`CryptoError::InvalidSaltLength`] unless `salt` is exactly
+/// [`SALT_LEN`] bytes. A salt arriving from a stored vault header is a
+/// variable-length field, so this is the reachable case rather than a
+/// defensive one.
+///
+/// Returns [`CryptoError::EncryptionFailed`] if Argon2id itself rejects the
+/// inputs. The length check above covers the reachable cause, so this is
+/// defence for a future caller.
+///
 /// # Panics
 ///
 /// Panics if Argon2id parameter construction fails (should not happen
 /// with compile-time constants).
-#[must_use]
 #[expect(
     clippy::expect_used,
     reason = "Argon2id params are compile-time constants; construction cannot fail"

--- a/crates/kryphos/src/error.rs
+++ b/crates/kryphos/src/error.rs
@@ -196,4 +196,13 @@ pub enum CryptoError {
         /// Actual byte count.
         actual: usize,
     },
+
+    /// The provided salt has the wrong length.
+    #[snafu(display("invalid salt length: expected {expected}, got {actual}"))]
+    InvalidSaltLength {
+        /// Expected byte count.
+        expected: usize,
+        /// Actual byte count.
+        actual: usize,
+    },
 }

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -273,7 +273,13 @@ impl Vault {
 
         let lock = acquire_lock(path)?;
         let salt = crypto::generate_salt();
-        let key = crypto::derive_key(passphrase, &salt);
+        // The salt here is freshly generated at SALT_LEN, so this cannot fail;
+        // it is mapped rather than unwrapped so no future change to salt
+        // generation can turn that assumption into a panic.
+        let key =
+            crypto::derive_key(passphrase, &salt).map_err(|source| VaultError::InvalidHeader {
+                reason: source.to_string(),
+            })?;
 
         let key_check = encrypt(&key, KEY_CHECK_PLAINTEXT, b"").context(EntryCryptoSnafu)?;
 
@@ -362,7 +368,15 @@ impl Vault {
             });
         }
 
-        let key = crypto::derive_key(passphrase, &header.salt);
+        // WHY(#231) this is the reachable one: `header.salt` is a
+        // variable-length field read from the stored JSON, so a corrupt or
+        // tampered vault can carry a salt Argon2 will not accept. A bad file
+        // must open as an invalid header, not crash the process.
+        let key = crypto::derive_key(passphrase, &header.salt).map_err(|source| {
+            VaultError::InvalidHeader {
+                reason: source.to_string(),
+            }
+        })?;
 
         let plaintext =
             decrypt(&key, &header.key_check, b"").map_err(|_| VaultError::WrongPassphrase)?;


### PR DESCRIPTION
## Summary

Closes the sharpest of #231's nine live findings: a salt read from a stored vault header could reach
an `expect` in Argon2 derivation and panic the process.

## Reachable, not theoretical

`Vault::open` derives its key from `header.salt`, and `header` is the on-disk `StoredHeader`
(`storage.rs:63-69`) whose salt is a **`Vec<u8>` deserialized from JSON** — not the fixed
`[u8; SALT_LEN]` that `VaultHeader` (`vault.rs:232`) declares. The version check above the derivation
constrains the version and nothing else, so a corrupt or hand-edited file supplies an arbitrary-length
salt straight to Argon2, which rejects anything below its minimum.

The `expect` that received that rejection carried a `SAFETY` note justifying only the **output**
length — a condition that cannot fail — while the failure that could actually occur went unmentioned.
So a bad file crashed the process instead of being reported as the invalid header it is.

## The fix

`derive_key` returns `Result<VaultKey, CryptoError>` and rejects any salt that is not `SALT_LEN`. That
is stricter than Argon2's own minimum and matches the invariant the vault already maintains — it only
ever writes 32 bytes — so a short-but-Argon2-acceptable salt is caught too.

`CryptoError::InvalidSaltLength { expected, actual }` mirrors the existing `InvalidNonceLength`.

Both call sites map to `VaultError::InvalidHeader`, which is the honest classification. The create
site cannot reach the error (its salt is freshly generated) and is mapped rather than unwrapped, so a
later change to salt generation cannot quietly reintroduce the panic. The Argon2 call is mapped rather
than expected for the same reason — the length check covers the reachable case, and that arm is
defence for a future caller.

## Verification

`a_salt_of_the_wrong_length_is_an_error_rather_than_a_panic` drives five lengths — empty, one byte,
`SALT_LEN - 1`, `SALT_LEN + 1`, and 4096 — and asserts each reports its own length rather than merely
failing.

`a_generated_salt_still_derives` is the anti-vacuity companion: without it, the rejection test would
pass against a function that had started refusing everything.

## Scope

This is one of nine findings on #231, so `Refs` rather than `Closes`. The other eight remain live:
the exposed caller-nonce sealing API, ignored stored KDF parameters, mutation-before-audit across the
four vault mutators, `get` not rejecting `Expired`, malformed key-check collapsing into
`WrongPassphrase`, all lock failures collapsing into `Locked`, one corrupt entry aborting `list`, and
the absent non-UTF-8 resolution test.

Refs #231
