### PR TITLE
fix(kryphos): report what actually failed, not the nearest familiar error

### DIFF
--- a/crates/akroasis/src/vault/mod.rs
+++ b/crates/akroasis/src/vault/mod.rs
@@ -243,15 +243,34 @@ fn run_list(json: bool, out: &mut dyn Write) -> Result<(), VaultCliError> {
     let passphrase = read_passphrase("Vault passphrase: ")?;
 
     let vault = Vault::open(&path, passphrase.as_bytes()).context(VaultSnafu)?;
-    let entries = vault.list().context(VaultSnafu)?;
+    let listing = vault.list().context(VaultSnafu)?;
+    let entries = listing.entries;
 
     if json {
         write_list_json_report(&entries, out)?;
         return Ok(());
     }
 
-    if entries.is_empty() {
+    if entries.is_empty() && listing.unreadable == 0 {
         writeln!(out, "Vault is empty.").context(IoSnafu)?;
+        return Ok(());
+    }
+
+    // WHY(#231): a listing that quietly omitted damaged records would leave the
+    // operator unable to tell a credential that is gone from one that cannot be
+    // read. The count is surfaced where they are already looking.
+    if listing.unreadable > 0 {
+        writeln!(
+            out,
+            "warning: {} entr{} could not be read and {} omitted below.",
+            listing.unreadable,
+            if listing.unreadable == 1 { "y" } else { "ies" },
+            if listing.unreadable == 1 { "is" } else { "are" }
+        )
+        .context(IoSnafu)?;
+    }
+
+    if entries.is_empty() {
         return Ok(());
     }
 
@@ -677,7 +696,7 @@ mod tests {
             .add("key-b", CredentialType::Psk, b"secret-b")
             .unwrap();
 
-        let entries = vault.list().unwrap();
+        let entries = vault.list().unwrap().entries;
         assert_eq!(entries.len(), 2, "list must return both entries");
     }
 
@@ -689,7 +708,7 @@ mod tests {
             .add("json-key", CredentialType::ApiKey, b"secret-not-in-report")
             .unwrap();
 
-        let entries = vault.list().unwrap();
+        let entries = vault.list().unwrap().entries;
         let mut out = Vec::new();
         write_list_json_report(&entries, &mut out).unwrap();
 

--- a/crates/kryphos/src/lib.rs
+++ b/crates/kryphos/src/lib.rs
@@ -17,7 +17,7 @@ pub use config::VaultProvider;
 pub use crypto::{decrypt, derive_key, encrypt, generate_salt};
 pub use error::{CryptoError, KeyError, VaultError};
 pub use key::{InstallationIdentity, SigningKey, VaultKey, VerifyingKey};
-pub use storage::{DecryptedEntry, EntryHistory, EntryInfo, Vault};
+pub use storage::{DecryptedEntry, EntryHistory, EntryInfo, Vault, VaultListing};
 pub use vault::{
     CredentialType, EntryMetadata, EntryStatus, HistoryEvent, HistoryEventKind, KdfParams,
     NONCE_LEN, SALT_LEN, VAULT_VERSION, VaultEntry, VaultHeader, seal_signing_key,

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -125,6 +125,21 @@ pub struct DecryptedEntry {
     pub metadata: EntryMetadata,
 }
 
+/// What a [`Vault::list`] call found, including what it could not read.
+///
+/// WHY(#231) the count is carried rather than logged: one unreadable record used
+/// to abort the whole listing, and skipping silently would trade that for an
+/// operator who cannot tell a missing credential from a damaged one. kryphos
+/// takes no logging dependency — a credential vault that writes to a log is a
+/// leak waiting to happen — so the caller is told through the return value.
+#[derive(Debug, Clone)]
+pub struct VaultListing {
+    /// Entries that were read successfully.
+    pub entries: Vec<EntryInfo>,
+    /// How many stored records could not be parsed or decrypted.
+    pub unreadable: usize,
+}
+
 // WHY: manual Debug instead of #[derive(Debug)] — `secret` holds the
 // decrypted plaintext credential; redact it so an accidental `{:?}` log
 // never prints it (RUST/no-debug-derive-on-public-types).
@@ -563,8 +578,9 @@ impl Vault {
     ///
     /// Returns [`VaultError::StorageBackend`] on iteration errors.
     /// Returns [`VaultError::EntryCrypto`] if metadata decryption fails.
-    pub fn list(&self) -> Result<Vec<EntryInfo>, VaultError> {
+    pub fn list(&self) -> Result<VaultListing, VaultError> {
         let mut entries = Vec::new();
+        let mut unreadable = 0usize;
 
         for guard in self.keyspace.iter() {
             let (_key, value) = guard.into_inner().map_err(fjall_err)?;
@@ -573,11 +589,11 @@ impl Vault {
             // row hid every good one and the operator could not see the
             // credentials they still had.
             let Ok(entry) = serde_json::from_slice::<StoredEntry>(&value) else {
-                tracing::warn!("skipping a vault entry whose stored record does not parse");
+                unreadable += 1;
                 continue;
             };
             let Ok(record) = self.decrypt_metadata(&entry) else {
-                tracing::warn!("skipping a vault entry whose metadata does not decrypt");
+                unreadable += 1;
                 continue;
             };
 
@@ -589,7 +605,10 @@ impl Vault {
             });
         }
 
-        Ok(entries)
+        Ok(VaultListing {
+            entries,
+            unreadable,
+        })
     }
 
     /// Removes a credential from the vault.

--- a/crates/kryphos/src/storage.rs
+++ b/crates/kryphos/src/storage.rs
@@ -14,9 +14,9 @@ use zeroize::Zeroizing;
 
 use crate::crypto::{self, ENTRY_ENVELOPE_VERSION, decrypt, encrypt, entry_aad};
 use crate::error::{
-    AlreadyExistsSnafu, EmptyPassphraseSnafu, EntryCryptoSnafu, EntryNotDeletableSnafu,
-    EntryRevokedSnafu, IoSnafu, NotInitializedSnafu, SerializationSnafu, TamperLogSnafu,
-    VaultError, WrongPassphraseSnafu,
+    AlreadyExistsSnafu, CryptoError, EmptyPassphraseSnafu, EntryCryptoSnafu,
+    EntryNotDeletableSnafu, EntryRevokedSnafu, IoSnafu, NotInitializedSnafu, SerializationSnafu,
+    TamperLogSnafu, VaultError, WrongPassphraseSnafu,
 };
 use crate::key::VaultKey;
 use crate::vault::{
@@ -383,8 +383,19 @@ impl Vault {
                 }
             })?;
 
-        let plaintext =
-            decrypt(&key, &header.key_check, b"").map_err(|_| VaultError::WrongPassphrase)?;
+        // WHY(#231) the two failures are separated: any decrypt error used to
+        // become WrongPassphrase, so a truncated or corrupt key-check told the
+        // operator their correct passphrase was wrong. They would retype it
+        // forever. A ciphertext shorter than a nonce is not a failed
+        // decryption — it is not a ciphertext.
+        let plaintext = decrypt(&key, &header.key_check, b"").map_err(|source| match source {
+            CryptoError::InvalidNonceLength { expected, actual } => VaultError::InvalidHeader {
+                reason: format!(
+                    "key check is {actual} bytes, too short to carry a {expected}-byte nonce"
+                ),
+            },
+            _ => VaultError::WrongPassphrase,
+        })?;
         if plaintext != KEY_CHECK_PLAINTEXT {
             return WrongPassphraseSnafu.fail();
         }
@@ -557,8 +568,18 @@ impl Vault {
 
         for guard in self.keyspace.iter() {
             let (_key, value) = guard.into_inner().map_err(fjall_err)?;
-            let entry: StoredEntry = serde_json::from_slice(&value).context(SerializationSnafu)?;
-            let record = self.decrypt_metadata(&entry)?;
+            // WHY(#231) an unreadable entry is skipped rather than fatal: a
+            // single corrupt record used to abort the whole listing, so one bad
+            // row hid every good one and the operator could not see the
+            // credentials they still had.
+            let Ok(entry) = serde_json::from_slice::<StoredEntry>(&value) else {
+                tracing::warn!("skipping a vault entry whose stored record does not parse");
+                continue;
+            };
+            let Ok(record) = self.decrypt_metadata(&entry) else {
+                tracing::warn!("skipping a vault entry whose metadata does not decrypt");
+                continue;
+            };
 
             entries.push(EntryInfo {
                 name: record.name,
@@ -878,8 +899,21 @@ fn acquire_lock(vault_path: &Path) -> Result<File, VaultError> {
 
     let file = create_owner_only_file(&lock_path)?;
 
-    file.try_lock_exclusive().map_err(|_| VaultError::Locked {
-        path: vault_path.to_path_buf(),
+    // WHY(#231) the error kind is inspected: every lock failure used to report
+    // "locked by another process", so a permission or filesystem problem sent
+    // the operator hunting for a process that was never there. Only WouldBlock
+    // means contention.
+    file.try_lock_exclusive().map_err(|source| {
+        if source.kind() == std::io::ErrorKind::WouldBlock {
+            VaultError::Locked {
+                path: vault_path.to_path_buf(),
+            }
+        } else {
+            VaultError::Io {
+                path: lock_path.clone(),
+                source,
+            }
+        }
     })?;
 
     Ok(file)

--- a/crates/kryphos/src/storage_security_tests.rs
+++ b/crates/kryphos/src/storage_security_tests.rs
@@ -393,7 +393,7 @@ fn concurrent_add_same_name_yields_one_winner_and_duplicate_losers() {
             "iteration {iteration}: every losing add must see DuplicateEntry, got {duplicates}"
         );
 
-        let entries = vault.list().unwrap();
+        let entries = vault.list().unwrap().entries;
         assert_eq!(
             entries.len(),
             1,

--- a/crates/kryphos/src/storage_tests.rs
+++ b/crates/kryphos/src/storage_tests.rs
@@ -709,3 +709,80 @@ fn collect_file_bytes(dir: &std::path::Path, out: &mut Vec<u8>) {
         }
     }
 }
+
+// ── Error fidelity (#231) ────────────────────────────────────────────────────
+
+/// WHY(#231): every key-check decrypt failure became `WrongPassphrase`, so a
+/// truncated or corrupt header told the operator their correct passphrase was
+/// wrong. They would retype it forever and never learn the file was damaged.
+#[test]
+fn a_truncated_key_check_is_a_corrupt_header_not_a_wrong_passphrase() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("test-vault");
+    drop(Vault::create(&vault_path, TEST_PASSPHRASE).unwrap());
+
+    // Shorten the key check below a nonce, which is not a ciphertext at all.
+    let header_path = vault_path.join(HEADER_FILE);
+    let mut header: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&header_path).unwrap()).unwrap();
+    header["key_check"] = serde_json::json!([1, 2, 3]);
+    std::fs::write(&header_path, serde_json::to_vec(&header).unwrap()).unwrap();
+
+    let error = Vault::open(&vault_path, TEST_PASSPHRASE).unwrap_err();
+
+    assert!(
+        matches!(error, VaultError::InvalidHeader { .. }),
+        "a key check too short to hold a nonce is corruption, got {error}"
+    );
+}
+
+/// Anti-vacuity: a genuinely wrong passphrase must still report itself as one,
+/// or the case above would pass against an open that calls everything corrupt.
+#[test]
+fn a_wrong_passphrase_still_reports_itself() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("test-vault");
+    drop(Vault::create(&vault_path, TEST_PASSPHRASE).unwrap());
+
+    let error = Vault::open(&vault_path, b"not the passphrase").unwrap_err();
+
+    assert!(
+        matches!(error, VaultError::WrongPassphrase),
+        "an intact vault opened with the wrong passphrase is exactly that, got {error}"
+    );
+}
+
+/// WHY(#231): a single unparseable record used to abort the whole listing, so
+/// one bad row hid every good one and the operator could not see the
+/// credentials they still had.
+#[test]
+fn one_unreadable_entry_does_not_hide_the_readable_ones() {
+    let dir = tempfile::tempdir().unwrap();
+    let vault_path = dir.path().join("test-vault");
+    let mut vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+    vault
+        .add("alpha", CredentialType::ApiKey, b"secret-a")
+        .unwrap();
+    vault
+        .add("beta", CredentialType::ApiKey, b"secret-b")
+        .unwrap();
+
+    // Overwrite one stored value with bytes that are not a StoredEntry.
+    let key = vault
+        .keyspace
+        .iter()
+        .next()
+        .unwrap()
+        .into_inner()
+        .unwrap()
+        .0;
+    vault.keyspace.insert(&key, b"not json").unwrap();
+
+    let listed = vault.list().unwrap();
+
+    assert_eq!(
+        listed.len(),
+        1,
+        "the surviving entry must still be listed; one bad row is not a dead vault"
+    );
+}

--- a/crates/kryphos/src/storage_tests.rs
+++ b/crates/kryphos/src/storage_tests.rs
@@ -103,7 +103,7 @@ fn list_returns_metadata_without_secrets() {
         .add("cred-b", CredentialType::Psk, b"secret-b")
         .unwrap();
 
-    let entries = vault.list().unwrap();
+    let entries = vault.list().unwrap().entries;
     assert_eq!(entries.len(), 2, "list must return all entries");
 
     for info in &entries {
@@ -129,7 +129,7 @@ fn remove_deletes_entry() {
     let result = vault.get("disposable");
     assert!(result.is_err(), "get after remove must fail");
 
-    let entries = vault.list().unwrap();
+    let entries = vault.list().unwrap().entries;
     assert!(entries.is_empty(), "list after remove must be empty");
 }
 
@@ -338,7 +338,7 @@ fn revoked_entry_not_deletable() {
         "removing a revoked entry must fail for audit trail"
     );
 
-    let entries = vault.list().unwrap();
+    let entries = vault.list().unwrap().entries;
     assert_eq!(entries.len(), 1, "revoked entry must remain in the vault");
 }
 
@@ -458,7 +458,7 @@ fn list_shows_entry_status() {
         .unwrap();
     vault.revoke("revoked-key").unwrap();
 
-    let entries = vault.list().unwrap();
+    let entries = vault.list().unwrap().entries;
     assert_eq!(entries.len(), 2, "list must return all entries");
 
     for info in &entries {

--- a/crates/kryphos/src/storage_tests.rs
+++ b/crates/kryphos/src/storage_tests.rs
@@ -759,7 +759,7 @@ fn a_wrong_passphrase_still_reports_itself() {
 fn one_unreadable_entry_does_not_hide_the_readable_ones() {
     let dir = tempfile::tempdir().unwrap();
     let vault_path = dir.path().join("test-vault");
-    let mut vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
+    let vault = Vault::create(&vault_path, TEST_PASSPHRASE).unwrap();
     vault
         .add("alpha", CredentialType::ApiKey, b"secret-a")
         .unwrap();

--- a/crates/kryphos/src/storage_tests.rs
+++ b/crates/kryphos/src/storage_tests.rs
@@ -776,13 +776,17 @@ fn one_unreadable_entry_does_not_hide_the_readable_ones() {
         .into_inner()
         .unwrap()
         .0;
-    vault.keyspace.insert(&key, b"not json").unwrap();
+    vault.keyspace.insert(key, b"not json").unwrap();
 
     let listed = vault.list().unwrap();
 
     assert_eq!(
-        listed.len(),
+        listed.entries.len(),
         1,
         "the surviving entry must still be listed; one bad row is not a dead vault"
+    );
+    assert_eq!(
+        listed.unreadable, 1,
+        "and the caller must be told one record could not be read"
     );
 }


### PR DESCRIPTION
## Summary

Three of #231's findings, all one shape: a wide class of failures collapsed into a single specific
error, so the message named a cause that was not the cause.

## Wrong passphrase, or a damaged file?

Every key-check decrypt failure became `WrongPassphrase`. But `decrypt` distinguishes two things:

- `InvalidNonceLength` — the ciphertext is shorter than a nonce. That is **not a failed decryption**;
  it is not a ciphertext.
- `DecryptionFailed` — AEAD authentication failed, which a wrong passphrase genuinely explains.

Collapsing the first into the second told an operator with a truncated header that their **correct**
passphrase was wrong. They would retype it forever and never learn the file was damaged. The first
case is now `InvalidHeader` with the observed length; the second is still `WrongPassphrase`.

## Locked, or unable to lock?

Every `try_lock_exclusive` failure became "locked by another process". Only `ErrorKind::WouldBlock`
means contention — a permission or filesystem error sent the operator hunting for a process that was
never there. Those now surface as the `Io` errors they are, carrying the lock file's own path.

## One bad row hid the whole vault

`list` propagated a parse or decrypt failure on any single entry, so one corrupt record aborted the
entire listing and an operator with one damaged entry could not see the credentials they still had.
Unreadable entries are skipped with a warning and the rest are returned — the availability the finding
asked for.

## Tests

`a_truncated_key_check_is_a_corrupt_header_not_a_wrong_passphrase` shortens the stored key check below
a nonce and requires `InvalidHeader`.

`a_wrong_passphrase_still_reports_itself` is its partner. Without it the first case would pass against
an `open` that had started calling everything corrupt — which would be the same defect pointing the
other way.

`one_unreadable_entry_does_not_hide_the_readable_ones` corrupts one stored record of two and requires
the survivor to be listed.

The lock split is deliberately untested here: distinguishing `WouldBlock` from a permission failure
needs a filesystem the test can make un-lockable, and the existing contention path is already covered.
The change is a match on `ErrorKind` rather than a discarded error, so what it claims is visible in
five lines.

Refs #231
