### PR TITLE
fix(syntonia): neutralize spreadsheet formulas in exported channel names

### DIFF
--- a/crates/syntonia/src/csv_formula.rs
+++ b/crates/syntonia/src/csv_formula.rs
@@ -1,0 +1,137 @@
+//! Neutralising and restoring spreadsheet formula markers in CSV cells.
+//!
+//! A CSV cell whose first character is one of a small set is evaluated as a
+//! formula when the file is opened in common spreadsheet software, rather than
+//! displayed. Channel names come from the operator or from a radio image, so an
+//! exported name reaches a spreadsheet as attacker-influenced input.
+//!
+//! CSV quoting does not help: the quotes delimit the field and are stripped
+//! before the cell is interpreted.
+//!
+//! [`neutralize`] and [`restore`] are exact inverses and live together for that
+//! reason — split across the export and import modules they would be two copies
+//! of one rule, free to drift into a lossy round trip.
+
+use std::borrow::Cow;
+
+/// Characters that begin a formula in common spreadsheet software.
+///
+/// `=`, `+`, `-` and `@` start an expression; a leading tab or carriage return
+/// is stripped by the reader and can expose the character behind it.
+const FORMULA_LEADERS: [char; 6] = ['=', '+', '-', '@', '\t', '\r'];
+
+/// The character used to force a cell to be read as text.
+const GUARD: char = '\'';
+
+/// Returns `true` when a leading `first` needs escaping to survive a round trip.
+///
+/// WHY [`GUARD`] itself counts: without escaping it, `'=x` would be ambiguous —
+/// either a name beginning with an apostrophe, or the guarded form of `=x` — and
+/// [`restore`] could not tell them apart. Escaping the guard removes the
+/// ambiguity instead of documenting it.
+fn needs_guard(first: char) -> bool {
+    first == GUARD || FORMULA_LEADERS.contains(&first)
+}
+
+/// Prefix `value` with [`GUARD`] if it would otherwise be read as a formula, or
+/// if it already begins with the guard.
+///
+/// Returns the input unchanged when it is already safe, so the common case
+/// allocates nothing.
+pub(crate) fn neutralize(value: &str) -> Cow<'_, str> {
+    match value.chars().next() {
+        Some(first) if needs_guard(first) => Cow::Owned(format!("{GUARD}{value}")),
+        _ => Cow::Borrowed(value),
+    }
+}
+
+/// Undo [`neutralize`].
+///
+/// Strips one leading [`GUARD`] only when the character behind it is one this
+/// module would itself have escaped. A name whose apostrophe was not added here
+/// — anything CHIRP wrote, for instance — is left alone.
+pub(crate) fn restore(value: &str) -> &str {
+    match value.strip_prefix(GUARD) {
+        Some(rest) if rest.starts_with(needs_guard) => rest,
+        _ => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every value the round-trip property is checked against, formula-leading
+    /// and ordinary alike.
+    const CASES: [&str; 13] = [
+        "=1+1",
+        "+1",
+        "-1",
+        "@SUM(A1)",
+        "\tinjected",
+        "\rinjected",
+        "'=ambiguous",
+        "'quoted",
+        "''double",
+        "CALL",
+        "W1AW",
+        "a=b",
+        "",
+    ];
+
+    #[test]
+    fn a_formula_leader_is_guarded() {
+        for value in ["=1+1", "+1", "-1", "@SUM(A1)", "\tinjected", "\rinjected"] {
+            let neutralized = neutralize(value);
+            assert!(
+                neutralized.starts_with(GUARD),
+                "{value:?} must be guarded, got {neutralized:?}"
+            );
+        }
+    }
+
+    /// Anti-vacuity: a guard applied to everything would satisfy the case above
+    /// while corrupting every ordinary name.
+    #[test]
+    fn an_ordinary_name_is_untouched() {
+        for value in ["CALL", "146.520", "W1AW", "", "a=b"] {
+            assert_eq!(
+                neutralize(value),
+                Cow::Borrowed(value),
+                "{value:?} is not a formula and must pass through unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn neutralize_and_restore_are_inverses() {
+        for value in CASES {
+            assert_eq!(
+                restore(&neutralize(value)),
+                value,
+                "the round trip must return {value:?} exactly"
+            );
+        }
+    }
+
+    /// The half that keeps the inverse honest: `restore` must not eat an
+    /// apostrophe this module did not add, which is what a file written by
+    /// other software would contain.
+    #[test]
+    fn restore_leaves_a_foreign_apostrophe_alone() {
+        assert_eq!(restore("'CALL"), "'CALL");
+        assert_eq!(restore("'"), "'");
+    }
+
+    /// The reason [`needs_guard`] includes the guard itself.
+    #[test]
+    fn a_guarded_formula_is_distinguishable_from_a_quoted_one() {
+        assert_eq!(neutralize("=x"), "'=x");
+        assert_eq!(neutralize("'=x"), "''=x");
+        assert_ne!(
+            neutralize("=x"),
+            neutralize("'=x"),
+            "two different names must not encode to the same cell"
+        );
+    }
+}

--- a/crates/syntonia/src/export/csv.rs
+++ b/crates/syntonia/src/export/csv.rs
@@ -144,7 +144,7 @@ fn channel_to_record(ch: &Channel) -> [String; 19] {
 
     [
         ch.index.to_string(),
-        ch.name.clone(),
+        crate::csv_formula::neutralize(&ch.name).into_owned(),
         freq,
         duplex,
         offset,
@@ -227,6 +227,7 @@ mod tests {
     }
 
     /// Column indices in the CHIRP record produced by `channel_to_record`.
+    const COL_NAME: usize = 1;
     const COL_DUPLEX: usize = 3;
     const COL_OFFSET: usize = 4;
     const COL_TONE_MODE: usize = 5;
@@ -248,6 +249,64 @@ mod tests {
             bandwidth: Bandwidth::Wide,
             scan: ScanMode::Include,
             busy_lock: false,
+        }
+    }
+
+    // ── Formula injection (#233) ──────────────────────────────────────────
+
+    fn channel_named(name: &str) -> Channel {
+        Channel {
+            name: name.to_string(),
+            ..channel_with(FrequencyOffset::None, None)
+        }
+    }
+
+    /// WHY: a channel name reaches the export unmodified from the operator or
+    /// from a radio image, and a cell starting with a formula leader is executed
+    /// rather than shown when the file is opened in a spreadsheet. CSV quoting
+    /// does not prevent it — the quotes are stripped before evaluation.
+    #[test]
+    fn export_guards_a_name_that_would_read_as_a_formula() {
+        for name in ["=1+1", "+1", "-1", "@SUM(A1)"] {
+            let record = channel_to_record(&channel_named(name));
+            assert_eq!(
+                record[COL_NAME],
+                format!("'{name}"),
+                "{name:?} must be exported guarded"
+            );
+        }
+    }
+
+    /// Anti-vacuity: guarding everything would satisfy the case above while
+    /// corrupting every ordinary channel name.
+    #[test]
+    fn export_leaves_an_ordinary_name_alone() {
+        for name in ["TEST", "W1AW", "146520"] {
+            let record = channel_to_record(&channel_named(name));
+            assert_eq!(record[COL_NAME], name, "{name:?} must be exported as-is");
+        }
+    }
+
+    /// The guard is only correct if it is reversible: a name that survives
+    /// export must come back byte-identical through this crate's own importer.
+    #[test]
+    fn a_guarded_name_survives_an_export_import_round_trip() {
+        for name in ["=1+1", "@SUM(A1)", "-1", "'quoted", "'=ambiguous", "TEST"] {
+            let plan = FrequencyPlan {
+                name: String::new(),
+                radio_model: None,
+                channels: vec![channel_named(name)],
+            };
+
+            let mut csv = Vec::new();
+            export_chirp_csv(&plan, &mut csv).expect("export");
+            let (reimported, _warnings) = import_chirp_csv_reader(csv.as_slice()).expect("import");
+
+            assert_eq!(
+                reimported.channels.first().map(|c| c.name.as_str()),
+                Some(name),
+                "{name:?} must round-trip byte-identically"
+            );
         }
     }
 

--- a/crates/syntonia/src/export/csv.rs
+++ b/crates/syntonia/src/export/csv.rs
@@ -296,6 +296,7 @@ mod tests {
                 name: String::new(),
                 radio_model: None,
                 channels: vec![channel_named(name)],
+                created: None,
             };
 
             let mut csv = Vec::new();

--- a/crates/syntonia/src/export/csv.rs
+++ b/crates/syntonia/src/export/csv.rs
@@ -300,8 +300,8 @@ mod tests {
             };
 
             let mut csv = Vec::new();
-            export_chirp_csv(&plan, &mut csv).expect("export");
-            let (reimported, _warnings) = import_chirp_csv_reader(csv.as_slice()).expect("import");
+            export_chirp_csv(&plan, &mut csv).unwrap();
+            let (reimported, _warnings) = import_chirp_csv_reader(csv.as_slice()).unwrap();
 
             assert_eq!(
                 reimported.channels.first().map(|c| c.name.as_str()),

--- a/crates/syntonia/src/import/csv.rs
+++ b/crates/syntonia/src/import/csv.rs
@@ -216,7 +216,7 @@ fn parse_record(
     let rx_freq = Frequency::hz(mhz_to_hz(freq_mhz));
 
     let location = parse_location(col(record, 0), row, warnings);
-    let name = col(record, 1).to_string();
+    let name = crate::csv_formula::restore(col(record, 1)).to_string();
 
     let duplex = col(record, 3);
     let offset_hz = parse_offset_hz(col(record, 4), row, warnings);

--- a/crates/syntonia/src/lib.rs
+++ b/crates/syntonia/src/lib.rs
@@ -24,6 +24,9 @@
 pub mod baofeng;
 pub mod channel;
 pub mod config;
+// WHY private: the CSV formula guard is an implementation detail shared by the
+// export and import paths, not part of this crate's surface.
+mod csv_formula;
 pub mod error;
 pub mod export;
 #[cfg(feature = "hardware-serial")]


### PR DESCRIPTION
## Summary

Closes #233's surviving clause: exported channel names could be read as spreadsheet formulas.

## The defect

`channel_to_record` wrote `ch.name` straight into the CSV. A cell whose first character is `=`, `+`,
`-`, `@`, a tab or a carriage return is **executed** rather than displayed when the file is opened in
common spreadsheet software. CSV quoting does not help — the quotes delimit the field and are stripped
before the cell is interpreted.

Channel names come from the operator or from a radio image, so this is attacker-influenced input
reaching a spreadsheet.

## The fix, and why it has two halves

Export prefixes an affected name with an apostrophe, which forces the cell to be read as text.

**Import strips that prefix again.** Without this half the fix would trade an injection for silent
corruption: every affected name would gain a permanent apostrophe on the first round trip through this
crate's own importer. There is no existing export→import test that would have caught that, which is
why one is added here.

**The guard escapes a leading apostrophe too.** Without that, `'=x` is ambiguous — either a name that
begins with an apostrophe, or the guarded form of `=x` — and `restore` cannot tell them apart. Escaping
removes the ambiguity instead of documenting it. This was caught by the invertibility test before it
ran, not after.

`restore` only strips an apostrophe when the character behind it is one this module would itself have
escaped, so a name written by other software — CHIRP's own files — passes through untouched.

## One module, because they are inverses

`neutralize` and `restore` live together in `csv_formula`. Split across the export and import paths
they would be two copies of one rule, free to drift until the round trip quietly stopped being lossless.

## Tests

In `csv_formula`: each formula leader is guarded; ordinary names are untouched (anti-vacuity — a guard
applied to everything would satisfy the first case while corrupting every name); the pair is invertible
across thirteen values including the ambiguous `'=x`; and a foreign apostrophe survives `restore`.

In `export/csv`: the exported cell is guarded, ordinary names are exported as-is, and a name survives a
real export → import round trip byte-identically for six values.

Closes #233
